### PR TITLE
Update Play Publisher and simplify its configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,7 @@ apply plugin: 'com.github.triplet.play'
 play {
     track = 'internal'
     defaultToAppBundles = true
+    serviceAccountCredentials = rootProject.file('signing/play-account.json')
 }
 
 if (file("google-services.json").exists()) {
@@ -54,12 +55,6 @@ println("APK version code: " + appVersionCode)
 android {
     compileSdkVersion buildConfig.compileSdk
 
-    playAccountConfigs {
-        defaultAccountConfig {
-            serviceAccountCredentials = rootProject.file('signing/play-account.json')
-        }
-    }
-
     defaultConfig {
         applicationId "app.tivi"
         minSdkVersion buildConfig.minSdk
@@ -71,8 +66,6 @@ android {
         resConfigs "en"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
-        playAccountConfig = playAccountConfigs.defaultAccountConfig
 
         buildConfigField "String", "TRAKT_CLIENT_ID", "\"" + propOrDef("TIVI_TRAKT_CLIENT_ID", "") + "\""
         buildConfigField "String", "TRAKT_CLIENT_SECRET", "\"" + propOrDef("TIVI_TRAKT_CLIENT_SECRET", "") + "\""

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ buildscript {
 
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.4'
 
-        classpath 'com.github.triplet.gradle:play-publisher:2.0.0-beta2'
+        classpath 'com.github.triplet.gradle:play-publisher:2.0.0-rc1'
 
         classpath 'com.google.gms:google-services:4.1.0'
         classpath 'io.fabric.tools:gradle:1.26.1'


### PR DESCRIPTION
`serviceAccountCredentials` configuration can be specified more succinctly.
Since there is no flavor-specific setup right now, I think it's reasonable to use the simpler way.