### PR TITLE
Move paged interactors to use Flow directly

### DIFF
--- a/buildSrc/src/main/java/app/tivi/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/app/tivi/buildsrc/dependencies.kt
@@ -101,7 +101,6 @@ object Libs {
 
         object Paging {
             private const val version = "2.1.0"
-            const val rxjava2 = "androidx.paging:paging-rxjava2:$version"
             const val common = "androidx.paging:paging-common-ktx:$version"
             const val runtime = "androidx.paging:paging-runtime-ktx:$version"
         }

--- a/data-android/src/main/java/app/tivi/data/FlowPagedListBuilder.kt
+++ b/data-android/src/main/java/app/tivi/data/FlowPagedListBuilder.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.tivi.data
+
+import androidx.arch.core.executor.ArchTaskExecutor
+import androidx.paging.DataSource
+import androidx.paging.PagedList
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.concurrent.Executor
+
+/**
+ * Builder for `Flow<PagedList>` given a [DataSource.Factory] and a [PagedList.Config].
+ *
+ * The required parameters are in the constructor, so you can simply construct and build, or
+ * optionally enable extra features (such as initial load key, or BoundaryCallback).
+ *
+ * The returned Flow will already be subscribed on the
+ * [.setFetchScheduler], and will perform all loading on that scheduler. It will
+ * already be observed on [.setNotifyScheduler], and will dispatch new PagedLists,
+ * as well as their updates to that scheduler.
+ *
+ * @param <K> Type of input valued used to load data from the DataSource. Must be integer if
+ * you're using PositionalDataSource.
+ * @param <V> Item type being presented.
+</Value></Key> */
+class FlowPagedListBuilder<K, V>(
+    private val dataSourceFactory: DataSource.Factory<K, V>,
+    private val config: PagedList.Config,
+
+    /**
+     * First loading key passed to the first PagedList/DataSource.
+     * <p>
+     * When a new PagedList/DataSource pair is created after the first, it acquires a load key from
+     * the previous generation so that data is loaded around the position already being observed.
+     *
+     * @param key Initial load key passed to the first PagedList/DataSource.
+     */
+    var initialLoadKey: K? = null,
+
+    /**
+     * Typically used to load additional data from network when paging from local storage.
+     *
+     * Pass a BoundaryCallback to listen to when the PagedList runs out of data to load. If this
+     * method is not called, or `null` is passed, you will not be notified when each
+     * DataSource runs out of data to provide to its PagedList.
+     *
+     * If you are paging from a DataSource.Factory backed by local storage, you can set a
+     * BoundaryCallback to know when there is no more information to page from local storage.
+     * This is useful to page from the network when local storage is a cache of network data.
+     *
+     * Note that when using a BoundaryCallback with a `Flow<PagedList>`, method calls
+     * on the callback may be dispatched multiple times - one for each PagedList/DataSource
+     * pair. If loading network data from a BoundaryCallback, you should prevent multiple
+     * dispatches of the same method from triggering multiple simultaneous network loads.
+     */
+    var boundaryCallback: PagedList.BoundaryCallback<*>? = null,
+
+    private var notifyExecutor: Executor? = null,
+    private var fetchExecutor: Executor? = null
+) {
+    /**
+     * Constructs a `Flow<PagedList>`.
+     *
+     * @return The Flow of PagedLists
+     */
+    fun buildFlow(): Flow<PagedList<V>> = channelFlow {
+        val nExecutor = notifyExecutor ?: ArchTaskExecutor.getMainThreadExecutor()
+        val fExecutor = fetchExecutor ?: ArchTaskExecutor.getIOThreadExecutor()
+
+        val nDispatcher = nExecutor.asCoroutineDispatcher()
+        val fDispatcher = fExecutor.asCoroutineDispatcher()
+
+        val invalidateCallback = object : ClearableInvalidatedCallback {
+            private var prevList: PagedList<V>? = null
+            private var dataSource: DataSource<K, V>? = null
+
+            override fun onInvalidated() = sendNewList()
+
+            override fun clear() {
+                dataSource?.removeInvalidatedCallback(this)
+            }
+
+            private fun sendNewList() {
+                launch(fDispatcher) {
+                    // Compute on the fetch dispatcher
+                    val list = createPagedList()
+
+                    withContext(nDispatcher) {
+                        // Send on the notify dispatcher
+                        send(list)
+                    }
+                }
+            }
+
+            @Suppress("UNCHECKED_CAST")
+            private fun createPagedList(): PagedList<V> {
+                do {
+                    dataSource?.removeInvalidatedCallback(this)
+
+                    dataSource = dataSourceFactory.create().also {
+                        it.addInvalidatedCallback(this)
+                    }
+
+                    val list = PagedList.Builder(dataSource!!, config)
+                            .setNotifyExecutor(nExecutor)
+                            .setFetchExecutor(fExecutor)
+                            .setBoundaryCallback(boundaryCallback)
+                            .setInitialKey(prevList?.lastKey as? K ?: initialLoadKey)
+                            .build()
+                            .also { prevList = it }
+
+                } while (list.isDetached)
+
+                return prevList!!
+            }
+        }
+
+        // Do the initial load
+        invalidateCallback.onInvalidated()
+
+        awaitClose {
+            invalidateCallback.clear()
+        }
+    }
+
+    private interface ClearableInvalidatedCallback: DataSource.InvalidatedCallback {
+        fun clear()
+    }
+}

--- a/data-android/src/main/java/app/tivi/data/FlowPagedListBuilder.kt
+++ b/data-android/src/main/java/app/tivi/data/FlowPagedListBuilder.kt
@@ -127,7 +127,6 @@ class FlowPagedListBuilder<K, V>(
                             .setInitialKey(prevList?.lastKey as? K ?: initialLoadKey)
                             .build()
                             .also { prevList = it }
-
                 } while (list.isDetached)
 
                 return prevList!!
@@ -142,7 +141,7 @@ class FlowPagedListBuilder<K, V>(
         }
     }
 
-    private interface ClearableInvalidatedCallback: DataSource.InvalidatedCallback {
+    private interface ClearableInvalidatedCallback : DataSource.InvalidatedCallback {
         fun clear()
     }
 }

--- a/data-android/src/main/java/app/tivi/data/FlowPagedListBuilder.kt
+++ b/data-android/src/main/java/app/tivi/data/FlowPagedListBuilder.kt
@@ -34,14 +34,14 @@ import java.util.concurrent.Executor
  * optionally enable extra features (such as initial load key, or BoundaryCallback).
  *
  * The returned Flow will already be subscribed on the
- * [.setFetchScheduler], and will perform all loading on that scheduler. It will
- * already be observed on [.setNotifyScheduler], and will dispatch new PagedLists,
+ * [fetchExecutor], and will perform all loading on that scheduler. It will
+ * already be observed on [notifyExecutor], and will dispatch new PagedLists,
  * as well as their updates to that scheduler.
  *
  * @param <K> Type of input valued used to load data from the DataSource. Must be integer if
  * you're using PositionalDataSource.
  * @param <V> Item type being presented.
-</Value></Key> */
+ */
 class FlowPagedListBuilder<K, V>(
     private val dataSourceFactory: DataSource.Factory<K, V>,
     private val config: PagedList.Config,

--- a/interactors/build.gradle
+++ b/interactors/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation project(":base")
     implementation project(":base-android")
     api project(":data")
+    implementation project(":data-android")
 
     kapt Libs.Dagger.compiler
 

--- a/interactors/build.gradle
+++ b/interactors/build.gradle
@@ -48,7 +48,6 @@ dependencies {
     kapt Libs.Dagger.compiler
 
     api Libs.AndroidX.Paging.common
-    implementation Libs.AndroidX.Paging.rxjava2
     implementation Libs.AndroidX.Paging.runtime
 
     implementation Libs.RxJava.rxJava

--- a/interactors/src/main/java/app/tivi/interactors/ObservePagedFollowedShows.kt
+++ b/interactors/src/main/java/app/tivi/interactors/ObservePagedFollowedShows.kt
@@ -17,15 +17,13 @@
 package app.tivi.interactors
 
 import androidx.paging.PagedList
-import androidx.paging.RxPagedListBuilder
+import app.tivi.data.FlowPagedListBuilder
 import app.tivi.data.entities.SortOption
 import app.tivi.data.repositories.followedshows.FollowedShowsRepository
 import app.tivi.data.resultentities.FollowedShowEntryWithShow
 import app.tivi.util.AppCoroutineDispatchers
-import io.reactivex.BackpressureStrategy
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.reactive.asFlow
 import javax.inject.Inject
 
 class ObservePagedFollowedShows @Inject constructor(
@@ -35,11 +33,11 @@ class ObservePagedFollowedShows @Inject constructor(
     override val dispatcher: CoroutineDispatcher = dispatchers.io
 
     override fun createObservable(params: Parameters): Flow<PagedList<FollowedShowEntryWithShow>> {
-        val source = followedShowsRepository.observeFollowedShows(params.sort, params.filter)
-        return RxPagedListBuilder(source, params.pagingConfig)
-                .setBoundaryCallback(params.boundaryCallback)
-                .buildFlowable(BackpressureStrategy.LATEST)
-                .asFlow()
+        return FlowPagedListBuilder(
+                followedShowsRepository.observeFollowedShows(params.sort, params.filter),
+                params.pagingConfig,
+                boundaryCallback = params.boundaryCallback
+        ).buildFlow()
     }
 
     data class Parameters(

--- a/interactors/src/main/java/app/tivi/interactors/ObservePagedPopularShows.kt
+++ b/interactors/src/main/java/app/tivi/interactors/ObservePagedPopularShows.kt
@@ -17,14 +17,12 @@
 package app.tivi.interactors
 
 import androidx.paging.PagedList
-import androidx.paging.RxPagedListBuilder
+import app.tivi.data.FlowPagedListBuilder
 import app.tivi.data.repositories.popularshows.PopularShowsRepository
 import app.tivi.data.resultentities.PopularEntryWithShow
 import app.tivi.util.AppCoroutineDispatchers
-import io.reactivex.BackpressureStrategy
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.reactive.asFlow
 import javax.inject.Inject
 
 class ObservePagedPopularShows @Inject constructor(
@@ -34,11 +32,11 @@ class ObservePagedPopularShows @Inject constructor(
     override val dispatcher: CoroutineDispatcher = dispatchers.io
 
     override fun createObservable(params: Params): Flow<PagedList<PopularEntryWithShow>> {
-        val source = popularShowsRepository.observeForPaging()
-        return RxPagedListBuilder(source, params.pagingConfig)
-                .setBoundaryCallback(params.boundaryCallback)
-                .buildFlowable(BackpressureStrategy.LATEST)
-                .asFlow()
+        return FlowPagedListBuilder(
+                popularShowsRepository.observeForPaging(),
+                params.pagingConfig,
+                boundaryCallback = params.boundaryCallback
+        ).buildFlow()
     }
 
     data class Params(

--- a/interactors/src/main/java/app/tivi/interactors/ObservePagedTrendingShows.kt
+++ b/interactors/src/main/java/app/tivi/interactors/ObservePagedTrendingShows.kt
@@ -17,14 +17,12 @@
 package app.tivi.interactors
 
 import androidx.paging.PagedList
-import androidx.paging.RxPagedListBuilder
+import app.tivi.data.FlowPagedListBuilder
 import app.tivi.data.repositories.trendingshows.TrendingShowsRepository
 import app.tivi.data.resultentities.TrendingEntryWithShow
 import app.tivi.util.AppCoroutineDispatchers
-import io.reactivex.BackpressureStrategy
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.reactive.asFlow
 import javax.inject.Inject
 
 class ObservePagedTrendingShows @Inject constructor(
@@ -34,11 +32,11 @@ class ObservePagedTrendingShows @Inject constructor(
     override val dispatcher: CoroutineDispatcher = dispatchers.io
 
     override fun createObservable(params: Params): Flow<PagedList<TrendingEntryWithShow>> {
-        val source = trendingShowsRepository.observeForPaging()
-        return RxPagedListBuilder(source, params.pagingConfig)
-                .setBoundaryCallback(params.boundaryCallback)
-                .buildFlowable(BackpressureStrategy.LATEST)
-                .asFlow()
+        return FlowPagedListBuilder(
+                trendingShowsRepository.observeForPaging(),
+                params.pagingConfig,
+                boundaryCallback = params.boundaryCallback
+        ).buildFlow()
     }
 
     data class Params(

--- a/interactors/src/main/java/app/tivi/interactors/ObservePagedWatchedShows.kt
+++ b/interactors/src/main/java/app/tivi/interactors/ObservePagedWatchedShows.kt
@@ -17,29 +17,27 @@
 package app.tivi.interactors
 
 import androidx.paging.PagedList
-import androidx.paging.RxPagedListBuilder
+import app.tivi.data.FlowPagedListBuilder
 import app.tivi.data.entities.SortOption
 import app.tivi.data.repositories.watchedshows.WatchedShowsRepository
 import app.tivi.data.resultentities.WatchedShowEntryWithShow
 import app.tivi.util.AppCoroutineDispatchers
-import io.reactivex.BackpressureStrategy
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.reactive.asFlow
 import javax.inject.Inject
 
-class ObserveWatchedShows @Inject constructor(
+class ObservePagedWatchedShows @Inject constructor(
     dispatchers: AppCoroutineDispatchers,
     private val watchedShowsRepository: WatchedShowsRepository
-) : PagingInteractor<ObserveWatchedShows.Params, WatchedShowEntryWithShow>() {
+) : PagingInteractor<ObservePagedWatchedShows.Params, WatchedShowEntryWithShow>() {
     override val dispatcher: CoroutineDispatcher = dispatchers.io
 
     override fun createObservable(params: Params): Flow<PagedList<WatchedShowEntryWithShow>> {
-        val source = watchedShowsRepository.observeWatchedShowsPagedList(params.filter, params.sort)
-        return RxPagedListBuilder(source, params.pagingConfig)
-                .setBoundaryCallback(params.boundaryCallback)
-                .buildFlowable(BackpressureStrategy.LATEST)
-                .asFlow()
+        return FlowPagedListBuilder(
+                watchedShowsRepository.observeWatchedShowsPagedList(params.filter, params.sort),
+                params.pagingConfig,
+                boundaryCallback = params.boundaryCallback
+        ).buildFlow()
     }
 
     data class Params(

--- a/ui-watched/src/main/java/app/tivi/home/watched/WatchedViewModel.kt
+++ b/ui-watched/src/main/java/app/tivi/home/watched/WatchedViewModel.kt
@@ -20,7 +20,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagedList
 import app.tivi.data.entities.SortOption
 import app.tivi.data.resultentities.WatchedShowEntryWithShow
-import app.tivi.interactors.ObserveWatchedShows
+import app.tivi.interactors.ObservePagedWatchedShows
 import app.tivi.interactors.UpdateWatchedShows
 import app.tivi.interactors.launchInteractor
 import app.tivi.tmdb.TmdbManager
@@ -43,7 +43,7 @@ import kotlinx.coroutines.launch
 class WatchedViewModel @AssistedInject constructor(
     @Assisted initialState: WatchedViewState,
     private val updateWatchedShows: UpdateWatchedShows,
-    private val observeWatchedShows: ObserveWatchedShows,
+    private val observePagedWatchedShows: ObservePagedWatchedShows,
     private val traktManager: TraktManager,
     tmdbManager: TmdbManager,
     private val logger: Logger,
@@ -76,7 +76,7 @@ class WatchedViewModel @AssistedInject constructor(
                     .execute { copy(tmdbImageUrlProvider = it() ?: tmdbImageUrlProvider) }
         }
 
-        viewModelScope.launchObserve(observeWatchedShows) {
+        viewModelScope.launchObserve(observePagedWatchedShows) {
             it.execute { copy(watchedShows = it()) }
         }
 
@@ -92,8 +92,8 @@ class WatchedViewModel @AssistedInject constructor(
     }
 
     private fun updateDataSource(state: WatchedViewState) {
-        viewModelScope.launchInteractor(observeWatchedShows,
-                ObserveWatchedShows.Params(
+        viewModelScope.launchInteractor(observePagedWatchedShows,
+                ObservePagedWatchedShows.Params(
                         sort = state.sort,
                         filter = state.filter,
                         pagingConfig = PAGING_CONFIG,


### PR DESCRIPTION
Allows us to move away from RxPagedListBuilder.

May not be a perfect port of RxPagedListBuilder, but it's close enough.