### PR TITLE
Increase java heap size to 2 GB

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,7 @@
 org.gradle.configureondemand=true
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx2g
 
 # AndroidX
 android.useAndroidX=true


### PR DESCRIPTION
Avoid "GC overhead limit exceeded" error while building. If this is not specified it should default to 1 GB, I wasn't able to run tivi without this.