### PR TITLE
Stop adding 1 hour onto episode watches

### DIFF
--- a/data/src/main/java/app/tivi/data/repositories/episodes/SeasonsEpisodesRepository.kt
+++ b/data/src/main/java/app/tivi/data/repositories/episodes/SeasonsEpisodesRepository.kt
@@ -169,7 +169,7 @@ class SeasonsEpisodesRepository @Inject constructor(
                 if (!episodeWatchStore.hasEpisodeBeenWatched(episode.id)) {
                     val timestamp = when (date) {
                         ActionDate.NOW -> OffsetDateTime.now()
-                        ActionDate.AIR_DATE -> episode.firstAired?.plusHours(1) ?: OffsetDateTime.now()
+                        ActionDate.AIR_DATE -> episode.firstAired ?: OffsetDateTime.now()
                     }
                     return@mapNotNull EpisodeWatchEntry(
                             episodeId = episode.id,


### PR DESCRIPTION
The watch time is the start of the watch, not
the end