### PR TITLE
Move PagedLists out of MvRx states

### DIFF
--- a/common-entrygrid/src/main/java/app/tivi/util/EntryGridEpoxyController.kt
+++ b/common-entrygrid/src/main/java/app/tivi/util/EntryGridEpoxyController.kt
@@ -30,7 +30,7 @@ import com.airbnb.epoxy.paging.PagedListEpoxyController
 
 abstract class EntryGridEpoxyController<LI : EntryWithShow<out Entry>> :
     PagedListEpoxyController<LI>() {
-    var state: EntryViewState<LI> by observable(EntryViewState(), ::requestModelBuild)
+    var state: EntryViewState by observable(EntryViewState(), ::requestModelBuild)
 
     @Suppress("UselessCallOnCollection")
     override fun addModels(models: List<EpoxyModel<*>>) {

--- a/common-entrygrid/src/main/java/app/tivi/util/EntryGridFragment.kt
+++ b/common-entrygrid/src/main/java/app/tivi/util/EntryGridFragment.kt
@@ -22,6 +22,7 @@ import android.view.ActionMode
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.view.updatePadding
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.recyclerview.widget.DefaultItemAnimator
@@ -40,6 +41,7 @@ import app.tivi.ui.SpacingItemDecorator
 import app.tivi.ui.transitions.GridToGridTransitioner
 import com.airbnb.mvrx.withState
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
 @SuppressLint("ValidFragment")
@@ -100,11 +102,14 @@ abstract class EntryGridFragment<LI, VM> : TiviFragmentWithBinding<FragmentEntry
         }
 
         binding.gridSwipeRefresh.setOnRefreshListener(viewModel::refresh)
+
+        lifecycleScope.launchWhenStarted {
+            viewModel.pagedList.collect { controller.submitList(it) }
+        }
     }
 
     override fun invalidate(binding: FragmentEntryGridBinding) = withState(viewModel) { state ->
         controller.state = state
-        controller.submitList(state.liveList)
 
         when (val status = state.status) {
             is UiError -> {

--- a/common-entrygrid/src/main/java/app/tivi/util/EntryViewState.kt
+++ b/common-entrygrid/src/main/java/app/tivi/util/EntryViewState.kt
@@ -16,14 +16,12 @@
 
 package app.tivi.util
 
-import androidx.paging.PagedList
 import app.tivi.api.UiIdle
 import app.tivi.api.UiStatus
 import com.airbnb.mvrx.MvRxState
 
-data class EntryViewState<LI>(
+data class EntryViewState(
     val status: UiStatus = UiIdle,
-    val liveList: PagedList<LI>? = null,
     val isLoaded: Boolean = false,
     val selectionOpen: Boolean = false,
     val selectedShowIds: Set<Long> = emptySet()

--- a/ui-followed/src/main/java/app/tivi/home/followed/FollowedViewModel.kt
+++ b/ui-followed/src/main/java/app/tivi/home/followed/FollowedViewModel.kt
@@ -40,6 +40,7 @@ import com.airbnb.mvrx.MvRxViewModelFactory
 import com.airbnb.mvrx.ViewModelContext
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -73,6 +74,9 @@ class FollowedViewModel @AssistedInject constructor(
     private val loadingState = ObservableLoadingCounter()
     private val showSelection = ShowStateSelector()
 
+    val pagedList: Flow<PagedList<FollowedShowEntryWithShow>>
+        get() = observePagedFollowedShows.observe()
+
     init {
         viewModelScope.launch {
             loadingState.observable
@@ -81,12 +85,6 @@ class FollowedViewModel @AssistedInject constructor(
                     .execute {
                         copy(isLoading = it() ?: false)
                     }
-        }
-
-        viewModelScope.launchObserve(observePagedFollowedShows) {
-            it.execute {
-                copy(followedShows = it())
-            }
         }
 
         viewModelScope.launch {

--- a/ui-followed/src/main/java/app/tivi/home/followed/FollowedViewState.kt
+++ b/ui-followed/src/main/java/app/tivi/home/followed/FollowedViewState.kt
@@ -16,10 +16,8 @@
 
 package app.tivi.home.followed
 
-import androidx.paging.PagedList
 import app.tivi.data.entities.SortOption
 import app.tivi.data.entities.TraktUser
-import app.tivi.data.resultentities.FollowedShowEntryWithShow
 import app.tivi.trakt.TraktAuthState
 import com.airbnb.mvrx.MvRxState
 
@@ -28,7 +26,6 @@ data class FollowedViewState(
     val authState: TraktAuthState = TraktAuthState.LOGGED_OUT,
     val isLoading: Boolean = false,
     val isEmpty: Boolean = false,
-    val followedShows: PagedList<FollowedShowEntryWithShow>? = null,
     val selectionOpen: Boolean = false,
     val selectedShowIds: Set<Long> = emptySet(),
     val filterActive: Boolean = false,

--- a/ui-popular/src/main/java/app/tivi/home/popular/PopularShowsViewModel.kt
+++ b/ui-popular/src/main/java/app/tivi/home/popular/PopularShowsViewModel.kt
@@ -33,7 +33,7 @@ import com.squareup.inject.assisted.AssistedInject
 import kotlinx.coroutines.flow.Flow
 
 class PopularShowsViewModel @AssistedInject constructor(
-    @Assisted initialState: EntryViewState<PopularEntryWithShow>,
+    @Assisted initialState: EntryViewState,
     override val dispatchers: AppCoroutineDispatchers,
     override val pagingInteractor: ObservePagedPopularShows,
     private val interactor: UpdatePopularShows,
@@ -58,13 +58,13 @@ class PopularShowsViewModel @AssistedInject constructor(
 
     @AssistedInject.Factory
     interface Factory {
-        fun create(initialState: EntryViewState<PopularEntryWithShow>): PopularShowsViewModel
+        fun create(initialState: EntryViewState): PopularShowsViewModel
     }
 
-    companion object : MvRxViewModelFactory<PopularShowsViewModel, EntryViewState<PopularEntryWithShow>> {
+    companion object : MvRxViewModelFactory<PopularShowsViewModel, EntryViewState> {
         override fun create(
             viewModelContext: ViewModelContext,
-            state: EntryViewState<PopularEntryWithShow>
+            state: EntryViewState
         ): PopularShowsViewModel? {
             val fragment: PopularShowsFragment = (viewModelContext as FragmentViewModelContext).fragment()
             return fragment.popularShowsViewModelFactory.create(state)

--- a/ui-recommended/src/main/java/app/tivi/home/recommended/RecommendedShowsViewModel.kt
+++ b/ui-recommended/src/main/java/app/tivi/home/recommended/RecommendedShowsViewModel.kt
@@ -33,7 +33,7 @@ import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 
 class RecommendedShowsViewModel @AssistedInject constructor(
-    @Assisted initialState: EntryViewState<RecommendedEntryWithShow>,
+    @Assisted initialState: EntryViewState,
     override val dispatchers: AppCoroutineDispatchers,
     override val pagingInteractor: ObservePagedRecommendedShows,
     private val interactor: UpdateRecommendedShows,
@@ -54,11 +54,11 @@ class RecommendedShowsViewModel @AssistedInject constructor(
 
     @AssistedInject.Factory
     interface Factory {
-        fun create(initialState: EntryViewState<RecommendedEntryWithShow>): RecommendedShowsViewModel
+        fun create(initialState: EntryViewState): RecommendedShowsViewModel
     }
 
-    companion object : MvRxViewModelFactory<RecommendedShowsViewModel, EntryViewState<RecommendedEntryWithShow>> {
-        override fun create(viewModelContext: ViewModelContext, state: EntryViewState<RecommendedEntryWithShow>): RecommendedShowsViewModel? {
+    companion object : MvRxViewModelFactory<RecommendedShowsViewModel, EntryViewState> {
+        override fun create(viewModelContext: ViewModelContext, state: EntryViewState): RecommendedShowsViewModel? {
             val fragment: RecommendedShowsFragment = (viewModelContext as FragmentViewModelContext).fragment()
             return fragment.recommendedShowsViewModelFactory.create(state)
         }

--- a/ui-trending/src/main/java/app/tivi/home/trending/TrendingShowsViewModel.kt
+++ b/ui-trending/src/main/java/app/tivi/home/trending/TrendingShowsViewModel.kt
@@ -33,7 +33,7 @@ import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 
 class TrendingShowsViewModel @AssistedInject constructor(
-    @Assisted initialState: EntryViewState<TrendingEntryWithShow>,
+    @Assisted initialState: EntryViewState,
     override val dispatchers: AppCoroutineDispatchers,
     override val pagingInteractor: ObservePagedTrendingShows,
     private val interactor: UpdateTrendingShows,
@@ -54,13 +54,13 @@ class TrendingShowsViewModel @AssistedInject constructor(
 
     @AssistedInject.Factory
     interface Factory {
-        fun create(initialState: EntryViewState<TrendingEntryWithShow>): TrendingShowsViewModel
+        fun create(initialState: EntryViewState): TrendingShowsViewModel
     }
 
-    companion object : MvRxViewModelFactory<TrendingShowsViewModel, EntryViewState<TrendingEntryWithShow>> {
+    companion object : MvRxViewModelFactory<TrendingShowsViewModel, EntryViewState> {
         override fun create(
             viewModelContext: ViewModelContext,
-            state: EntryViewState<TrendingEntryWithShow>
+            state: EntryViewState
         ): TrendingShowsViewModel? {
             val fragment: TrendingShowsFragment = (viewModelContext as FragmentViewModelContext).fragment()
             return fragment.trendingShowsViewModelFactory.create(state)

--- a/ui-watched/src/main/java/app/tivi/home/watched/WatchedFragment.kt
+++ b/ui-watched/src/main/java/app/tivi/home/watched/WatchedFragment.kt
@@ -24,6 +24,7 @@ import android.view.MenuItem
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.core.view.updatePadding
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import app.tivi.TiviFragmentWithBinding
 import app.tivi.common.imageloading.loadImageUrl
@@ -42,6 +43,7 @@ import app.tivi.ui.createSharedElementHelperForItem
 import app.tivi.ui.recyclerview.HideImeOnScrollListener
 import com.airbnb.mvrx.fragmentViewModel
 import com.airbnb.mvrx.withState
+import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
 class WatchedFragment : TiviFragmentWithBinding<FragmentWatchedBinding>() {
@@ -124,6 +126,12 @@ class WatchedFragment : TiviFragmentWithBinding<FragmentWatchedBinding>() {
         }
 
         binding.watchedSwipeRefresh.setOnRefreshListener(viewModel::refresh)
+
+        lifecycleScope.launchWhenStarted {
+            viewModel.pagedList.collect {
+                controller.submitList(it)
+            }
+        }
     }
 
     override fun invalidate(binding: FragmentWatchedBinding) = withState(viewModel) { state ->
@@ -138,20 +146,12 @@ class WatchedFragment : TiviFragmentWithBinding<FragmentWatchedBinding>() {
             currentActionMode?.finish()
         }
 
-        if (currentActionMode != null) {
-            currentActionMode?.title = getString(R.string.selection_title,
-                    state.selectedShowIds.size)
-        }
-
-        binding.state = state
+        currentActionMode?.title = getString(R.string.selection_title, state.selectedShowIds.size)
 
         authStateMenuItemBinder?.bind(state.authState, state.user)
 
-        if (state.watchedShows != null) {
-            // PagingEpoxyController does not like being updated before it has a list
-            controller.state = state
-            controller.submitList(state.watchedShows)
-        }
+        binding.state = state
+        controller.state = state
     }
 
     override fun onDestroyView() {

--- a/ui-watched/src/main/java/app/tivi/home/watched/WatchedViewModel.kt
+++ b/ui-watched/src/main/java/app/tivi/home/watched/WatchedViewModel.kt
@@ -39,6 +39,7 @@ import com.airbnb.mvrx.MvRxViewModelFactory
 import com.airbnb.mvrx.ViewModelContext
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -72,6 +73,9 @@ class WatchedViewModel @AssistedInject constructor(
     private val loadingState = ObservableLoadingCounter()
     private val showSelection = ShowStateSelector()
 
+    val pagedList: Flow<PagedList<WatchedShowEntryWithShow>>
+        get() = observePagedWatchedShows.observe()
+
     init {
         viewModelScope.launch {
             loadingState.observable
@@ -90,10 +94,6 @@ class WatchedViewModel @AssistedInject constructor(
             showSelection.observeIsSelectionOpen().collect {
                 setState { copy(selectionOpen = it) }
             }
-        }
-
-        viewModelScope.launchObserve(observePagedWatchedShows) {
-            it.execute { copy(watchedShows = it()) }
         }
 
         viewModelScope.launchObserve(observeTraktAuthState) { flow ->

--- a/ui-watched/src/main/java/app/tivi/home/watched/WatchedViewState.kt
+++ b/ui-watched/src/main/java/app/tivi/home/watched/WatchedViewState.kt
@@ -16,10 +16,8 @@
 
 package app.tivi.home.watched
 
-import androidx.paging.PagedList
 import app.tivi.data.entities.SortOption
 import app.tivi.data.entities.TraktUser
-import app.tivi.data.resultentities.WatchedShowEntryWithShow
 import app.tivi.trakt.TraktAuthState
 import com.airbnb.mvrx.MvRxState
 
@@ -28,7 +26,6 @@ data class WatchedViewState(
     val authState: TraktAuthState = TraktAuthState.LOGGED_OUT,
     val isLoading: Boolean = false,
     val isEmpty: Boolean = false,
-    val watchedShows: PagedList<WatchedShowEntryWithShow>? = null,
     val selectionOpen: Boolean = false,
     val selectedShowIds: Set<Long> = emptySet(),
     val filterActive: Boolean = false,


### PR DESCRIPTION
MvRxStates are designed to be completely immutable, which conflicts with PagedLists which are very mutable.

This commit moves the paged lists out of the MvRxStates, and to their own Flow, which each Fragment collects separately.

Closes #517