### PR TITLE
Explicitly build APKs on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           command: signing/setup.sh $ENCRYPT_KEY
       - run:
           name: Check and assemble APKs
-          command: ./gradlew clean check dependencyUpdates --no-daemon
+          command: ./gradlew check assemble dependencyUpdates --no-daemon
       - run:
           name: Cleanup secrets
           command: signing/cleanup.sh


### PR DESCRIPTION
The `check` task used to build APKs, but no more it seems...