### PR TITLE
Only run assembleRelease on feature branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,7 @@ jobs:
         run: ./gradlew app:lintDebug dependencyUpdates --scan
 
       - name: Build release
+        if: github.ref != 'refs/heads/master'
         run: ./gradlew bundleRelease assembleRelease -Ptivi.versioncode=$BUILD_NUMBER --scan
 
       - name: Publish to Play Store


### PR DESCRIPTION
On master we call `publishRelease`, which will automatically build the release variant. If we do both `assembleRelease` and `publishRelease` on master, we're running R8 twice, which is wasteful.