### PR TITLE
Use Maven Central over jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,8 @@ buildscript {
 
     repositories {
         google()
+        mavenCentral()
         jcenter()
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
         maven { url 'https://maven.fabric.io/public' }
     }
 
@@ -83,8 +83,8 @@ plugins {
 allprojects {
     repositories {
         google()
+        mavenCentral()
         jcenter()
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
         maven { url 'https://maven.fabric.io/public' }
     }
 


### PR DESCRIPTION
We still need jcenter, but it is a lower priority than Maven Central