### PR TITLE
Fix checksum script

### DIFF
--- a/checksum.sh
+++ b/checksum.sh
@@ -13,7 +13,7 @@ checksum_file() {
 FILES=()
 while read -r -d ''; do
 	FILES+=("$REPLY")
-done < <(find . -name 'build.gradle*' -or -name 'dependencies.kt' -or -name 'gradle-wrapper.properties' -type f -print0)
+done < <(find . -type f \( -name "build.gradle*" -o -name "dependencies.kt" -o -name "gradle-wrapper.properties" \) -print0)
 
 # Loop through files and append MD5 to result file
 for FILE in ${FILES[@]}; do


### PR DESCRIPTION
Hey, I used the same script on an integration for CloudBuild and noticed that the `checksum.sh` was not working correctly. This PR fixes it 😃 