### PR TITLE
106/Fix NPE in TmdbImageUrlProvider

### DIFF
--- a/tmdb/src/main/java/me/banes/chris/tivi/tmdb/TmdbImageUrlProvider.kt
+++ b/tmdb/src/main/java/me/banes/chris/tivi/tmdb/TmdbImageUrlProvider.kt
@@ -16,6 +16,8 @@
 
 package me.banes.chris.tivi.tmdb
 
+private const val IMAGE_SIZE_PATTERN = "w(\\d+)$"
+
 class TmdbImageUrlProvider(
         private var baseImageUrl: String = TmdbImageSizes.baseImageUrl,
         private var posterSizes: Array<String> = TmdbImageSizes.posterSizes,
@@ -57,6 +59,6 @@ class TmdbImageUrlProvider(
     }
 
     private fun extractWidthAsIntFrom(size: String): Int? {
-        return "w(\\d+)$".toRegex().matchEntire(size)?.groups?.get(1)?.value?.toInt()
+        return IMAGE_SIZE_PATTERN.toRegex().matchEntire(size)?.groups?.get(1)?.value?.toInt()
     }
 }

--- a/tmdb/src/main/java/me/banes/chris/tivi/tmdb/TmdbImageUrlProvider.kt
+++ b/tmdb/src/main/java/me/banes/chris/tivi/tmdb/TmdbImageUrlProvider.kt
@@ -34,14 +34,7 @@ class TmdbImageUrlProvider(
 
         for (i in sizes.indices) {
             val size = sizes[i]
-            val indexOfW = size.indexOf('w')
-
-            if (indexOfW < 0) {
-                // This dimension doesn't start with w, so skip
-                continue
-            }
-
-            val sizeWidth = size.substring(indexOfW + 1 until size.length).toInt()
+            val sizeWidth = extractWidthAsIntFrom(size) ?: continue
 
             if (sizeWidth > imageWidth) {
                 return if (forceLarger || (previousSize != null && imageWidth > (previousWidth + sizeWidth) / 2)) {
@@ -61,5 +54,9 @@ class TmdbImageUrlProvider(
         }
 
         return previousSize ?: sizes.last()
+    }
+
+    private fun extractWidthAsIntFrom(size: String): Int? {
+        return "w(\\d+)$".toRegex().matchEntire(size)?.groups?.get(1)?.value?.toInt()
     }
 }

--- a/tmdb/src/main/java/me/banes/chris/tivi/tmdb/TmdbImageUrlProvider.kt
+++ b/tmdb/src/main/java/me/banes/chris/tivi/tmdb/TmdbImageUrlProvider.kt
@@ -37,10 +37,10 @@ class TmdbImageUrlProvider(
             val sizeWidth = extractWidthAsIntFrom(size) ?: continue
 
             if (sizeWidth > imageWidth) {
-                return if (forceLarger || (previousSize != null && imageWidth > (previousWidth + sizeWidth) / 2)) {
-                    size
-                } else {
-                    previousSize!!
+                if (forceLarger || (previousSize != null && imageWidth > (previousWidth + sizeWidth) / 2)) {
+                    return size
+                } else if (previousSize != null) {
+                    return previousSize
                 }
             } else if (i == sizes.size - 1) {
                 // If we get here then we're larger than the last bucket


### PR DESCRIPTION
This PR fixes #106 the NPE in TmdbImageUrlProvider where `previousUrl` is null but is accessed with `previousUrl!!`.

It also replaces the parsing of the size with regex - I can revert this since this fixes something that will only manifest as a bug if TMDB changes their size format (e.g. from `w72` to `72w` or `w72px`).