### PR TITLE
Fix random re-ordering in grids

### DIFF
--- a/app/src/main/java/me/banes/chris/tivi/data/daos/TrendingDao.kt
+++ b/app/src/main/java/me/banes/chris/tivi/data/daos/TrendingDao.kt
@@ -28,15 +28,15 @@ import me.banes.chris.tivi.data.entities.TrendingListItem
 @Dao
 abstract class TrendingDao : PaginatedEntryDao<TrendingEntry, TrendingListItem> {
     @Transaction
-    @Query("SELECT * FROM trending_shows ORDER BY page ASC, watchers DESC")
+    @Query("SELECT * FROM trending_shows ORDER BY page ASC, watchers DESC, id ASC")
     abstract override fun entries(): Flowable<List<TrendingListItem>>
 
     @Transaction
-    @Query("SELECT * FROM trending_shows ORDER BY page ASC, watchers DESC")
+    @Query("SELECT * FROM trending_shows ORDER BY page ASC, watchers DESC, id ASC")
     abstract override fun entriesLiveList(): LivePagedListProvider<Int, TrendingListItem>
 
     @Transaction
-    @Query("SELECT * FROM trending_shows WHERE page = :page ORDER BY watchers DESC")
+    @Query("SELECT * FROM trending_shows WHERE page = :page ORDER BY watchers DESC, id ASC")
     abstract override fun entriesPage(page: Int): Flowable<List<TrendingListItem>>
 
     @Query("DELETE FROM trending_shows WHERE page = :page")

--- a/app/src/main/java/me/banes/chris/tivi/ui/ShowPosterGridAdapter.kt
+++ b/app/src/main/java/me/banes/chris/tivi/ui/ShowPosterGridAdapter.kt
@@ -42,13 +42,15 @@ open class ShowPosterGridAdapter<LI : ListItem<out Entry>>(
 
     var isLoading = false
         set(value) {
-            if (value == field) return
-            field = if (value) {
-                notifyItemInserted(loadingMoreItemPosition)
-                value
-            } else {
-                notifyItemRemoved(loadingMoreItemPosition)
-                value
+            if (value != field) {
+                val position = loadingMoreItemPosition
+                if (position >= 0) {
+                    when {
+                        value -> notifyItemInserted(position)
+                        else -> notifyItemRemoved(position)
+                    }
+                }
+                field = value
             }
         }
 


### PR DESCRIPTION
Was caused by the loading progress bar logic
removing actual items

Also made the sort for trending items stable