### PR TITLE
Update CopyDynamic to 0.1.3

### DIFF
--- a/data/build.gradle
+++ b/data/build.gradle
@@ -36,8 +36,8 @@ dependencies {
 
     compile "io.reactivex.rxjava2:rxjava:${versions.rx}"
 
-    kapt 'io.sweers.copydynamic:copydynamic:0.1.2'
-    compile 'io.sweers.copydynamic:copydynamic-annotations:0.1.2'
+    kapt 'io.sweers.copydynamic:copydynamic:0.1.3'
+    compile 'io.sweers.copydynamic:copydynamic-annotations:0.1.3'
 
     compile 'org.threeten:threetenbp:1.3.6:no-tzdb'
 }


### PR DESCRIPTION
This is 10% OSS contribution stuff and 90% me guinea pigging this project to make sure the new release worked somewhere other than my own pet project :)

https://github.com/hzsweers/copydynamic/blob/master/CHANGELOG.md#version-013

TL;DR: fix a name collision if there was a property also named `source` and shade kotlinpoet/autocommon dependencies to avoid potential conflicts.