### PR TITLE
Google Cloud Build implementation

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -24,10 +24,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectPlainTextFileTypeManager">
-    <file url="file://$PROJECT_DIR$/tasks/src/main/java/app/tivi/tasks/TiviJob.kt" />
-  </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,17 +3,28 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/base/base.iml" filepath="$PROJECT_DIR$/base/base.iml" />
       <module fileurl="file://$PROJECT_DIR$/base/base.iml" filepath="$PROJECT_DIR$/base/base.iml" />
       <module fileurl="file://$PROJECT_DIR$/base-android/base-android.iml" filepath="$PROJECT_DIR$/base-android/base-android.iml" />
       <module fileurl="file://$PROJECT_DIR$/buildSrc/buildSrc.iml" filepath="$PROJECT_DIR$/buildSrc/buildSrc.iml" />
       <module fileurl="file://$PROJECT_DIR$/data/data.iml" filepath="$PROJECT_DIR$/data/data.iml" />
+      <module fileurl="file://$PROJECT_DIR$/data/data.iml" filepath="$PROJECT_DIR$/data/data.iml" />
+      <module fileurl="file://$PROJECT_DIR$/data-android/data-android.iml" filepath="$PROJECT_DIR$/data-android/data-android.iml" />
       <module fileurl="file://$PROJECT_DIR$/data-android/data-android.iml" filepath="$PROJECT_DIR$/data-android/data-android.iml" />
       <module fileurl="file://$PROJECT_DIR$/datasources/datasources.iml" filepath="$PROJECT_DIR$/datasources/datasources.iml" />
+      <module fileurl="file://$PROJECT_DIR$/datasources/datasources.iml" filepath="$PROJECT_DIR$/datasources/datasources.iml" />
+      <module fileurl="file://$PROJECT_DIR$/interactors/interactors.iml" filepath="$PROJECT_DIR$/interactors/interactors.iml" />
       <module fileurl="file://$PROJECT_DIR$/interactors/interactors.iml" filepath="$PROJECT_DIR$/interactors/interactors.iml" />
       <module fileurl="file://$PROJECT_DIR$/tasks/tasks.iml" filepath="$PROJECT_DIR$/tasks/tasks.iml" />
+      <module fileurl="file://$PROJECT_DIR$/tasks/tasks.iml" filepath="$PROJECT_DIR$/tasks/tasks.iml" />
+      <module fileurl="file://$PROJECT_DIR$/tivi.iml" filepath="$PROJECT_DIR$/tivi.iml" />
       <module fileurl="file://$PROJECT_DIR$/tivi.iml" filepath="$PROJECT_DIR$/tivi.iml" />
       <module fileurl="file://$PROJECT_DIR$/tmdb/tmdb.iml" filepath="$PROJECT_DIR$/tmdb/tmdb.iml" />
+      <module fileurl="file://$PROJECT_DIR$/tmdb/tmdb.iml" filepath="$PROJECT_DIR$/tmdb/tmdb.iml" />
       <module fileurl="file://$PROJECT_DIR$/trakt/trakt.iml" filepath="$PROJECT_DIR$/trakt/trakt.iml" />
+      <module fileurl="file://$PROJECT_DIR$/trakt/trakt.iml" filepath="$PROJECT_DIR$/trakt/trakt.iml" />
+      <module fileurl="file://$PROJECT_DIR$/trakt-auth/trakt-auth.iml" filepath="$PROJECT_DIR$/trakt-auth/trakt-auth.iml" />
       <module fileurl="file://$PROJECT_DIR$/trakt-auth/trakt-auth.iml" filepath="$PROJECT_DIR$/trakt-auth/trakt-auth.iml" />
     </modules>
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,7 +137,7 @@ android {
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
-            versionNameSuffix "-dev [${getGitHash()}]"
+            versionNameSuffix "-dev"
             applicationIdSuffix ".debug"
         }
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -33,22 +33,6 @@ steps:
   - '--bucket=gs://${_CACHE_BUCKET}'
   - --key=gradle-$( checksum checksum.txt )
 
-# - name: gcr.io/$PROJECT_ID/restore_cache:1.0
-#   id: garbage
-#   waitFor: ['restore_cache']
-#   entrypoint: bash
-#   args:
-#   - -c
-#   - |
-#     echo "ls /workspace/.gradle"
-#     ls /workspace/.gradle
-
-#     echo "ls /workspace/.gradle/wrapper/dists"
-#     ls /workspace/.gradle/wrapper/dists
-
-#     exit 1
-
-
   # Build the project
 - name: gcr.io/$PROJECT_ID/android:28
   id: download_dependencies
@@ -57,8 +41,8 @@ steps:
     env:
     - 'TERM=dumb'
     - 'GRADLE_USER_HOME=/workspace/.gradle'
-    - 'JAVA_TOOL_OPTIONS="-Xmx1024m"'
     - 'GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false"'
+    - 'JAVA_TOOL_OPTIONS="-Xmx2048m"'
     - 'BRANCH_NAME=$BRANCH_NAME'
     - 'ARTIFACT_BUCKET=gs://${_ARTIFACT_BUCKET}'
   waitFor:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,165 @@
+steps:
+
+#
+# Get a build number
+#
+# Download the config bucket, which stores the build number.
+- name: 'gcr.io/cloud-builders/gsutil'
+  id: copy_config
+  waitFor: ['-']  # The '-' indicates that this step begins immediately.
+  # we use rsync and not cp so that this step doesn't fail the first time it's run
+  args: ['rsync', 'gs://${PROJECT_ID}-config/', '/config']
+  volumes:
+  - name: 'config'
+    path: '/config'
+
+# Runs the setup_env.sh script, which writes build environment
+# variables to build_environment.sh
+- name: 'gcr.io/$PROJECT_ID/tar'
+  id: setup_env
+  entrypoint: 'bash'
+  args: ['-c', 'cloudbuild/setup_env.sh']
+  waitFor: ['copy_config']
+  volumes:
+  - name: 'config'
+    path: '/config'
+
+# Save the updated build number to cloud storage
+- name: 'gcr.io/cloud-builders/gsutil'
+  id: save_env
+  args: ['cp', '/config/version.txt', 'gs://${PROJECT_ID}-config/version.txt']
+  waitFor: ['setup_env']
+  volumes:
+  - name: 'config'
+    path: '/config'
+
+#
+# Extract the cache
+#
+# The gradle build cache is stored as a tarball in Google Cloud Storage to make builds faster.
+#
+- name: 'gcr.io/cloud-builders/gsutil'
+  id: copy_build_cache
+  waitFor: ['-']  # The '-' indicates that this step begins immediately.
+  # we use rsync and not cp so that this step doesn't fail the first time it's run
+  args: ['rsync', 'gs://${PROJECT_ID}-cache/', '/build_cache']
+  volumes:
+  - name: 'build_cache'
+    path: '/build_cache'
+
+- name: 'gcr.io/$PROJECT_ID/tar'
+  id: extract_build_cache
+  waitFor: ['copy_build_cache']
+  # This might fail the first time, but that's okay
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    tar xpzf /build_cache/cache.tgz -C /build_cache || echo "No cache found."
+  volumes:
+  - name: 'build_cache'
+    path: '/build_cache'
+
+#
+# Build the project
+#
+# In order to get the build number that we calculated earlier, we need to source the
+# build_environment.sh file *in each step it's needed* before running our build.
+#
+- name: 'gcr.io/$PROJECT_ID/android'
+  id: build
+  entrypoint: 'bash'
+  args:
+    - '-c'
+    - |
+      source build_environment.sh
+      ./gradlew --stacktrace bundleDebug assembleDebug app:assembleDebugAndroidTest
+#-Ptivi.versioncode=${BUILD_NUM}
+  <<: &env
+    env:
+    - 'TERM=dumb'
+    - 'JAVA_TOOL_OPTIONS="-Xmx1024m"'
+    - 'GRADLE_USER_HOME=/build_cache/.gradle'
+    - 'GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false"'
+  waitFor:
+#    - decrypt_secrets
+    - extract_build_cache
+  volumes:
+  - name: 'build_cache'
+    path: '/build_cache'
+
+#
+# Save the APKs
+#
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['-q', 'cp', '-r', 'app/build/outputs/apk', 'gs://${PROJECT_ID}-artifacts/$BRANCH_NAME-$BUILD_ID/']
+  waitFor: ['build']
+
+#
+# Unit Tests
+#
+# Run the unit tests using the same type of step as the build.
+#
+- name: 'gcr.io/$PROJECT_ID/android'
+  id: unit_tests
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    source build_environment.sh
+    ./gradlew --stacktrace check
+  <<: *env
+  waitFor: ['build']
+  volumes:
+  - name: 'build_cache'
+    path: '/build_cache'
+
+#
+# Store the unit test reports
+#
+- name: 'gcr.io/cloud-builders/gsutil'
+  id: store_unit_test_reports
+  args: ['-q', 'cp', '-r', 'app/build/reports/', 'gs://${PROJECT_ID}-artifacts/$BRANCH_NAME-$BUILD_ID/']
+  waitFor: ['unit_tests']
+
+#
+# Store the unit test results
+#
+- name: 'gcr.io/cloud-builders/gsutil'
+  id: store_unit_test_results
+  args: ['-q', 'cp', '-r', 'app/build/test-results/', 'gs://${PROJECT_ID}-artifacts/$BRANCH_NAME-$BUILD_ID/']
+  waitFor: ['unit_tests']
+
+#
+# Cleanup
+#
+
+# Compress the gradle build cache
+- name: 'gcr.io/$PROJECT_ID/tar'
+  id: compress_cache
+  args: ['cpvzf', '/build_cache/cache.tgz', '-C', '/build_cache', '/build_cache/.gradle']
+  waitFor: ['unit_tests']
+  volumes:
+  - name: 'build_cache'
+    path: '/build_cache'
+
+# Store the build cache
+- name: gcr.io/cloud-builders/gsutil
+  args: ['cp', '/build_cache/cache.tgz', 'gs://${PROJECT_ID}-cache/cache.tgz']
+  waitFor: ['compress_cache']
+  volumes:
+  - name: 'build_cache'
+    path: '/build_cache'
+
+timeout: 1800s
+
+# This build requires more than 3.75 GB of memory, so I have to use a HIGHCPU machine
+# which has 30 GB of memory.  This means I can give Gradle lots of processes to run
+# highly parallelized.
+#
+# A standard machine is $0.003 per build minute, but these high cpu machines are
+# $0.016 per build minute. That means that a 15 minute build will cost $0.045 on
+# a standard machine, but $0.24 on the larger machine.  A machine half that size
+# from CircleCI would cost $0.024 per build minute, so that saves 1/3 the cost.
+#options:
+#  machineType: 'N1_HIGHCPU_8'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,8 +41,12 @@ steps:
     env:
     - 'TERM=dumb'
     - 'GRADLE_USER_HOME=/workspace/.gradle'
+    # For standard maching, use these options
     - 'GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false"'
     - 'JAVA_TOOL_OPTIONS="-Xmx1024m"'
+    # For High CPU machine, use these options
+    # - 'GRADLE_OPTS="-Dorg.gradle.daemon=false -Dkotlin.incremental=false"'
+    # - 'JAVA_TOOL_OPTIONS="-Xmx4g"'
     - 'BRANCH_NAME=$BRANCH_NAME'
     - 'ARTIFACT_BUCKET=gs://${_ARTIFACT_BUCKET}'
   waitFor:
@@ -107,3 +111,7 @@ substitutions:
   _CONFIG_BUCKET: black-circle-221-tivi-build-config
 
 timeout: 1800s
+
+# Uncomment this to use the High CPU machine
+# options:
+#   machineType: 'N1_HIGHCPU_8'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,155 +1,125 @@
 ##
 # Required images
 #
-# * https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/android
-# * https://github.com/pixiteapps/android-cloud-build/tree/master/buildnum
-# * https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/tar
+# In order for this to run you need to deploy the Pixite Android cloud builders.
+#
+# ```bash
+# git clone git@github.com:pixiteapps/android-cloud-build /tmp/android-cloud-build
+# cd /tmp/android-cloud-build
+# gcloud builds submit .
+# ```
 
 steps:
 
-# First things first, get and save a build number
-# Fail if we can't
-- name: 'gcr.io/cloud-builders/gsutil'
-  id: copy_config
-  waitFor: ['-']  # The '-' indicates that this step begins immediately.
-  # we use rsync and not cp so that this step doesn't fail the first time it's run
-  args: ['rsync', 'gs://${_CONFIG_BUCKET}/', '/config']
-  volumes:
-  - name: 'config'
-    path: '/config'
-
-# Runs the setup_env.sh script to setup the CI environment
-- name: 'gcr.io/$PROJECT_ID/buildnum'
+# Update the build number
+- name: 'gcr.io/$PROJECT_ID/buildnum:1.0'
   id: setup_env
-  args: ['/config/buildnum', '.buildenv']
-  waitFor: ['copy_config']
-  volumes:
-  - name: 'config'
-    path: '/config'
+  waitFor: ['-']
+  args: ['gs://${_CONFIG_BUCKET}/buildnum']
 
-- name: 'gcr.io/cloud-builders/gsutil'
-  id: save_env
-  args: ['cp', '/config/buildnum', 'gs://${_CONFIG_BUCKET}/buildnum']
-  waitFor: ['setup_env']
-  volumes:
-  - name: 'config'
-    path: '/config'
-
-#
-# Build
-#
-- name: 'gcr.io/cloud-builders/gsutil'
-  id: copy_build_cache
-  waitFor: ['-']  # The '-' indicates that this step begins immediately.
-  # we use rsync and not cp so that this step doesn't fail the first time it's run
-  args: ['rsync', 'gs://${_CACHE_BUCKET}/', '/build_cache']
-  volumes:
-  - name: 'build_cache'
-    path: '/build_cache'
-
-- name: 'gcr.io/$PROJECT_ID/tar'
-  id: extract_build_cache
-  waitFor: ['copy_build_cache']
-  # This might fail the first time, but that's okay
-  entrypoint: '/bin/bash'
+- name: gcr.io/cloud-builders/gcloud
+  id: generate_cache_key
+  entrypoint: bash
+  waitFor: ['-']
   args:
-  - '-c'
+  - -c
   - |
-    tar xpzf /build_cache/cache.tgz -C / || echo "No cache found."
-  volumes:
-  - name: 'build_cache'
-    path: '/build_cache'
+    ./checksum.sh checksum.txt
+
+- name: gcr.io/$PROJECT_ID/restore_cache:1.0
+  id: restore_cache
+  waitFor: ['generate_cache_key']
+  args:
+  - '--bucket=gs://${_CACHE_BUCKET}'
+  - --key=gradle-$( checksum checksum.txt )
+
+# - name: gcr.io/$PROJECT_ID/restore_cache:1.0
+#   id: garbage
+#   waitFor: ['restore_cache']
+#   entrypoint: bash
+#   args:
+#   - -c
+#   - |
+#     echo "ls /workspace/.gradle"
+#     ls /workspace/.gradle
+
+#     echo "ls /workspace/.gradle/wrapper/dists"
+#     ls /workspace/.gradle/wrapper/dists
+
+#     exit 1
+
 
   # Build the project
-- name: 'gcr.io/$PROJECT_ID/android:28'
-  id: build
-  args: ['./gradlew', '--stacktrace', '-Dtrace', 'bundleDebug', 'assembleDebug', 'app:assembleDebugAndroidTest']
+- name: gcr.io/$PROJECT_ID/android:28
+  id: download_dependencies
+  args: ['./gradlew', 'dependencies']
   <<: &env
     env:
     - 'TERM=dumb'
-    - 'JAVA_TOOL_OPTIONS="-Xmx4g"'
-    - 'GRADLE_USER_HOME=/build_cache/.gradle'
-    - 'GRADLE_OPTS="-Dorg.gradle.daemon=false -Dkotlin.incremental=false"'
+    - 'GRADLE_USER_HOME=/workspace/.gradle'
+    - 'JAVA_TOOL_OPTIONS="-Xmx1024m"'
+    - 'GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false"'
     - 'BRANCH_NAME=$BRANCH_NAME'
+    - 'ARTIFACT_BUCKET=gs://${_ARTIFACT_BUCKET}'
   waitFor:
-  - extract_build_cache
-  volumes:
-  - name: 'build_cache'
-    path: '/build_cache'
+  - setup_env
+  - restore_cache
 
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['-q', 'cp', '-r', 'app/build/outputs/apk', 'gs://${_ARTIFACT_BUCKET}/$BRANCH_NAME-$BUILD_ID/']
-  waitFor: ['build']
-
-#
-# Unit Tests
-#
-
-# Run the unit tests
 - name: 'gcr.io/$PROJECT_ID/android:28'
-  id: unit_tests
-  args: ['./gradlew', '--stacktrace', '-Dtrace', 'check']
+  id: build
+  args: ['./gradlew', 'bundleDebug', 'assembleDebug', '-Ptivi.versioncode=1']
   <<: *env
-  waitFor: ['build']
-  volumes:
-  - name: 'build_cache'
-    path: '/build_cache'
+  waitFor:
+  - download_dependencies
 
-# Store the unit test reports
-- name: 'gcr.io/cloud-builders/gsutil'
-  id: store_unit_test_reports
-  args: ['-q', 'cp', '-r', 'app/build/reports/', 'gs://${_ARTIFACT_BUCKET}/$BRANCH_NAME-$BUILD_ID/']
-  waitFor: ['unit_tests']
-
-# Store the unit test results
-- name: 'gcr.io/cloud-builders/gsutil'
-  id: store_unit_test_results
-  args: ['-q', 'cp', '-r', 'app/build/test-results/', 'gs://${_ARTIFACT_BUCKET}/$BRANCH_NAME-$BUILD_ID/']
-  waitFor: ['unit_tests']
-
-#
-# Deployment
-#
-
-# Deploy to Google Play
-- name: 'gcr.io/$PROJECT_ID/android:28'
-  id: deploy_to_play
-  args: ["for_branch", "master", "./gradlew", "--stacktrace", "-Dtrace", ":app:publishReleaseApk"]
+- name: gcr.io/$PROJECT_ID/deploy_to_gcs:1.0
+  args:
+  - --path=app/build/outputs
+  waitFor: 
+  - build
   <<: *env
-  waitFor: ['unit_tests'] # removed 'ftl_tests'
-  volumes:
-  - name: 'build_cache'
-    path: '/build_cache'
 
-# Deploy to Crashlytics Beta
-- name: 'gcr.io/$PROJECT_ID/android:28'
-  id: deploy_to_beta
-  args: ["for_branch", "develop", "./gradlew", "--stacktrace", "-Dtrace", ":app:crashlyticsUploadDistributionDebug"]
+#
+# Check
+#
+- name: gcr.io/$PROJECT_ID/android:28
+  id: check
+  args: ['./gradlew', 'check', 'dependencyUpdates']
+  waitFor:
+  - build
   <<: *env
-  waitFor: ['unit_tests'] # removed 'ftl_tests'
-  volumes:
-  - name: 'build_cache'
-    path: '/build_cache'
 
-#
-# Cleanup
-#
+- name: gcr.io/$PROJECT_ID/deploy_to_gcs:1.0
+  args:
+  - --path=app/build/reports
+  - --path=build/dependencyUpdates
+  waitFor: ['check']
+  <<: *env
 
-# Compress the gradle build cache
-- name: 'gcr.io/$PROJECT_ID/tar'
-  id: compress_cache
-  args: ['cpzf', '/build_cache/cache.tgz', '/build_cache/.gradle/caches', '/build_cache/.gradle/wrapper']
-  waitFor: ['deploy_to_play', 'deploy_to_beta']
-  volumes:
-  - name: 'build_cache'
-    path: '/build_cache'
+- name: gcr.io/$PROJECT_ID/deploy_to_gcs:1.0
+  id: save_test_results
+  waitFor: ['check']
+  entrypoint: bash
+  <<: *env
+  args:
+  - -c
+  - |
+    mkdir -p junit
+    find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} junit/ \;
 
-# Store the build cache
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', '/build_cache/cache.tgz', 'gs://${_CACHE_BUCKET}/cache.tgz']
-  waitFor: ['compress_cache']
-  volumes:
-  - name: 'build_cache'
-    path: '/build_cache'
+    deploy_to_gcs --path=junit
+
+- name: 'gcr.io/$PROJECT_ID/save_cache:1.0'
+  waitFor: ['check']
+  args:
+  - '--bucket=gs://${_CACHE_BUCKET}'
+  - --key=gradle-$( checksum checksum.txt )
+  - '--path=/workspace/.gradle/caches'
+  - '--path=/workspace/.gradle/wrapper'
+
+substitutions:
+  _ARTIFACT_BUCKET: black-circle-221-tivi-build-artifacts
+  _CACHE_BUCKET: black-circle-221-tivi-build-cache
+  _CONFIG_BUCKET: black-circle-221-tivi-build-config
 
 timeout: 1800s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,7 +30,7 @@ steps:
   id: restore_cache
   waitFor: ['generate_cache_key']
   args:
-  - '--bucket=gs://${_CACHE_BUCKET}'
+  - --bucket=gs://${_CACHE_BUCKET}
   - --key=gradle-$( checksum checksum.txt )
 
   # Build the project
@@ -93,13 +93,13 @@ steps:
 
     deploy_to_gcs --path=junit
 
-- name: 'gcr.io/$PROJECT_ID/save_cache:1.0'
+- name: gcr.io/$PROJECT_ID/save_cache:1.0
   waitFor: ['check']
   args:
-  - '--bucket=gs://${_CACHE_BUCKET}'
+  - --bucket=gs://${_CACHE_BUCKET}
   - --key=gradle-$( checksum checksum.txt )
-  - '--path=/workspace/.gradle/caches'
-  - '--path=/workspace/.gradle/wrapper'
+  - --path=/workspace/.gradle/caches
+  - --path=/workspace/.gradle/wrapper
 
 substitutions:
   _ARTIFACT_BUCKET: black-circle-221-tivi-build-artifacts

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -42,7 +42,7 @@ steps:
     - 'TERM=dumb'
     - 'GRADLE_USER_HOME=/workspace/.gradle'
     - 'GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false"'
-    - 'JAVA_TOOL_OPTIONS="-Xmx2048m"'
+    - 'JAVA_TOOL_OPTIONS="-Xmx1024m"'
     - 'BRANCH_NAME=$BRANCH_NAME'
     - 'ARTIFACT_BUCKET=gs://${_ARTIFACT_BUCKET}'
   waitFor:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,48 +1,48 @@
+##
+# Required images
+#
+# * https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/android
+# * https://github.com/pixiteapps/android-cloud-build/tree/master/buildnum
+# * https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/tar
+
 steps:
 
-#
-# Get a build number
-#
-# Download the config bucket, which stores the build number.
+# First things first, get and save a build number
+# Fail if we can't
 - name: 'gcr.io/cloud-builders/gsutil'
   id: copy_config
   waitFor: ['-']  # The '-' indicates that this step begins immediately.
   # we use rsync and not cp so that this step doesn't fail the first time it's run
-  args: ['rsync', 'gs://${PROJECT_ID}-config/', '/config']
+  args: ['rsync', 'gs://${_CONFIG_BUCKET}/', '/config']
   volumes:
   - name: 'config'
     path: '/config'
 
-# Runs the setup_env.sh script, which writes build environment
-# variables to build_environment.sh
-- name: 'gcr.io/$PROJECT_ID/tar'
+# Runs the setup_env.sh script to setup the CI environment
+- name: 'gcr.io/$PROJECT_ID/buildnum'
   id: setup_env
-  entrypoint: 'bash'
-  args: ['-c', 'cloudbuild/setup_env.sh']
+  args: ['/config/buildnum', '.buildenv']
   waitFor: ['copy_config']
   volumes:
   - name: 'config'
     path: '/config'
 
-# Save the updated build number to cloud storage
 - name: 'gcr.io/cloud-builders/gsutil'
   id: save_env
-  args: ['cp', '/config/version.txt', 'gs://${PROJECT_ID}-config/version.txt']
+  args: ['cp', '/config/buildnum', 'gs://${_CONFIG_BUCKET}/buildnum']
   waitFor: ['setup_env']
   volumes:
   - name: 'config'
     path: '/config'
 
 #
-# Extract the cache
-#
-# The gradle build cache is stored as a tarball in Google Cloud Storage to make builds faster.
+# Build
 #
 - name: 'gcr.io/cloud-builders/gsutil'
   id: copy_build_cache
   waitFor: ['-']  # The '-' indicates that this step begins immediately.
   # we use rsync and not cp so that this step doesn't fail the first time it's run
-  args: ['rsync', 'gs://${PROJECT_ID}-cache/', '/build_cache']
+  args: ['rsync', 'gs://${_CACHE_BUCKET}/', '/build_cache']
   volumes:
   - name: 'build_cache'
     path: '/build_cache'
@@ -51,84 +51,85 @@ steps:
   id: extract_build_cache
   waitFor: ['copy_build_cache']
   # This might fail the first time, but that's okay
-  entrypoint: 'bash'
+  entrypoint: '/bin/bash'
   args:
   - '-c'
   - |
-    tar xpzf /build_cache/cache.tgz -C /build_cache || echo "No cache found."
+    tar xpzf /build_cache/cache.tgz -C / || echo "No cache found."
   volumes:
   - name: 'build_cache'
     path: '/build_cache'
 
-#
-# Build the project
-#
-# In order to get the build number that we calculated earlier, we need to source the
-# build_environment.sh file *in each step it's needed* before running our build.
-#
-- name: 'gcr.io/$PROJECT_ID/android'
+  # Build the project
+- name: 'gcr.io/$PROJECT_ID/android:28'
   id: build
-  entrypoint: 'bash'
-  args:
-    - '-c'
-    - |
-      source build_environment.sh
-      ./gradlew --stacktrace bundleDebug assembleDebug app:assembleDebugAndroidTest
-#-Ptivi.versioncode=${BUILD_NUM}
+  args: ['./gradlew', '--stacktrace', '-Dtrace', 'bundleDebug', 'assembleDebug', 'app:assembleDebugAndroidTest']
   <<: &env
     env:
     - 'TERM=dumb'
-    - 'JAVA_TOOL_OPTIONS="-Xmx1024m"'
+    - 'JAVA_TOOL_OPTIONS="-Xmx4g"'
     - 'GRADLE_USER_HOME=/build_cache/.gradle'
-    - 'GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false"'
+    - 'GRADLE_OPTS="-Dorg.gradle.daemon=false -Dkotlin.incremental=false"'
+    - 'BRANCH_NAME=$BRANCH_NAME'
   waitFor:
-#    - decrypt_secrets
-    - extract_build_cache
+  - extract_build_cache
   volumes:
   - name: 'build_cache'
     path: '/build_cache'
 
-#
-# Save the APKs
-#
 - name: 'gcr.io/cloud-builders/gsutil'
-  args: ['-q', 'cp', '-r', 'app/build/outputs/apk', 'gs://${PROJECT_ID}-artifacts/$BRANCH_NAME-$BUILD_ID/']
+  args: ['-q', 'cp', '-r', 'app/build/outputs/apk', 'gs://${_ARTIFACT_BUCKET}/$BRANCH_NAME-$BUILD_ID/']
   waitFor: ['build']
 
 #
 # Unit Tests
 #
-# Run the unit tests using the same type of step as the build.
-#
-- name: 'gcr.io/$PROJECT_ID/android'
+
+# Run the unit tests
+- name: 'gcr.io/$PROJECT_ID/android:28'
   id: unit_tests
-  entrypoint: 'bash'
-  args:
-  - '-c'
-  - |
-    source build_environment.sh
-    ./gradlew --stacktrace check
+  args: ['./gradlew', '--stacktrace', '-Dtrace', 'check']
   <<: *env
   waitFor: ['build']
   volumes:
   - name: 'build_cache'
     path: '/build_cache'
 
-#
 # Store the unit test reports
-#
 - name: 'gcr.io/cloud-builders/gsutil'
   id: store_unit_test_reports
-  args: ['-q', 'cp', '-r', 'app/build/reports/', 'gs://${PROJECT_ID}-artifacts/$BRANCH_NAME-$BUILD_ID/']
+  args: ['-q', 'cp', '-r', 'app/build/reports/', 'gs://${_ARTIFACT_BUCKET}/$BRANCH_NAME-$BUILD_ID/']
+  waitFor: ['unit_tests']
+
+# Store the unit test results
+- name: 'gcr.io/cloud-builders/gsutil'
+  id: store_unit_test_results
+  args: ['-q', 'cp', '-r', 'app/build/test-results/', 'gs://${_ARTIFACT_BUCKET}/$BRANCH_NAME-$BUILD_ID/']
   waitFor: ['unit_tests']
 
 #
-# Store the unit test results
+# Deployment
 #
-- name: 'gcr.io/cloud-builders/gsutil'
-  id: store_unit_test_results
-  args: ['-q', 'cp', '-r', 'app/build/test-results/', 'gs://${PROJECT_ID}-artifacts/$BRANCH_NAME-$BUILD_ID/']
-  waitFor: ['unit_tests']
+
+# Deploy to Google Play
+- name: 'gcr.io/$PROJECT_ID/android:28'
+  id: deploy_to_play
+  args: ["for_branch", "master", "./gradlew", "--stacktrace", "-Dtrace", ":app:publishReleaseApk"]
+  <<: *env
+  waitFor: ['unit_tests'] # removed 'ftl_tests'
+  volumes:
+  - name: 'build_cache'
+    path: '/build_cache'
+
+# Deploy to Crashlytics Beta
+- name: 'gcr.io/$PROJECT_ID/android:28'
+  id: deploy_to_beta
+  args: ["for_branch", "develop", "./gradlew", "--stacktrace", "-Dtrace", ":app:crashlyticsUploadDistributionDebug"]
+  <<: *env
+  waitFor: ['unit_tests'] # removed 'ftl_tests'
+  volumes:
+  - name: 'build_cache'
+    path: '/build_cache'
 
 #
 # Cleanup
@@ -137,29 +138,18 @@ steps:
 # Compress the gradle build cache
 - name: 'gcr.io/$PROJECT_ID/tar'
   id: compress_cache
-  args: ['cpvzf', '/build_cache/cache.tgz', '-C', '/build_cache', '/build_cache/.gradle']
-  waitFor: ['unit_tests']
+  args: ['cpzf', '/build_cache/cache.tgz', '/build_cache/.gradle/caches', '/build_cache/.gradle/wrapper']
+  waitFor: ['deploy_to_play', 'deploy_to_beta']
   volumes:
   - name: 'build_cache'
     path: '/build_cache'
 
 # Store the build cache
-- name: gcr.io/cloud-builders/gsutil
-  args: ['cp', '/build_cache/cache.tgz', 'gs://${PROJECT_ID}-cache/cache.tgz']
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['cp', '/build_cache/cache.tgz', 'gs://${_CACHE_BUCKET}/cache.tgz']
   waitFor: ['compress_cache']
   volumes:
   - name: 'build_cache'
     path: '/build_cache'
 
 timeout: 1800s
-
-# This build requires more than 3.75 GB of memory, so I have to use a HIGHCPU machine
-# which has 30 GB of memory.  This means I can give Gradle lots of processes to run
-# highly parallelized.
-#
-# A standard machine is $0.003 per build minute, but these high cpu machines are
-# $0.016 per build minute. That means that a 15 minute build will cost $0.045 on
-# a standard machine, but $0.24 on the larger machine.  A machine half that size
-# from CircleCI would cost $0.024 per build minute, so that saves 1/3 the cost.
-#options:
-#  machineType: 'N1_HIGHCPU_8'

--- a/cloudbuild/android/Dockerfile
+++ b/cloudbuild/android/Dockerfile
@@ -1,0 +1,48 @@
+# we use a gcr.io image and not openjdk:8-jdk-slim because it loads faster in the google Google Cloud Build environment
+FROM gcr.io/cloud-builders/javac
+
+LABEL maintainer="ryan@pixiteapps.com"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# make Apt non-interactive
+RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90builder \
+  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90builder
+
+# Install Dependencies
+RUN apt-get update && \
+    apt-get install -y \
+        git locales sudo openssh-client ca-certificates tar gzip parallel \
+        zip unzip bzip2 gnupg curl wget
+
+# Set timezone to UTC by default
+RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
+
+# Use unicode
+RUN locale-gen C.UTF-8 || true
+ENV LANG=C.UTF-8
+
+ARG sdk_version=sdk-tools-linux-4333796.zip
+ARG android_home=/opt/android/sdk
+
+# Install Android SDK
+RUN sudo mkdir -p ${android_home} && \
+    curl --silent --show-error --location --fail --retry 3 --output /tmp/${sdk_version} https://dl.google.com/android/repository/${sdk_version} && \
+    unzip -q /tmp/${sdk_version} -d ${android_home} && \
+    rm /tmp/${sdk_version}
+
+# Set environment variables
+ENV ANDROID_HOME ${android_home}
+ENV ADB_INSTALL_TIMEOUT 120
+ENV PATH=${ANDROID_HOME}/emulator:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:${PATH}
+
+RUN mkdir ~/.android && echo '### User Sources for Android SDK Manager' > ~/.android/repositories.cfg
+
+RUN yes | sdkmanager --licenses && sdkmanager --update
+
+# Update SDK manager and install system image, platform and build tools
+RUN sdkmanager \
+    "tools" \
+    "platform-tools" \
+    "build-tools;28.0.3" \
+    "platforms;android-28"

--- a/cloudbuild/android/README.md
+++ b/cloudbuild/android/README.md
@@ -1,0 +1,17 @@
+# android
+
+This is an image that contains the latest Android SDK and NDK, used to build Android projects.
+
+## Examples
+
+The following examples demonstrate build requests that use this builder.
+
+### Fetch the contents of a remote URL
+
+This `cloudbuild.yaml` extracts a zip archive, overwriting any existing data.
+
+```
+steps:
+- name: gcr.io/$PROJECT_ID/unzip
+  args: ['-o', '-q', 'cache.zip']
+```

--- a/cloudbuild/android/cloudbuild.yaml
+++ b/cloudbuild/android/cloudbuild.yaml
@@ -1,0 +1,5 @@
+steps:
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/android', '.']
+
+images: ['gcr.io/$PROJECT_ID/android']

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -1,0 +1,10 @@
+steps:
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/tar', './tar']
+
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/android', './android']
+
+images: 
+- 'gcr.io/$PROJECT_ID/tar'
+- 'gcr.io/$PROJECT_ID/android'

--- a/cloudbuild/setup_env.sh
+++ b/cloudbuild/setup_env.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+version_file="/config/version.txt"
+
+__LAST_BUILD_NUM=1900
+
+if [ -f "${version_file}" ];then
+  echo "Reading existing version from ${version_file}"
+  source "${version_file}"
+fi
+
+BUILD_NUM=$((__LAST_BUILD_NUM+1))
+
+echo
+echo "       Last build number: ${__LAST_BUILD_NUM}"
+echo "Updating to build number: ${BUILD_NUM}"
+
+echo "__LAST_BUILD_NUM=${BUILD_NUM}" > "${version_file}"
+
+OUTPUT_FILE=build_environment.sh
+echo "export BUILD_NUM=${BUILD_NUM}" > ${OUTPUT_FILE}
+
+echo "Wrote output file: ${OUTPUT_FILE}"

--- a/cloudbuild/tar/Dockerfile
+++ b/cloudbuild/tar/Dockerfile
@@ -1,0 +1,6 @@
+FROM launcher.gcr.io/google/ubuntu16_04
+
+RUN apt-get update && \
+    apt-get -y install tar bzip2 gzip
+
+ENTRYPOINT ["tar"]

--- a/cloudbuild/tar/README.md
+++ b/cloudbuild/tar/README.md
@@ -1,0 +1,28 @@
+# tar
+
+This is a tool build to simply invoke the
+[`tar`](https://linux.die.net/man/1/tar) command.
+
+Arguments passed to this builder will be passed to `tar` directly.
+
+## Examples
+
+The following examples demonstrate build requests that use this builder.
+
+### Archive and compress caches
+
+This `cloudbuild.yaml` archives and compresses the build cache directories.
+
+```
+steps:
+- name: gcr.io/$PROJECT_ID/tar
+  args: ['cpzf', 'cache.tar.gz', '.gradle', '/root/.gradle', '/root/.m2']
+```
+
+### Extract an existing archive
+
+```
+steps:
+- name: gcr.io/$PROJECT_ID/tar
+  args: ['cpzf', 'cache.tar.gz', '.gradle', '/root/.gradle', '/root/.m2']
+```

--- a/cloudbuild/tar/cloudbuild.yaml
+++ b/cloudbuild/tar/cloudbuild.yaml
@@ -1,0 +1,5 @@
+steps:
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/tar', '.']
+
+images: ['gcr.io/$PROJECT_ID/tar']


### PR DESCRIPTION
I've done a lot of work on the cloud builders since you started the integration, so here's the updated build script.

This is mostly functional, minus the deployment data since I don't have access to your keys.

Setup is much easier than before, simply: 

0. Setup `gcloud`, etc.
1. Install the cloud builders.

```bash
git clone git@github.com:pixiteapps/android-cloud-build /tmp/android-cloud-build
cd /tmp/android-cloud-build
gcloud builds submit .
```

2. Setup GCS buckets for cache, config and artifacts and update substitutions (via `--substitutions` works).

```yaml
  _ARTIFACT_BUCKET: black-circle-221-tivi-build-artifacts
  _CACHE_BUCKET: black-circle-221-tivi-build-cache
  _CONFIG_BUCKET: black-circle-221-tivi-build-config
```

### Note

This should still probably be considered experimental as it takes roughly 10-12 minutes to build, compared to the 4-5 minutes I'm seeing in your public CIrcleCI data.

I think this is due to the fact that GCB is running on an `n1-standard-1` instance, which only has a single vCPU and 3.75 GB of memory, as part of the free tier. 

Changing that to an `n1-highcpu-8` instance, which costs $0.016 / build-minute executes the build in 3-4 minutes. Based on the cost, and looking at how many builds you performed last month on CircleCI would cost $2.17 per month.  If you increased your build count by 60% to 50 builds per month, that would cost $3.20 per month.

While these costs aren't large, I'm going to suggest that GCB make at least the `n1-standard-2` VMs the free tier, since that would match up with the free offering of CircleCI (in CPU count) and Bitrise (in CPU count and Memory).