### PR TITLE
Use process scope for long-lived operations

### DIFF
--- a/app/src/main/java/app/tivi/home/HomeActivityViewModel.kt
+++ b/app/src/main/java/app/tivi/home/HomeActivityViewModel.kt
@@ -24,11 +24,13 @@ import app.tivi.interactors.launchInteractor
 import app.tivi.trakt.TraktAuthState
 import app.tivi.trakt.TraktManager
 import app.tivi.TiviMvRxViewModel
+import app.tivi.inject.ProcessLifetime
 import app.tivi.interactors.launchObserve
 import com.airbnb.mvrx.MvRxViewModelFactory
 import com.airbnb.mvrx.ViewModelContext
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -40,7 +42,8 @@ class HomeActivityViewModel @AssistedInject constructor(
     @Assisted initialState: HomeActivityViewState,
     private val traktManager: TraktManager,
     private val updateUserDetails: UpdateUserDetails,
-    observeUserDetails: ObserveUserDetails
+    observeUserDetails: ObserveUserDetails,
+    @ProcessLifetime private val dataOperationScope: CoroutineScope
 ) : TiviMvRxViewModel<HomeActivityViewState>(initialState) {
     init {
         viewModelScope.launchObserve(observeUserDetails) {
@@ -55,7 +58,7 @@ class HomeActivityViewModel @AssistedInject constructor(
                     .distinctUntilChanged()
                     .onEach {
                         if (it == TraktAuthState.LOGGED_IN) {
-                            viewModelScope.launchInteractor(updateUserDetails,
+                            dataOperationScope.launchInteractor(updateUserDetails,
                                     UpdateUserDetails.Params("me", false))
                         }
                     }

--- a/app/src/main/java/app/tivi/inject/AppModule.kt
+++ b/app/src/main/java/app/tivi/inject/AppModule.kt
@@ -19,6 +19,8 @@ package app.tivi.inject
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.coroutineScope
 import androidx.preference.PreferenceManager
 import app.tivi.BuildConfig
 import app.tivi.TiviApplication
@@ -26,6 +28,7 @@ import app.tivi.util.AppCoroutineDispatchers
 import dagger.Module
 import dagger.Provides
 import io.reactivex.disposables.CompositeDisposable
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.threeten.bp.ZoneId
 import org.threeten.bp.format.DateTimeFormatter
@@ -123,5 +126,11 @@ class AppModule {
         return DateTimeFormatter.ofPattern(dateF.toPattern())
                 .withLocale(Locale.getDefault())
                 .withZone(ZoneId.systemDefault())
+    }
+
+    @Provides
+    @ProcessLifetime
+    fun provideLongLifetimeScope(): CoroutineScope {
+        return ProcessLifecycleOwner.get().lifecycle.coroutineScope
     }
 }

--- a/base/src/main/java/app/tivi/inject/Annotations.kt
+++ b/base/src/main/java/app/tivi/inject/Annotations.kt
@@ -57,3 +57,8 @@ annotation class PerApplication
 @Qualifier
 @MustBeDocumented
 annotation class ApplicationId
+
+@Retention(AnnotationRetention.RUNTIME)
+@Qualifier
+@MustBeDocumented
+annotation class ProcessLifetime

--- a/common-entrygrid/src/main/java/app/tivi/util/EntryViewModel.kt
+++ b/common-entrygrid/src/main/java/app/tivi/util/EntryViewModel.kt
@@ -25,6 +25,7 @@ import app.tivi.data.Entry
 import app.tivi.data.resultentities.EntryWithShow
 import app.tivi.interactors.PagingInteractor
 import app.tivi.tmdb.TmdbManager
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.combine
@@ -81,7 +82,7 @@ abstract class EntryViewModel<LI : EntryWithShow<out Entry>, PI : PagingInteract
         viewModelScope.launch {
             sendMessage(UiResource(Status.LOADING_MORE))
             try {
-                callLoadMore()
+                callLoadMore().join()
                 onSuccess()
             } catch (e: Exception) {
                 onError(e)
@@ -93,7 +94,7 @@ abstract class EntryViewModel<LI : EntryWithShow<out Entry>, PI : PagingInteract
         viewModelScope.launch {
             sendMessage(UiResource(Status.REFRESHING))
             try {
-                callRefresh()
+                callRefresh().join()
                 onSuccess()
             } catch (e: Exception) {
                 onError(e)
@@ -101,9 +102,9 @@ abstract class EntryViewModel<LI : EntryWithShow<out Entry>, PI : PagingInteract
         }
     }
 
-    protected open suspend fun callRefresh() = Unit
+    protected abstract suspend fun callRefresh(): Job
 
-    protected open suspend fun callLoadMore() = Unit
+    protected abstract suspend fun callLoadMore(): Job
 
     private fun onError(t: Throwable) {
         logger.e(t)

--- a/ui-discover/src/main/java/app/tivi/home/discover/DiscoverViewModel.kt
+++ b/ui-discover/src/main/java/app/tivi/home/discover/DiscoverViewModel.kt
@@ -17,20 +17,22 @@
 package app.tivi.home.discover
 
 import androidx.lifecycle.viewModelScope
+import app.tivi.TiviMvRxViewModel
+import app.tivi.inject.ProcessLifetime
 import app.tivi.interactors.ObservePopularShows
 import app.tivi.interactors.ObserveTrendingShows
 import app.tivi.interactors.UpdatePopularShows
 import app.tivi.interactors.UpdateTrendingShows
 import app.tivi.interactors.launchInteractor
-import app.tivi.tmdb.TmdbManager
-import app.tivi.TiviMvRxViewModel
 import app.tivi.interactors.launchObserve
+import app.tivi.tmdb.TmdbManager
 import app.tivi.util.ObservableLoadingCounter
 import com.airbnb.mvrx.FragmentViewModelContext
 import com.airbnb.mvrx.MvRxViewModelFactory
 import com.airbnb.mvrx.ViewModelContext
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
@@ -41,9 +43,9 @@ class DiscoverViewModel @AssistedInject constructor(
     observePopularShows: ObservePopularShows,
     private val updateTrendingShows: UpdateTrendingShows,
     observeTrendingShows: ObserveTrendingShows,
-    tmdbManager: TmdbManager
+    tmdbManager: TmdbManager,
+    @ProcessLifetime private val dataOperationScope: CoroutineScope
 ) : TiviMvRxViewModel<DiscoverViewState>(initialState) {
-
     private val trendingLoadingState = ObservableLoadingCounter()
     private val popularLoadingState = ObservableLoadingCounter()
 
@@ -84,12 +86,12 @@ class DiscoverViewModel @AssistedInject constructor(
     }
 
     fun refresh() {
-        viewModelScope.launchInteractor(
+        dataOperationScope.launchInteractor(
                 updatePopularShows,
                 UpdatePopularShows.Params(UpdatePopularShows.Page.REFRESH),
                 popularLoadingState
         )
-        viewModelScope.launchInteractor(
+        dataOperationScope.launchInteractor(
                 updateTrendingShows,
                 UpdateTrendingShows.Params(UpdateTrendingShows.Page.REFRESH),
                 trendingLoadingState

--- a/ui-popular/src/main/java/app/tivi/home/popular/PopularShowsViewModel.kt
+++ b/ui-popular/src/main/java/app/tivi/home/popular/PopularShowsViewModel.kt
@@ -18,15 +18,15 @@ package app.tivi.home.popular
 
 import androidx.lifecycle.viewModelScope
 import app.tivi.data.resultentities.PopularEntryWithShow
+import app.tivi.inject.ProcessLifetime
 import app.tivi.interactors.ObservePagedPopularShows
 import app.tivi.interactors.UpdatePopularShows
-import app.tivi.interactors.UpdatePopularShows.Page.NEXT_PAGE
-import app.tivi.interactors.UpdatePopularShows.Page.REFRESH
-import app.tivi.interactors.execute
+import app.tivi.interactors.launchInteractor
 import app.tivi.tmdb.TmdbManager
 import app.tivi.util.AppCoroutineDispatchers
 import app.tivi.util.EntryViewModel
 import app.tivi.util.Logger
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -35,7 +35,8 @@ class PopularShowsViewModel @Inject constructor(
     private val interactor: UpdatePopularShows,
     observePagedPopularShows: ObservePagedPopularShows,
     tmdbManager: TmdbManager,
-    logger: Logger
+    logger: Logger,
+    @ProcessLifetime private val dataOperationScope: CoroutineScope
 ) : EntryViewModel<PopularEntryWithShow, ObservePagedPopularShows>(
         dispatchers,
         observePagedPopularShows,
@@ -48,7 +49,13 @@ class PopularShowsViewModel @Inject constructor(
         }
     }
 
-    override suspend fun callLoadMore() = interactor.execute(UpdatePopularShows.Params(NEXT_PAGE))
+    override suspend fun callLoadMore() = dataOperationScope.launchInteractor(
+            interactor,
+            UpdatePopularShows.Params(UpdatePopularShows.Page.NEXT_PAGE)
+    )
 
-    override suspend fun callRefresh() = interactor.execute(UpdatePopularShows.Params(REFRESH))
+    override suspend fun callRefresh() = dataOperationScope.launchInteractor(
+            interactor,
+            UpdatePopularShows.Params(UpdatePopularShows.Page.REFRESH)
+    )
 }

--- a/ui-trending/src/main/java/app/tivi/home/trending/TrendingShowsViewModel.kt
+++ b/ui-trending/src/main/java/app/tivi/home/trending/TrendingShowsViewModel.kt
@@ -18,15 +18,17 @@ package app.tivi.home.trending
 
 import androidx.lifecycle.viewModelScope
 import app.tivi.data.resultentities.TrendingEntryWithShow
+import app.tivi.inject.ProcessLifetime
 import app.tivi.interactors.ObservePagedTrendingShows
 import app.tivi.interactors.UpdateTrendingShows
 import app.tivi.interactors.UpdateTrendingShows.Page.NEXT_PAGE
 import app.tivi.interactors.UpdateTrendingShows.Page.REFRESH
-import app.tivi.interactors.execute
+import app.tivi.interactors.launchInteractor
 import app.tivi.tmdb.TmdbManager
 import app.tivi.util.AppCoroutineDispatchers
 import app.tivi.util.EntryViewModel
 import app.tivi.util.Logger
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -35,7 +37,8 @@ class TrendingShowsViewModel @Inject constructor(
     private val interactor: UpdateTrendingShows,
     observePagedTrendingShows: ObservePagedTrendingShows,
     tmdbManager: TmdbManager,
-    logger: Logger
+    logger: Logger,
+    @ProcessLifetime private val dataOperationScope: CoroutineScope
 ) : EntryViewModel<TrendingEntryWithShow, ObservePagedTrendingShows>(
         dispatchers,
         observePagedTrendingShows,
@@ -49,7 +52,13 @@ class TrendingShowsViewModel @Inject constructor(
         }
     }
 
-    override suspend fun callLoadMore() = interactor.execute(UpdateTrendingShows.Params(NEXT_PAGE))
+    override suspend fun callLoadMore() = dataOperationScope.launchInteractor(
+            interactor,
+            UpdateTrendingShows.Params(NEXT_PAGE)
+    )
 
-    override suspend fun callRefresh() = interactor.execute(UpdateTrendingShows.Params(REFRESH))
+    override suspend fun callRefresh() = dataOperationScope.launchInteractor(
+            interactor,
+            UpdateTrendingShows.Params(REFRESH)
+    )
 }


### PR DESCRIPTION
We now inject a CoroutineScope which is based off the ProcessLifecycleOwner lifecycle, meaning that the operations will not be cancelled prematurely. Flow/observable subscriptions still happen within the `viewModelScope`.

Closes #360