### PR TITLE
Verify with the proper keystore for release build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,7 +54,7 @@ if (file("google-services.json").exists()) {
 def appVersionCode = propOrDef("tivi.versioncode", 17) as Integer
 println("APK version code: " + appVersionCode)
 
-def useReleaseKeystore = rootProject.file("signing/app-debug.jks").exists()
+def useReleaseKeystore = rootProject.file("signing/app-release.jks").exists()
 
 android {
     compileSdkVersion buildConfig.compileSdk


### PR DESCRIPTION
I think the proper verification is to check if the `app-release.jks` file exists for release build.