### PR TITLE
Remove sdk licenses in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,20 +8,10 @@ defaults: &defaults
     _JAVA_OPTIONS: "-Xmx1400m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2"
     TERM: dumb
 
-update_sdk: &update_sdk
-  name: Update SDK
-  command: |
-    mkdir "$ANDROID_HOME/licenses" || true
-    echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
-    echo "84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
-    sdkmanager "platform-tools" "platforms;android-27"
-
 jobs:
   build:
     <<: *defaults
     steps:
-      - run:
-          <<: *update_sdk
       - checkout
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
@@ -61,8 +51,6 @@ jobs:
   deploy_to_play:
     <<: *defaults
     steps:
-      - run:
-          <<: *update_sdk
       - checkout
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}


### PR DESCRIPTION
I wasn't sure if I should open a Pull Request for this. But I realized and read in slack groups that other developers were also looking at the CircleCI config of this project in order to build their own.

With a change in the Android DockerFile it's not longer necessary to update the sdk licenses in the config file. 
https://github.com/circleci/circleci-images/blob/master/android/Dockerfile.m4#L69

I've tested it out and removed it too with success. Unless you need it for something else that I'm not aware of.

As last I want to point out that Benoît Quenaudon made me aware of this.
