### PR TITLE
Move all network calls to use RetrofitRunner

### DIFF
--- a/app/src/androidTest/java/app/tivi/data/repositories/FollowedShowRepositoryTest.kt
+++ b/app/src/androidTest/java/app/tivi/data/repositories/FollowedShowRepositoryTest.kt
@@ -19,6 +19,7 @@ package app.tivi.data.repositories
 import app.tivi.data.RoomTransactionRunner
 import app.tivi.data.daos.EntityInserter
 import app.tivi.data.daos.FollowedShowsDao
+import app.tivi.data.entities.Success
 import app.tivi.data.repositories.followedshows.FollowedShowsDataSource
 import app.tivi.data.repositories.followedshows.FollowedShowsRepository
 import app.tivi.data.repositories.followedshows.LocalFollowedShowsStore
@@ -84,7 +85,7 @@ class FollowedShowRepositoryTest : BaseDatabaseTest() {
     @Test
     fun testSync() = runBlocking {
         `when`(traktDataSource.getFollowedListId()).thenReturn(0)
-        `when`(traktDataSource.getListShows(0)).thenReturn(listOf(followedShow1 to show))
+        `when`(traktDataSource.getListShows(0)).thenReturn(Success(listOf(followedShow1 to show)))
 
         assertThat(repository.getFollowedShows(), `is`(listOf(followedShow1)))
 
@@ -97,7 +98,7 @@ class FollowedShowRepositoryTest : BaseDatabaseTest() {
         insertFollowedShow(db)
 
         `when`(traktDataSource.getFollowedListId()).thenReturn(0)
-        `when`(traktDataSource.getListShows(0)).thenReturn(listOf())
+        `when`(traktDataSource.getListShows(0)).thenReturn(Success(emptyList()))
 
         assertThat(repository.getFollowedShows(), `is`(emptyList()))
     }
@@ -107,7 +108,7 @@ class FollowedShowRepositoryTest : BaseDatabaseTest() {
         insertFollowedShow(db)
 
         `when`(traktDataSource.getFollowedListId()).thenReturn(0)
-        `when`(traktDataSource.getListShows(0)).thenReturn(listOf(followedShow2 to show2))
+        `when`(traktDataSource.getListShows(0)).thenReturn(Success(listOf(followedShow2 to show2)))
 
         assertThat(repository.getFollowedShows(), `is`(listOf(followedShow2)))
 

--- a/app/src/androidTest/java/app/tivi/data/repositories/SeasonsEpisodesRepositoryTest.kt
+++ b/app/src/androidTest/java/app/tivi/data/repositories/SeasonsEpisodesRepositoryTest.kt
@@ -19,6 +19,7 @@ package app.tivi.data.repositories
 import app.tivi.data.RoomTransactionRunner
 import app.tivi.data.daos.EntityInserter
 import app.tivi.data.daos.EpisodeWatchEntryDao
+import app.tivi.data.entities.Success
 import app.tivi.data.repositories.episodes.EpisodeDataSource
 import app.tivi.data.repositories.episodes.LocalSeasonsEpisodesStore
 import app.tivi.data.repositories.episodes.SeasonsEpisodesDataSource
@@ -88,7 +89,7 @@ class SeasonsEpisodesRepositoryTest : BaseDatabaseTest() {
     fun testSyncEpisodeWatches() = runBlocking {
         // Return a response with 2 items
         `when`(traktSeasonsDataSource.getShowEpisodeWatches(showId)).thenReturn(
-                listOf(episodeOne to episodeWatch1, episodeOne to episodeWatch2)
+                Success(listOf(episodeOne to episodeWatch1, episodeOne to episodeWatch2))
         )
         // Sync
         repository.syncEpisodeWatchesForShow(showId)
@@ -102,7 +103,7 @@ class SeasonsEpisodesRepositoryTest : BaseDatabaseTest() {
         episodeWatchDao.insertAll(episodeWatch1, episodeWatch2)
         // Return a response with the same items
         `when`(traktSeasonsDataSource.getShowEpisodeWatches(showId))
-                .thenReturn(listOf(episodeOne to episodeWatch1, episodeOne to episodeWatch2))
+                .thenReturn(Success(listOf(episodeOne to episodeWatch1, episodeOne to episodeWatch2)))
         // Now re-sync with the same response
         repository.syncEpisodeWatchesForShow(showId)
         // Assert that both are in the db
@@ -115,7 +116,7 @@ class SeasonsEpisodesRepositoryTest : BaseDatabaseTest() {
         episodeWatchDao.insertAll(episodeWatch1, episodeWatch2)
         // Return a response with just the second item
         `when`(traktSeasonsDataSource.getShowEpisodeWatches(showId))
-                .thenReturn(listOf(episodeOne to episodeWatch2))
+                .thenReturn(Success(listOf(episodeOne to episodeWatch2)))
         // Now re-sync
         repository.syncEpisodeWatchesForShow(showId)
         // Assert that only the second is in the db
@@ -127,7 +128,7 @@ class SeasonsEpisodesRepositoryTest : BaseDatabaseTest() {
         // Insert both the watches
         episodeWatchDao.insertAll(episodeWatch1, episodeWatch2)
         // Return a empty response
-        `when`(traktSeasonsDataSource.getShowEpisodeWatches(showId)).thenReturn(emptyList())
+        `when`(traktSeasonsDataSource.getShowEpisodeWatches(showId)).thenReturn(Success(emptyList()))
         // Now re-sync
         repository.syncEpisodeWatchesForShow(showId)
         // Assert that the database is empty

--- a/data/src/main/java/app/tivi/data/RetrofitRunner.kt
+++ b/data/src/main/java/app/tivi/data/RetrofitRunner.kt
@@ -42,4 +42,11 @@ class RetrofitRunner @Inject constructor() {
             ErrorResult(e)
         }
     }
+
+    suspend fun <T> executeForResponse(request: suspend () -> Response<T>): Result<Unit> {
+        val unitMapper = object : Mapper<T, Unit> {
+            override fun map(from: T) = Unit
+        }
+        return executeForResponse(unitMapper, request)
+    }
 }

--- a/data/src/main/java/app/tivi/data/RetrofitRunner.kt
+++ b/data/src/main/java/app/tivi/data/RetrofitRunner.kt
@@ -20,6 +20,7 @@ import app.tivi.data.entities.ErrorResult
 import app.tivi.data.entities.Result
 import app.tivi.data.entities.Success
 import app.tivi.data.mappers.Mapper
+import app.tivi.extensions.bodyOrThrow
 import app.tivi.extensions.toException
 import retrofit2.Response
 import javax.inject.Inject
@@ -28,13 +29,17 @@ import javax.inject.Singleton
 @Singleton
 class RetrofitRunner @Inject constructor() {
     suspend fun <T, E> executeForResponse(mapper: Mapper<T, E>, request: suspend () -> Response<T>): Result<E> {
-        val response = request()
-        if (response.isSuccessful) {
-            val okHttpNetworkResponse = response.raw().networkResponse()
-            val notModified = okHttpNetworkResponse == null || okHttpNetworkResponse.code() == 304
-            return Success(data = mapper.map(response.body()!!), responseModified = !notModified)
-        } else {
-            return ErrorResult(response.toException())
+        return try {
+            val response = request()
+            if (response.isSuccessful) {
+                val okHttpNetworkResponse = response.raw().networkResponse()
+                val notModified = okHttpNetworkResponse == null || okHttpNetworkResponse.code() == 304
+                Success(data = mapper.map(response.bodyOrThrow()), responseModified = !notModified)
+            } else {
+                ErrorResult(response.toException())
+            }
+        } catch (e: Exception) {
+            ErrorResult(e)
         }
     }
 }

--- a/data/src/main/java/app/tivi/data/mappers/Mapper.kt
+++ b/data/src/main/java/app/tivi/data/mappers/Mapper.kt
@@ -19,3 +19,7 @@ package app.tivi.data.mappers
 interface Mapper<F, T> {
     fun map(from: F): T
 }
+
+interface IndexedMapper<F, T> {
+    fun map(index: Int, from: F): T
+}

--- a/data/src/main/java/app/tivi/data/mappers/PairMapper.kt
+++ b/data/src/main/java/app/tivi/data/mappers/PairMapper.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.tivi.data.mappers
+
+private class PairMapper<F, T1, T2>(
+    private val firstMapper: Mapper<F, T1>,
+    private val secondMapper: Mapper<F, T2>
+) : Mapper<List<F>, List<Pair<T1, T2>>> {
+    override fun map(from: List<F>): List<Pair<T1, T2>> = from.map {
+        firstMapper.map(it) to secondMapper.map(it)
+    }
+}
+
+private class PairMapper2<F, T1, T2>(
+    private val firstMapper: Mapper<F, T1>,
+    private val secondMapper: IndexedMapper<F, T2>
+) : Mapper<List<F>, List<Pair<T1, T2>>> {
+    override fun map(from: List<F>): List<Pair<T1, T2>> = from.mapIndexed { index, value ->
+        firstMapper.map(value) to secondMapper.map(index, value)
+    }
+}
+
+fun <F, T1, T2> pairMapperOf(
+    firstMapper: Mapper<F, T1>,
+    secondMapper: Mapper<F, T2>
+): Mapper<List<F>, List<Pair<T1, T2>>> {
+    return PairMapper(firstMapper, secondMapper)
+}
+
+fun <F, T1, T2> pairMapperOf(
+    firstMapper: Mapper<F, T1>,
+    secondMapper: IndexedMapper<F, T2>
+): Mapper<List<F>, List<Pair<T1, T2>>> {
+    return PairMapper2(firstMapper, secondMapper)
+}

--- a/data/src/main/java/app/tivi/data/mappers/ShowIdToTmdbIdMapper.kt
+++ b/data/src/main/java/app/tivi/data/mappers/ShowIdToTmdbIdMapper.kt
@@ -23,6 +23,7 @@ import javax.inject.Singleton
 @Singleton
 class ShowIdToTmdbIdMapper @Inject constructor(
     private val showDao: TiviShowDao
-) : Mapper<Long, Int?> {
+) : Mapper<Long, Int> {
     override fun map(from: Long) = showDao.getTmdbIdForShowId(from)
+            ?: throw IllegalArgumentException("Show with id $from does not exist")
 }

--- a/data/src/main/java/app/tivi/data/mappers/SingleToListMapper.kt
+++ b/data/src/main/java/app/tivi/data/mappers/SingleToListMapper.kt
@@ -16,8 +16,13 @@
 
 package app.tivi.data.mappers
 
-internal class SingleToListMapper<F, T>(private val singleMapper: Mapper<F, T>) : Mapper<List<F>, List<T>> {
+private class MapperToListMapper<F, T>(val singleMapper: Mapper<F, T>) : Mapper<List<F>, List<T>> {
     override fun map(from: List<F>): List<T> = from.map(singleMapper::map)
 }
 
-fun <F, T> Mapper<F, T>.toListMapper(): Mapper<List<F>, List<T>> = SingleToListMapper(this)
+private class IndexedMapperToListMapper<F, T>(val singleMapper: IndexedMapper<F, T>) : Mapper<List<F>, List<T>> {
+    override fun map(from: List<F>): List<T> = from.mapIndexed(singleMapper::map)
+}
+
+fun <F, T> Mapper<F, T>.toListMapper(): Mapper<List<F>, List<T>> = MapperToListMapper(this)
+fun <F, T> IndexedMapper<F, T>.toListMapper(): Mapper<List<F>, List<T>> = IndexedMapperToListMapper(this)

--- a/data/src/main/java/app/tivi/data/mappers/TmdbShowResultsPageUnwrapper.kt
+++ b/data/src/main/java/app/tivi/data/mappers/TmdbShowResultsPageUnwrapper.kt
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package app.tivi.data.repositories.relatedshows
+package app.tivi.data.mappers
 
-import app.tivi.data.entities.RelatedShowEntry
-import app.tivi.data.entities.Result
-import app.tivi.data.entities.TiviShow
+import com.uwetrottmann.tmdb2.entities.BaseTvShow
+import com.uwetrottmann.tmdb2.entities.TvShowResultsPage
 
-interface RelatedShowsDataSource {
-    suspend fun getRelatedShows(showId: Long): Result<List<Pair<TiviShow, RelatedShowEntry>>>
+class TmdbShowResultsPageUnwrapper<T>(
+    private val tmdbShowMapper: Mapper<List<BaseTvShow>, List<T>>
+) : Mapper<TvShowResultsPage, List<T>> {
+    override fun map(from: TvShowResultsPage): List<T> = tmdbShowMapper.map(from.results)
 }

--- a/data/src/main/java/app/tivi/data/mappers/TraktBaseShowToTiviShow.kt
+++ b/data/src/main/java/app/tivi/data/mappers/TraktBaseShowToTiviShow.kt
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-package app.tivi.data.repositories.relatedshows
+package app.tivi.data.mappers
 
-import app.tivi.data.entities.RelatedShowEntry
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.TiviShow
+import com.uwetrottmann.trakt5.entities.BaseShow
+import javax.inject.Inject
+import javax.inject.Singleton
 
-interface RelatedShowsDataSource {
-    suspend fun getRelatedShows(showId: Long): Result<List<Pair<TiviShow, RelatedShowEntry>>>
+@Singleton
+class TraktBaseShowToTiviShow @Inject constructor(
+    private val showMapper: TraktShowToTiviShow
+) : Mapper<BaseShow, TiviShow> {
+    override fun map(from: BaseShow) = showMapper.map(from.show)
 }

--- a/data/src/main/java/app/tivi/data/mappers/TraktHistoryEntryToEpisode.kt
+++ b/data/src/main/java/app/tivi/data/mappers/TraktHistoryEntryToEpisode.kt
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-package app.tivi.data.repositories.relatedshows
+package app.tivi.data.mappers
 
-import app.tivi.data.entities.RelatedShowEntry
-import app.tivi.data.entities.Result
-import app.tivi.data.entities.TiviShow
+import app.tivi.data.entities.Episode
+import com.uwetrottmann.trakt5.entities.HistoryEntry
+import javax.inject.Inject
+import javax.inject.Singleton
 
-interface RelatedShowsDataSource {
-    suspend fun getRelatedShows(showId: Long): Result<List<Pair<TiviShow, RelatedShowEntry>>>
+@Singleton
+class TraktHistoryEntryToEpisode @Inject constructor(
+    private val mapper: TraktEpisodeToEpisode
+) : Mapper<HistoryEntry, Episode> {
+    override fun map(from: HistoryEntry) = mapper.map(from.episode)
 }

--- a/data/src/main/java/app/tivi/data/mappers/TraktListEntryToTiviShow.kt
+++ b/data/src/main/java/app/tivi/data/mappers/TraktListEntryToTiviShow.kt
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-package app.tivi.data.repositories.relatedshows
+package app.tivi.data.mappers
 
-import app.tivi.data.entities.RelatedShowEntry
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.TiviShow
+import com.uwetrottmann.trakt5.entities.ListEntry
+import javax.inject.Inject
+import javax.inject.Singleton
 
-interface RelatedShowsDataSource {
-    suspend fun getRelatedShows(showId: Long): Result<List<Pair<TiviShow, RelatedShowEntry>>>
+@Singleton
+class TraktListEntryToTiviShow @Inject constructor(
+    private val showMapper: TraktShowToTiviShow
+) : Mapper<ListEntry, TiviShow> {
+    override fun map(from: ListEntry) = showMapper.map(from.show)
 }

--- a/data/src/main/java/app/tivi/data/mappers/TraktTrendingShowToTiviShow.kt
+++ b/data/src/main/java/app/tivi/data/mappers/TraktTrendingShowToTiviShow.kt
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-package app.tivi.data.repositories.relatedshows
+package app.tivi.data.mappers
 
-import app.tivi.data.entities.RelatedShowEntry
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.TiviShow
+import com.uwetrottmann.trakt5.entities.TrendingShow
+import javax.inject.Inject
+import javax.inject.Singleton
 
-interface RelatedShowsDataSource {
-    suspend fun getRelatedShows(showId: Long): Result<List<Pair<TiviShow, RelatedShowEntry>>>
+@Singleton
+class TraktTrendingShowToTiviShow @Inject constructor(
+    private val showMapper: TraktShowToTiviShow
+) : Mapper<TrendingShow, TiviShow> {
+    override fun map(from: TrendingShow) = showMapper.map(from.show)
 }

--- a/data/src/main/java/app/tivi/data/repositories/episodes/EpisodeDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/episodes/EpisodeDataSource.kt
@@ -17,7 +17,8 @@
 package app.tivi.data.repositories.episodes
 
 import app.tivi.data.entities.Episode
+import app.tivi.data.entities.Result
 
 interface EpisodeDataSource {
-    suspend fun getEpisode(showId: Long, seasonNumber: Int, episodeNumber: Int): Episode?
+    suspend fun getEpisode(showId: Long, seasonNumber: Int, episodeNumber: Int): Result<Episode>
 }

--- a/data/src/main/java/app/tivi/data/repositories/episodes/SeasonsEpisodesDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/episodes/SeasonsEpisodesDataSource.kt
@@ -25,6 +25,6 @@ interface SeasonsEpisodesDataSource {
     suspend fun getSeasonsEpisodes(showId: Long): Result<List<Pair<Season, List<Episode>>>>
     suspend fun getShowEpisodeWatches(showId: Long): Result<List<Pair<Episode, EpisodeWatchEntry>>>
     suspend fun getEpisodeWatches(episodeId: Long): Result<List<EpisodeWatchEntry>>
-    suspend fun addEpisodeWatches(watches: List<EpisodeWatchEntry>)
-    suspend fun removeEpisodeWatches(watches: List<EpisodeWatchEntry>)
+    suspend fun addEpisodeWatches(watches: List<EpisodeWatchEntry>): Result<Unit>
+    suspend fun removeEpisodeWatches(watches: List<EpisodeWatchEntry>): Result<Unit>
 }

--- a/data/src/main/java/app/tivi/data/repositories/episodes/TraktSeasonsEpisodesDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/episodes/TraktSeasonsEpisodesDataSource.kt
@@ -22,16 +22,15 @@ import app.tivi.data.entities.EpisodeWatchEntry
 import app.tivi.data.entities.Result
 import app.tivi.data.entities.Season
 import app.tivi.data.mappers.EpisodeIdToTraktIdMapper
-import app.tivi.data.mappers.Mapper
 import app.tivi.data.mappers.ShowIdToTraktIdMapper
-import app.tivi.data.mappers.TraktEpisodeToEpisode
+import app.tivi.data.mappers.TraktHistoryEntryToEpisode
 import app.tivi.data.mappers.TraktHistoryItemToEpisodeWatchEntry
 import app.tivi.data.mappers.TraktSeasonToSeasonWithEpisodes
+import app.tivi.data.mappers.pairMapperOf
 import app.tivi.data.mappers.toListMapper
 import app.tivi.extensions.executeWithRetry
 import app.tivi.extensions.fetchBody
 import com.uwetrottmann.trakt5.entities.EpisodeIds
-import com.uwetrottmann.trakt5.entities.HistoryEntry
 import com.uwetrottmann.trakt5.entities.SyncEpisode
 import com.uwetrottmann.trakt5.entities.SyncItems
 import com.uwetrottmann.trakt5.entities.UserSlug
@@ -50,40 +49,30 @@ class TraktSeasonsEpisodesDataSource @Inject constructor(
     private val usersService: Provider<Users>,
     private val syncService: Provider<Sync>,
     private val seasonMapper: TraktSeasonToSeasonWithEpisodes,
-    private val episodeMapper: TraktEpisodeToEpisode,
+    private val episodeMapper: TraktHistoryEntryToEpisode,
     private val historyItemMapper: TraktHistoryItemToEpisodeWatchEntry,
     private val retrofitRunner: RetrofitRunner
 ) : SeasonsEpisodesDataSource {
     override suspend fun getSeasonsEpisodes(showId: Long): Result<List<Pair<Season, List<Episode>>>> {
-        val showTraktId = showIdToTraktIdMapper.map(showId)
         return retrofitRunner.executeForResponse(seasonMapper.toListMapper()) {
-            seasonsService.get().summary(showTraktId.toString(), Extended.FULLEPISODES).executeWithRetry()
+            seasonsService.get().summary(showIdToTraktIdMapper.map(showId).toString(), Extended.FULLEPISODES)
+                    .executeWithRetry()
         }
     }
 
     override suspend fun getShowEpisodeWatches(showId: Long): Result<List<Pair<Episode, EpisodeWatchEntry>>> {
-        val showTraktId = showIdToTraktIdMapper.map(showId)
-
-        val mapper = object : Mapper<HistoryEntry, Pair<Episode, EpisodeWatchEntry>> {
-            override fun map(from: HistoryEntry): Pair<Episode, EpisodeWatchEntry> {
-                return episodeMapper.map(from.episode) to historyItemMapper.map(from)
-            }
-        }
-
-        return retrofitRunner.executeForResponse(mapper.toListMapper()) {
-            usersService.get().history(UserSlug.ME, HistoryType.SHOWS, showTraktId,
+        return retrofitRunner.executeForResponse(pairMapperOf(episodeMapper, historyItemMapper)) {
+            usersService.get().history(UserSlug.ME, HistoryType.SHOWS, showIdToTraktIdMapper.map(showId),
                     0, 10000, Extended.NOSEASONS, null, null)
-                    .execute()
+                    .executeWithRetry()
         }
     }
 
     override suspend fun getEpisodeWatches(episodeId: Long): Result<List<EpisodeWatchEntry>> {
-        val episodeTraktId = episodeIdToTraktIdMapper.map(episodeId)
-
         return retrofitRunner.executeForResponse(historyItemMapper.toListMapper()) {
-            usersService.get().history(UserSlug.ME, HistoryType.EPISODES, episodeTraktId,
+            usersService.get().history(UserSlug.ME, HistoryType.EPISODES, episodeIdToTraktIdMapper.map(episodeId),
                     0, 10000, Extended.NOSEASONS, null, null)
-                    .execute()
+                    .executeWithRetry()
         }
     }
 

--- a/data/src/main/java/app/tivi/data/repositories/followedshows/FollowedShowsDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/followedshows/FollowedShowsDataSource.kt
@@ -22,7 +22,7 @@ import app.tivi.data.entities.TiviShow
 
 interface FollowedShowsDataSource {
     suspend fun getListShows(listId: Int): Result<List<Pair<FollowedShowEntry, TiviShow>>>
-    suspend fun addShowIdsToList(listId: Int, shows: List<TiviShow>)
-    suspend fun removeShowIdsFromList(listId: Int, shows: List<TiviShow>)
+    suspend fun addShowIdsToList(listId: Int, shows: List<TiviShow>): Result<Unit>
+    suspend fun removeShowIdsFromList(listId: Int, shows: List<TiviShow>): Result<Unit>
     suspend fun getFollowedListId(): Int?
 }

--- a/data/src/main/java/app/tivi/data/repositories/followedshows/FollowedShowsDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/followedshows/FollowedShowsDataSource.kt
@@ -17,14 +17,12 @@
 package app.tivi.data.repositories.followedshows
 
 import app.tivi.data.entities.FollowedShowEntry
+import app.tivi.data.entities.Result
 import app.tivi.data.entities.TiviShow
 
 interface FollowedShowsDataSource {
-    suspend fun getListShows(listId: Int): List<Pair<FollowedShowEntry, TiviShow>>
-
+    suspend fun getListShows(listId: Int): Result<List<Pair<FollowedShowEntry, TiviShow>>>
     suspend fun addShowIdsToList(listId: Int, shows: List<TiviShow>)
-
     suspend fun removeShowIdsFromList(listId: Int, shows: List<TiviShow>)
-
     suspend fun getFollowedListId(): Int?
 }

--- a/data/src/main/java/app/tivi/data/repositories/popularshows/PopularShowsDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/popularshows/PopularShowsDataSource.kt
@@ -17,8 +17,9 @@
 package app.tivi.data.repositories.popularshows
 
 import app.tivi.data.entities.PopularShowEntry
+import app.tivi.data.entities.Result
 import app.tivi.data.entities.TiviShow
 
 interface PopularShowsDataSource {
-    suspend fun getPopularShows(page: Int, pageSize: Int): List<Pair<TiviShow, PopularShowEntry>>
+    suspend fun getPopularShows(page: Int, pageSize: Int): Result<List<Pair<TiviShow, PopularShowEntry>>>
 }

--- a/data/src/main/java/app/tivi/data/repositories/popularshows/PopularShowsRepository.kt
+++ b/data/src/main/java/app/tivi/data/repositories/popularshows/PopularShowsRepository.kt
@@ -17,6 +17,7 @@
 package app.tivi.data.repositories.popularshows
 
 import android.arch.paging.DataSource
+import app.tivi.data.entities.Success
 import app.tivi.data.repositories.shows.LocalShowStore
 import app.tivi.data.repositories.shows.ShowRepository
 import app.tivi.data.resultentities.PopularEntryWithShow
@@ -48,14 +49,15 @@ class PopularShowsRepository @Inject constructor(
     }
 
     private suspend fun updatePopularShows(page: Int, resetOnSave: Boolean) {
-        traktDataSource.getPopularShows(page, 20)
-                .map { (show, entry) ->
+        val response = traktDataSource.getPopularShows(page, 20)
+        when (response) {
+            is Success -> {
+                response.data.map { (show, entry) ->
                     // Grab the show id if it exists, or save the show and use it's generated ID
                     val showId = showStore.getIdOrSavePlaceholder(show)
                     // Make a copy of the entry with the id
-                    entry.copy(showId = showId)
-                }
-                .also { entries ->
+                    entry.copy(showId = showId, page = page)
+                }.also { entries ->
                     if (resetOnSave) {
                         localStore.deleteAll()
                     }
@@ -68,5 +70,7 @@ class PopularShowsRepository @Inject constructor(
                         }
                     }
                 }
+            }
+        }
     }
 }

--- a/data/src/main/java/app/tivi/data/repositories/popularshows/TraktPopularShowsDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/popularshows/TraktPopularShowsDataSource.kt
@@ -16,10 +16,15 @@
 
 package app.tivi.data.repositories.popularshows
 
+import app.tivi.data.RetrofitRunner
 import app.tivi.data.entities.PopularShowEntry
+import app.tivi.data.entities.Result
 import app.tivi.data.entities.TiviShow
+import app.tivi.data.mappers.IndexedMapper
 import app.tivi.data.mappers.TraktShowToTiviShow
-import app.tivi.extensions.fetchBodyWithRetry
+import app.tivi.data.mappers.pairMapperOf
+import app.tivi.extensions.executeWithRetry
+import com.uwetrottmann.trakt5.entities.Show
 import com.uwetrottmann.trakt5.enums.Extended
 import com.uwetrottmann.trakt5.services.Shows
 import javax.inject.Inject
@@ -27,13 +32,21 @@ import javax.inject.Provider
 
 class TraktPopularShowsDataSource @Inject constructor(
     private val showService: Provider<Shows>,
-    private val mapper: TraktShowToTiviShow
+    private val retrofitRunner: RetrofitRunner,
+    private val showMapper: TraktShowToTiviShow
 ) : PopularShowsDataSource {
-    override suspend fun getPopularShows(page: Int, pageSize: Int): List<Pair<TiviShow, PopularShowEntry>> {
-        // We add 1 because Trakt uses a 1-based index whereas we use a 0-based index
-        val results = showService.get().popular(page + 1, pageSize, Extended.NOSEASONS).fetchBodyWithRetry()
-        return results.mapIndexed { index, show ->
-            mapper.map(show) to PopularShowEntry(showId = 0, pageOrder = index, page = page)
+    private val entryMapper = object : IndexedMapper<Show, PopularShowEntry> {
+        override fun map(index: Int, from: Show): PopularShowEntry {
+            return PopularShowEntry(showId = 0, pageOrder = index, page = 0)
+        }
+    }
+
+    private val resultsMapper = pairMapperOf(showMapper, entryMapper)
+
+    override suspend fun getPopularShows(page: Int, pageSize: Int): Result<List<Pair<TiviShow, PopularShowEntry>>> {
+        return retrofitRunner.executeForResponse(resultsMapper) {
+            // We add 1 because Trakt uses a 1-based index whereas we use a 0-based index
+            showService.get().popular(page + 1, pageSize, Extended.NOSEASONS).executeWithRetry()
         }
     }
 }

--- a/data/src/main/java/app/tivi/data/repositories/trendingshows/TraktTrendingShowsDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/trendingshows/TraktTrendingShowsDataSource.kt
@@ -16,10 +16,15 @@
 
 package app.tivi.data.repositories.trendingshows
 
+import app.tivi.data.RetrofitRunner
+import app.tivi.data.entities.Result
 import app.tivi.data.entities.TiviShow
 import app.tivi.data.entities.TrendingShowEntry
-import app.tivi.data.mappers.TraktShowToTiviShow
-import app.tivi.extensions.fetchBodyWithRetry
+import app.tivi.data.mappers.Mapper
+import app.tivi.data.mappers.TraktTrendingShowToTiviShow
+import app.tivi.data.mappers.pairMapperOf
+import app.tivi.extensions.executeWithRetry
+import com.uwetrottmann.trakt5.entities.TrendingShow
 import com.uwetrottmann.trakt5.enums.Extended
 import com.uwetrottmann.trakt5.services.Shows
 import javax.inject.Inject
@@ -27,13 +32,20 @@ import javax.inject.Provider
 
 class TraktTrendingShowsDataSource @Inject constructor(
     private val showService: Provider<Shows>,
-    private val mapper: TraktShowToTiviShow
+    private val retrofitRunner: RetrofitRunner,
+    private val showMapper: TraktTrendingShowToTiviShow
 ) : TrendingShowsDataSource {
-    override suspend fun getTrendingShows(page: Int, pageSize: Int): List<Pair<TiviShow, TrendingShowEntry>> {
-        // We add 1 because Trakt uses a 1-based index whereas we use a 0-based index
-        val results = showService.get().trending(page + 1, pageSize, Extended.NOSEASONS).fetchBodyWithRetry()
-        return results.map { show ->
-            mapper.map(show.show) to TrendingShowEntry(showId = 0, watchers = show.watchers, page = page)
+    private val entryMapper = object : Mapper<TrendingShow, TrendingShowEntry> {
+        override fun map(from: TrendingShow): TrendingShowEntry {
+            return TrendingShowEntry(showId = 0, watchers = from.watchers, page = 0)
+        }
+    }
+    private val responseMapper = pairMapperOf(showMapper, entryMapper)
+
+    override suspend fun getTrendingShows(page: Int, pageSize: Int): Result<List<Pair<TiviShow, TrendingShowEntry>>> {
+        return retrofitRunner.executeForResponse(responseMapper) {
+            // We add 1 because Trakt uses a 1-based index whereas we use a 0-based index
+            showService.get().trending(page + 1, pageSize, Extended.NOSEASONS).executeWithRetry()
         }
     }
 }

--- a/data/src/main/java/app/tivi/data/repositories/trendingshows/TrendingShowsDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/trendingshows/TrendingShowsDataSource.kt
@@ -16,9 +16,10 @@
 
 package app.tivi.data.repositories.trendingshows
 
+import app.tivi.data.entities.Result
 import app.tivi.data.entities.TiviShow
 import app.tivi.data.entities.TrendingShowEntry
 
 interface TrendingShowsDataSource {
-    suspend fun getTrendingShows(page: Int, pageSize: Int): List<Pair<TiviShow, TrendingShowEntry>>
+    suspend fun getTrendingShows(page: Int, pageSize: Int): Result<List<Pair<TiviShow, TrendingShowEntry>>>
 }

--- a/data/src/main/java/app/tivi/data/repositories/watchedshows/WatchedShowsDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/watchedshows/WatchedShowsDataSource.kt
@@ -16,9 +16,10 @@
 
 package app.tivi.data.repositories.watchedshows
 
+import app.tivi.data.entities.Result
 import app.tivi.data.entities.TiviShow
 import app.tivi.data.entities.WatchedShowEntry
 
 interface WatchedShowsDataSource {
-    suspend fun getWatchedShows(): List<Pair<TiviShow, WatchedShowEntry>>
+    suspend fun getWatchedShows(): Result<List<Pair<TiviShow, WatchedShowEntry>>>
 }


### PR DESCRIPTION
Currently only about a third of network calls are done using RetrofitRunner. RetrofitRunner forces good practice by wrapping the result into a `Result` sealed class. It also does automatic checking of the HTTP response code.

Trakt had a lot of network issues today which were causing most of the app to crash a lot (due to HTTP 502 responses). This commit fixes Tivi to handle that gracefully.