### PR TITLE
Fix OutOfMemoryError when building the first time

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,6 @@ android.enableJetifier=true
 
 # Enable Robolectric to use the same resources as Android
 android.enableUnitTestBinaryResources=true
+
+# The default memory is 512m
+org.gradle.jvmargs=-Xmx1g


### PR DESCRIPTION
Gradle 5.0 change the default memory from 1g to 512m. This caused failed build with `OutOfMemoryError: GC overhead limit exceeded` error. Setting back the memory to 1g fix this issue. See https://github.com/gradle/gradle/issues/7746#issuecomment-439137327