### PR TITLE
Fix to use nested class

### DIFF
--- a/app/src/main/java/me/banes/chris/tivi/ui/TiviShowGridAdapter.kt
+++ b/app/src/main/java/me/banes/chris/tivi/ui/TiviShowGridAdapter.kt
@@ -52,8 +52,8 @@ internal class TiviShowGridAdapter
         diffResult.dispatchUpdatesTo(this)
     }
 
-    private inner class DiffCb(val oldItems: List<TiviShow>,
-                               val newItems: List<TiviShow>) : DiffUtil.Callback() {
+    private class DiffCb(val oldItems: List<TiviShow>,
+                         val newItems: List<TiviShow>) : DiffUtil.Callback() {
         override fun getOldListSize(): Int {
             return oldItems.size
         }


### PR DESCRIPTION
I fixed to use nested class instead of inner class.
Because `DiffCb` class doesn't need to access members of outer class.

Here is the official reference.
https://kotlinlang.org/docs/reference/nested-classes.html