### PR TITLE
Use $(...)  instead of legacy backticks for checksum.sh

### DIFF
--- a/checksum.sh
+++ b/checksum.sh
@@ -7,7 +7,7 @@ fi
 touch $RESULT_FILE
 
 checksum_file() {
-  echo `openssl md5 $1 | awk '{print $2}'`
+  echo $(openssl md5 $1 | awk '{print $2}')
 }
 
 FILES=()
@@ -17,7 +17,7 @@ done < <(find . -name 'build.gradle' -type f -print0)
 
 # Loop through files and append MD5 to result file
 for FILE in ${FILES[@]}; do
-	echo `checksum_file $FILE` >> $RESULT_FILE
+	echo $(checksum_file $FILE) >> $RESULT_FILE
 done
 # Now sort the file so that it is 
 sort $RESULT_FILE -o $RESULT_FILE


### PR DESCRIPTION
Backtick command substitution `...` is legacy syntax with several issues.

- It has a series of undefined behaviors related to quoting in POSIX.
- It imposes a custom escaping mode with surprising results.
- It's exceptionally hard to nest.

$(...) command substitution has none of these problems, and is therefore strongly encouraged.