### PR TITLE
Use dexcount 'enabled' flag to run it only on CI

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ androidExtensions {
 apply plugin: 'com.getkeepsafe.dexcount'
 dexcount {
     // Only run the method counter on CI
-    runOnEachPackage = ci
+    enabled = ci
 }
 
 apply plugin: 'com.github.triplet.play'


### PR DESCRIPTION
New `enabled` [flag](https://github.com/KeepSafe/dexcount-gradle-plugin#configuration) was introduced in v0.8.4, which explicitly enables/disables counting, so it makes sense to use it for this purpose.
>enabled: When false, no build outputs will be counted. Defaults to true.