### PR TITLE
Scroll to top when bottom navigation is clicked

### DIFF
--- a/app/src/main/java/me/banes/chris/tivi/home/HomeActivity.kt
+++ b/app/src/main/java/me/banes/chris/tivi/home/HomeActivity.kt
@@ -63,7 +63,11 @@ class HomeActivity : TiviActivity() {
                             supportFragmentManager.popBackStackImmediate()
                         }
                     } else {
-                        // TODO scroll to top of main fragment
+                        val fragment = supportFragmentManager.fragments[1]
+                        when (fragment){
+                            is DiscoverFragment -> fragment.scrollToTop()
+                            is LibraryFragment -> fragment.scrollToTop()
+                        }
                     }
                     true
                 }

--- a/app/src/main/java/me/banes/chris/tivi/home/HomeActivity.kt
+++ b/app/src/main/java/me/banes/chris/tivi/home/HomeActivity.kt
@@ -63,7 +63,7 @@ class HomeActivity : TiviActivity() {
                             supportFragmentManager.popBackStackImmediate()
                         }
                     } else {
-                        val fragment = supportFragmentManager.fragments[1]
+                        val fragment = supportFragmentManager.findFragmentById(R.id.home_content)
                         when (fragment){
                             is DiscoverFragment -> fragment.scrollToTop()
                             is LibraryFragment -> fragment.scrollToTop()

--- a/app/src/main/java/me/banes/chris/tivi/home/discover/DiscoverFragment.kt
+++ b/app/src/main/java/me/banes/chris/tivi/home/discover/DiscoverFragment.kt
@@ -127,6 +127,13 @@ internal class DiscoverFragment : HomeFragment<DiscoverViewModel>() {
         TRENDING -> getString(R.string.discover_trending)
     }
 
+    internal fun scrollToTop() {
+        discover_rv.apply {
+            stopScroll()
+            smoothScrollToPosition(0)
+        }
+    }
+
     internal inner class HeaderItem(val section: DiscoverViewModel.Section) : Item<ViewHolder>() {
         override fun getLayout() = R.layout.header_item
 

--- a/app/src/main/java/me/banes/chris/tivi/home/library/LibraryFragment.kt
+++ b/app/src/main/java/me/banes/chris/tivi/home/library/LibraryFragment.kt
@@ -61,4 +61,10 @@ class LibraryFragment : HomeFragment<LibraryViewModel>() {
         return library_toolbar.menu.findItem(R.id.home_menu_user_login)
     }
 
+    internal fun scrollToTop() {
+        library_rv.apply {
+            stopScroll()
+            smoothScrollToPosition(0)
+        }
+    }
 }


### PR DESCRIPTION
Scrolls the `RecyclerView` to the top when the bottom navigation tab is clicked and the backstack is empty. There should be a better way to do this than using `supportFragmentManager.fragments[1]` to get the current fragment.