### PR TITLE
Move LeakCanary out to different variant

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -113,6 +113,12 @@ android {
     }
 
     buildTypes {
+        leakcanary {
+            signingConfig signingConfigs.debug
+            versionNameSuffix "-dev-nolc [${getGitHash()}]"
+            matchingFallbacks = ['debug', 'release']
+        }
+
         debug {
             signingConfig signingConfigs.debug
             versionNameSuffix "-dev [${getGitHash()}]"
@@ -170,7 +176,8 @@ dependencies {
 
     debugImplementation "nl.littlerobots.rxlint:rxlint:${versions.rxlint}"
 
-    debugImplementation "com.squareup.leakcanary:leakcanary-android:${versions.leakcanary}"
+    leakcanaryImplementation "com.squareup.leakcanary:leakcanary-android:${versions.leakcanary}"
+    debugImplementation "com.squareup.leakcanary:leakcanary-android-no-op:${versions.leakcanary}"
     releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:${versions.leakcanary}"
 
     implementation('com.crashlytics.sdk.android:crashlytics:2.8.0@aar') {


### PR DESCRIPTION
Causing too many slows down while debugging transitions.