### PR TITLE
Update show details to use `Action`

### DIFF
--- a/app/src/main/res/navigation/show_details_nav_graph.xml
+++ b/app/src/main/res/navigation/show_details_nav_graph.xml
@@ -41,8 +41,15 @@
             android:name="show_id"
             app:argType="long" />
 
+        <argument
+            android:name="episode_id"
+            app:argType="long" />
+
         <deepLink
             app:uri="app.tivi://show/{show_id}" />
+
+        <deepLink
+            app:uri="app.tivi://show/{show_id}/episode/{episode_id}" />
 
     </activity>
 

--- a/common-epoxy/src/main/java/app/tivi/common/epoxy/EpoxyExtensions.kt
+++ b/common-epoxy/src/main/java/app/tivi/common/epoxy/EpoxyExtensions.kt
@@ -19,6 +19,7 @@ package app.tivi.common.epoxy
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.epoxy.EpoxyController
+import com.airbnb.epoxy.EpoxyControllerAdapter
 import com.airbnb.epoxy.EpoxyModel
 
 /** Add models to a CarouselModel_ by transforming a list of items into EpoxyModels.
@@ -42,4 +43,9 @@ fun RecyclerView.syncSpanSizes(controller: EpoxyController) {
             layout.spanSizeLookup = controller.spanSizeLookup
         }
     }
+}
+
+fun EpoxyControllerAdapter.findPositionOfItemId(itemId: Long): Int {
+    return (0 until itemCount).firstOrNull { getItemId(it) == itemId }
+            ?: RecyclerView.NO_POSITION
 }

--- a/common-ui/src/main/java/app/tivi/extensions/AnimatorExtensions.kt
+++ b/common-ui/src/main/java/app/tivi/extensions/AnimatorExtensions.kt
@@ -17,7 +17,9 @@
 package app.tivi.extensions
 
 import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
 import android.animation.AnimatorSet
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 fun animatorSetOf(vararg animators: Animator, playTogether: Boolean = true) = AnimatorSet().apply {
     if (playTogether) {
@@ -33,4 +35,18 @@ fun animatorSetOf(animators: List<Animator>, playTogether: Boolean = true) = Ani
     } else {
         playSequentially(animators)
     }
+}
+
+suspend fun Animator.awaitEnd() = suspendCancellableCoroutine<Unit> { cont ->
+    addListener(object : AnimatorListenerAdapter() {
+        override fun onAnimationEnd(animation: Animator) {
+            cont.resume(Unit) {
+                end()
+            }
+        }
+
+        override fun onAnimationCancel(animation: Animator) {
+            cont.cancel()
+        }
+    })
 }

--- a/common-ui/src/main/java/app/tivi/extensions/RecyclerViewExtensions.kt
+++ b/common-ui/src/main/java/app/tivi/extensions/RecyclerViewExtensions.kt
@@ -17,10 +17,38 @@
 package app.tivi.extensions
 
 import android.view.ViewGroup
+import androidx.recyclerview.widget.LinearSmoothScroller
 import androidx.recyclerview.widget.RecyclerView
+import app.tivi.ui.recyclerview.TiviLinearSmoothScroller
 
 fun <VH : RecyclerView.ViewHolder> RecyclerView.Adapter<VH>.createAndBind(parent: ViewGroup, position: Int): VH {
     val vh = onCreateViewHolder(parent, getItemViewType(position))
     onBindViewHolder(vh, position)
     return vh
+}
+
+fun RecyclerView.scrollToItemId(itemId: Long, animatedScroll: Boolean = false): Boolean {
+    val vh = findViewHolderForItemId(itemId)
+    if (vh != null) {
+        if (animatedScroll) {
+            smoothScrollToViewHolder(vh)
+        } else {
+            scrollToPosition(vh.adapterPosition)
+        }
+        return true
+    }
+    return false
+}
+
+fun RecyclerView.smoothScrollToViewHolder(
+    viewHolder: RecyclerView.ViewHolder
+) {
+    val scroller = TiviLinearSmoothScroller(
+            context,
+            snapPreference = LinearSmoothScroller.SNAP_TO_START,
+            scrollMsPerInch = 60f
+    )
+    scroller.targetPosition = viewHolder.adapterPosition
+    scroller.targetOffset = viewHolder.itemView.height / 3
+    layoutManager?.startSmoothScroll(scroller)
 }

--- a/common-ui/src/main/java/app/tivi/extensions/RecyclerViewExtensions.kt
+++ b/common-ui/src/main/java/app/tivi/extensions/RecyclerViewExtensions.kt
@@ -80,6 +80,10 @@ suspend fun RecyclerView.awaitScrollEnd() {
         addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
                 if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+                    // Make sure we remove the listener so we don't keep leak the
+                    // coroutine continuation
+                    recyclerView.removeOnScrollListener(this)
+                    // Finally, resume the coroutine
                     cont.resume(Unit)
                 }
             }

--- a/common-ui/src/main/java/app/tivi/extensions/RecyclerViewExtensions.kt
+++ b/common-ui/src/main/java/app/tivi/extensions/RecyclerViewExtensions.kt
@@ -20,6 +20,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearSmoothScroller
 import androidx.recyclerview.widget.RecyclerView
 import app.tivi.ui.recyclerview.TiviLinearSmoothScroller
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -70,7 +71,12 @@ suspend fun RecyclerView.awaitScrollEnd() {
     // Now we can check if we're actually idle. If so, return now
     if (scrollState == RecyclerView.SCROLL_STATE_IDLE) return
 
-    suspendCoroutine<Unit> { cont ->
+    suspendCancellableCoroutine<Unit> { cont ->
+        cont.invokeOnCancellation {
+            // If the coroutine is cancelled, stop the RecyclerView scrolling
+            stopScroll()
+        }
+
         addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
                 if (newState == RecyclerView.SCROLL_STATE_IDLE) {

--- a/common-ui/src/main/java/app/tivi/extensions/RecyclerViewExtensions.kt
+++ b/common-ui/src/main/java/app/tivi/extensions/RecyclerViewExtensions.kt
@@ -40,15 +40,23 @@ fun RecyclerView.scrollToItemId(itemId: Long, animatedScroll: Boolean = false): 
     return false
 }
 
-fun RecyclerView.smoothScrollToViewHolder(
-    viewHolder: RecyclerView.ViewHolder
-) {
-    val scroller = TiviLinearSmoothScroller(
-            context,
-            snapPreference = LinearSmoothScroller.SNAP_TO_START,
-            scrollMsPerInch = 60f
-    )
-    scroller.targetPosition = viewHolder.adapterPosition
-    scroller.targetOffset = viewHolder.itemView.height / 3
-    layoutManager?.startSmoothScroll(scroller)
+fun RecyclerView.smoothScrollToViewHolder(vh: RecyclerView.ViewHolder) = TiviLinearSmoothScroller(
+        context,
+        snapPreference = LinearSmoothScroller.SNAP_TO_START,
+        scrollMsPerInch = 60f
+).apply {
+    targetPosition = vh.adapterPosition
+    targetOffset = vh.itemView.height / 3
+}.also {
+    layoutManager!!.startSmoothScroll(it)
+}
+
+fun RecyclerView.smoothScrollToItemPosition(position: Int) = TiviLinearSmoothScroller(
+        context,
+        snapPreference = LinearSmoothScroller.SNAP_TO_START,
+        scrollMsPerInch = 60f
+).apply {
+    targetPosition = position
+}.also {
+    layoutManager!!.startSmoothScroll(it)
 }

--- a/common-ui/src/main/java/app/tivi/extensions/ViewExtensions.kt
+++ b/common-ui/src/main/java/app/tivi/extensions/ViewExtensions.kt
@@ -19,8 +19,12 @@ package app.tivi.extensions
 import android.graphics.Rect
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.doOnNextLayout
+import androidx.core.view.doOnPreDraw
 import androidx.transition.AutoTransition
 import androidx.transition.TransitionManager
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 fun ViewGroup.beginDelayedTransition(duration: Long = 200) {
     TransitionManager.beginDelayedTransition(this, AutoTransition().apply { setDuration(duration) })
@@ -105,4 +109,16 @@ inline fun View.doOnSizeChange(crossinline action: (view: View) -> Boolean) {
             }
         }
     })
+}
+
+suspend fun View.awaitNextLayout() = suspendCoroutine<Unit> { cont ->
+    doOnNextLayout { cont.resume(Unit) }
+}
+
+suspend fun View.awaitPreDraw() = suspendCoroutine<Unit> { cont ->
+    doOnPreDraw { cont.resume(Unit) }
+}
+
+suspend fun View.awaitAnimationFrame() = suspendCoroutine<Unit> { cont ->
+    postOnAnimation { cont.resume(Unit) }
 }

--- a/common-ui/src/main/java/app/tivi/extensions/ViewExtensions.kt
+++ b/common-ui/src/main/java/app/tivi/extensions/ViewExtensions.kt
@@ -60,8 +60,9 @@ fun View.doOnAttach(f: (View) -> Unit) {
  * Allows easy listening to layout passing. Return [true] if you need the listener to keep being
  * attached.
  */
-inline fun View.doOnLayouts(crossinline action: (view: View) -> Boolean) {
+inline fun <V : View> V.doOnLayouts(crossinline action: (view: V) -> Boolean) {
     addOnLayoutChangeListener(object : View.OnLayoutChangeListener {
+        @Suppress("UNCHECKED_CAST")
         override fun onLayoutChange(
             view: View,
             left: Int,
@@ -73,7 +74,7 @@ inline fun View.doOnLayouts(crossinline action: (view: View) -> Boolean) {
             oldRight: Int,
             oldBottom: Int
         ) {
-            if (!action(view)) {
+            if (!action(view as V)) {
                 view.removeOnLayoutChangeListener(this)
             }
         }

--- a/common-ui/src/main/java/app/tivi/extensions/ViewExtensions.kt
+++ b/common-ui/src/main/java/app/tivi/extensions/ViewExtensions.kt
@@ -19,6 +19,7 @@ package app.tivi.extensions
 import android.graphics.Rect
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.doOnLayout
 import androidx.core.view.doOnNextLayout
 import androidx.core.view.doOnPreDraw
 import androidx.transition.AutoTransition
@@ -113,6 +114,11 @@ inline fun View.doOnSizeChange(crossinline action: (view: View) -> Boolean) {
 
 suspend fun View.awaitNextLayout() = suspendCoroutine<Unit> { cont ->
     doOnNextLayout { cont.resume(Unit) }
+}
+
+suspend fun View.awaitLayout() {
+    if (isLaidOut) return
+    suspendCoroutine<Unit> { cont -> doOnLayout { cont.resume(Unit) } }
 }
 
 suspend fun View.awaitPreDraw() = suspendCoroutine<Unit> { cont ->

--- a/common-ui/src/main/java/app/tivi/ui/widget/TiviMotionLayout.kt
+++ b/common-ui/src/main/java/app/tivi/ui/widget/TiviMotionLayout.kt
@@ -21,12 +21,56 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
 import androidx.constraintlayout.motion.widget.MotionLayout
+import java.util.concurrent.CopyOnWriteArrayList
 
 class TiviMotionLayout @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : MotionLayout(context, attrs, defStyleAttr) {
+
+    private val listeners = CopyOnWriteArrayList<TransitionListener>()
+
+    fun addTransitionListener(listener: TransitionListener) {
+        listeners.addIfAbsent(listener)
+    }
+
+    fun removeTransitionListener(listener: TransitionListener) {
+        listeners.remove(listener)
+    }
+
+    init {
+        super.setTransitionListener(object : TransitionListener {
+            override fun onTransitionTrigger(motionLayout: MotionLayout, triggerId: Int, positive: Boolean, progress: Float) {
+                listeners.forEach {
+                    it.onTransitionTrigger(motionLayout, triggerId, positive, progress)
+                }
+            }
+
+            override fun onTransitionStarted(motionLayout: MotionLayout, startId: Int, endId: Int) {
+                listeners.forEach {
+                    it.onTransitionStarted(motionLayout, startId, endId)
+                }
+            }
+
+            override fun onTransitionChange(motionLayout: MotionLayout, startId: Int, endId: Int, progress: Float) {
+                listeners.forEach {
+                    it.onTransitionChange(motionLayout, startId, endId, progress)
+                }
+            }
+
+            override fun onTransitionCompleted(motionLayout: MotionLayout, currentId: Int) {
+                listeners.forEach {
+                    it.onTransitionCompleted(motionLayout, currentId)
+                }
+            }
+        })
+    }
+
+    @Deprecated("Use addTransitionListener instead")
+    override fun setTransitionListener(listener: TransitionListener) {
+        throw IllegalArgumentException("Use addTransitionListener instead")
+    }
 
     /**
      * Whether this MotionLayout should react to nested scrolls and touch events

--- a/common-ui/src/main/res/drawable/ic_add_24dp.xml
+++ b/common-ui/src/main/res/drawable/ic_add_24dp.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright 2019 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0"
+        android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/common-ui/src/main/res/values/ids.xml
+++ b/common-ui/src/main/res/values/ids.xml
@@ -30,4 +30,6 @@
 
     <id name="activity_show_details" />
 
+    <id name="motion_layout_listeners" />
+
 </resources>

--- a/data/src/main/java/app/tivi/data/repositories/episodes/SeasonsEpisodesRepository.kt
+++ b/data/src/main/java/app/tivi/data/repositories/episodes/SeasonsEpisodesRepository.kt
@@ -52,6 +52,8 @@ class SeasonsEpisodesRepository @Inject constructor(
 
     fun observeEpisode(episodeId: Long) = seasonsEpisodesStore.observeEpisode(episodeId)
 
+    suspend fun getEpisode(episodeId: Long): Episode? = seasonsEpisodesStore.getEpisode(episodeId)
+
     fun observeEpisodeWatches(episodeId: Long) = episodeWatchStore.observeEpisodeWatches(episodeId)
 
     fun observeNextEpisodeToWatch(showId: Long) = seasonsEpisodesStore.observeShowNextEpisodeToWatch(showId)

--- a/domain/src/main/java/app/tivi/domain/Interactor.kt
+++ b/domain/src/main/java/app/tivi/domain/Interactor.kt
@@ -69,6 +69,16 @@ abstract class Interactor<in P> {
     }
 }
 
+abstract class ResultInteractor<in P, R> {
+    abstract val dispatcher: CoroutineDispatcher
+
+    suspend operator fun invoke(params: P): R {
+        return withContext(dispatcher) { doWork(params) }
+    }
+
+    protected abstract suspend fun doWork(params: P): R
+}
+
 interface ObservableInteractor<T> {
     val dispatcher: CoroutineDispatcher
     fun observe(): Flow<T>

--- a/domain/src/main/java/app/tivi/domain/interactors/GetEpisodeDetails.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/GetEpisodeDetails.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.tivi.domain.interactors
+
+import app.tivi.data.entities.Episode
+import app.tivi.data.repositories.episodes.SeasonsEpisodesRepository
+import app.tivi.domain.ResultInteractor
+import app.tivi.util.AppCoroutineDispatchers
+import kotlinx.coroutines.CoroutineDispatcher
+import javax.inject.Inject
+
+class GetEpisodeDetails @Inject constructor(
+    private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
+    private val dispatchers: AppCoroutineDispatchers
+) : ResultInteractor<GetEpisodeDetails.Params, Episode?>() {
+    override val dispatcher: CoroutineDispatcher
+        get() = dispatchers.io
+
+    override suspend fun doWork(params: Params): Episode? {
+        return seasonsEpisodesRepository.getEpisode(params.episodeId)
+    }
+
+    data class Params(val episodeId: Long)
+}

--- a/ui-discover/src/main/java/app/tivi/home/discover/DiscoverFragment.kt
+++ b/ui-discover/src/main/java/app/tivi/home/discover/DiscoverFragment.kt
@@ -148,9 +148,10 @@ class DiscoverFragment : TiviFragmentWithBinding<FragmentDiscoverBinding>() {
             override fun onNextEpisodeToWatchClicked() {
                 withState(viewModel) {
                     checkNotNull(it.nextEpisodeWithShowToWatched)
-
+                    val show = it.nextEpisodeWithShowToWatched.show
+                    val episode = it.nextEpisodeWithShowToWatched.episode
                     findNavController().navigate(
-                            "app.tivi://show/${it.nextEpisodeWithShowToWatched.show.id}".toUri()
+                            "app.tivi://show/${show.id}/episode/${episode.id}".toUri()
                     )
                 }
             }

--- a/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsActions.kt
+++ b/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsActions.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.tivi.episodedetails
+
+sealed class EpisodeDetailsAction
+object RefreshAction : EpisodeDetailsAction()
+object AddEpisodeWatchAction : EpisodeDetailsAction()
+data class RemoveEpisodeWatchAction(val watchId: Long) : EpisodeDetailsAction()
+object RemoveAllEpisodeWatchesAction : EpisodeDetailsAction()

--- a/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsFragment.kt
+++ b/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsFragment.kt
@@ -63,8 +63,8 @@ class EpisodeDetailsFragment : TiviFragmentWithBinding<FragmentEpisodeDetailsBin
         binding.epDetailsFab.setOnClickListener {
             withState(viewModel) { state ->
                 when (state.action) {
-                    EpisodeDetailsViewState.Action.WATCH -> viewModel.markWatched()
-                    EpisodeDetailsViewState.Action.UNWATCH -> viewModel.markUnwatched()
+                    EpisodeDetailsViewState.Action.WATCH -> viewModel.submitAction(AddEpisodeWatchAction)
+                    EpisodeDetailsViewState.Action.UNWATCH -> viewModel.submitAction(RemoveAllEpisodeWatchesAction)
                 }
             }
         }
@@ -81,7 +81,7 @@ class EpisodeDetailsFragment : TiviFragmentWithBinding<FragmentEpisodeDetailsBin
                 itemView: View,
                 position: Int,
                 direction: Int
-            ) = viewModel.removeWatchEntry(model.watch())
+            ) = viewModel.submitAction(RemoveEpisodeWatchAction(model.watch().id))
 
             override fun isSwipeEnabledForModel(model: EpisodeDetailsWatchItemBindingModel_): Boolean {
                 return model.watch() != null

--- a/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsViewModel.kt
+++ b/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsViewModel.kt
@@ -68,13 +68,11 @@ class EpisodeDetailsViewModel @AssistedInject constructor(
         }
 
         viewModelScope.launch {
-            for (action in pendingActions) {
-                when (action) {
-                    RefreshAction -> refresh()
-                    AddEpisodeWatchAction -> markWatched()
-                    RemoveAllEpisodeWatchesAction -> markUnwatched()
-                    is RemoveEpisodeWatchAction -> removeWatchEntry(action)
-                }
+            for (action in pendingActions) when (action) {
+                RefreshAction -> refresh()
+                AddEpisodeWatchAction -> markWatched()
+                RemoveAllEpisodeWatchesAction -> markUnwatched()
+                is RemoveEpisodeWatchAction -> removeWatchEntry(action)
             }
         }
 

--- a/ui-episodedetails/src/main/res/layout/fragment_episode_details.xml
+++ b/ui-episodedetails/src/main/res/layout/fragment_episode_details.xml
@@ -100,7 +100,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/spacing_normal"
-            android:src="@{state.action == Action.WATCH ? @drawable/ic_eye_24dp : @drawable/ic_eye_off_24dp}"
+            android:src="@{state.action == Action.WATCH ? @drawable/ic_add_24dp : @drawable/ic_eye_off_24dp}"
             app:layout_constraintBottom_toTopOf="@id/ep_details_rv"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/ep_details_rv"

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragment.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragment.kt
@@ -200,28 +200,26 @@ class ShowDetailsFragment : TiviFragmentWithBinding<FragmentShowDetailsBinding>(
         requireActivity().onBackPressedDispatcher.addCallback(this, backPressedCallback)
     }
 
-    override fun invalidate(binding: FragmentShowDetailsBinding) {
-        withState(viewModel) { state ->
-            if (binding.state == null) {
-                // First time we've had state, start any postponed transitions
-                scheduleStartPostponedTransitions()
-            }
-            binding.state = state
-            controller.state = state
+    override fun invalidate(binding: FragmentShowDetailsBinding) = withState(viewModel) { state ->
+        if (binding.state == null) {
+            // First time we've had state, start any postponed transitions
+            scheduleStartPostponedTransitions()
+        }
+        binding.state = state
+        controller.state = state
 
-            if (state.focusedSeasonId != null) {
-                binding.detailsRv.scrollToItemId(generateSeasonItemId(state.focusedSeasonId))
-            }
+        if (state.focusedSeasonId != null) {
+            binding.detailsRv.scrollToItemId(generateSeasonItemId(state.focusedSeasonId))
+        }
 
-            if (state.expandedEpisodeId != null) {
-                childFragmentManager.commitNow {
-                    setTransition(FragmentTransaction.TRANSIT_NONE)
-                    replace(R.id.details_expanded_pane,
-                            EpisodeDetailsFragment.create(state.expandedEpisodeId))
-                }
-                binding.detailsExpandedPane.doOnNextLayout {
-                    binding.detailsRv.expandItem(generateEpisodeItemId(state.expandedEpisodeId))
-                }
+        if (state.expandedEpisodeId != null) {
+            childFragmentManager.commitNow {
+                setTransition(FragmentTransaction.TRANSIT_NONE)
+                replace(R.id.details_expanded_pane,
+                        EpisodeDetailsFragment.create(state.expandedEpisodeId))
+            }
+            binding.detailsExpandedPane.doOnNextLayout {
+                binding.detailsRv.expandItem(generateEpisodeItemId(state.expandedEpisodeId))
             }
         }
     }

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragment.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragment.kt
@@ -29,15 +29,14 @@ import androidx.fragment.app.commit
 import androidx.fragment.app.commitNow
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import androidx.recyclerview.widget.RecyclerView
 import app.tivi.TiviFragmentWithBinding
-import app.tivi.common.epoxy.findPositionOfItemId
 import app.tivi.common.epoxy.syncSpanSizes
 import app.tivi.data.entities.ActionDate
 import app.tivi.data.entities.Episode
 import app.tivi.data.entities.Season
 import app.tivi.data.entities.TiviShow
 import app.tivi.episodedetails.EpisodeDetailsFragment
+import app.tivi.extensions.awaitItemIdPosition
 import app.tivi.extensions.awaitScrollEnd
 import app.tivi.extensions.awaitTransitionComplete
 import app.tivi.extensions.doOnLayouts
@@ -54,7 +53,6 @@ import com.airbnb.mvrx.fragmentViewModel
 import com.airbnb.mvrx.withState
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import kotlinx.android.parcel.Parcelize
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import me.saket.inboxrecyclerview.dimming.TintPainter
 import me.saket.inboxrecyclerview.page.PageStateChangeCallbacks
@@ -152,21 +150,14 @@ class ShowDetailsFragment : TiviFragmentWithBinding<FragmentShowDetailsBinding>(
                 val seasonItemId = generateSeasonItemId(expandedEpisode.seasonId)
                 val episodeItemId = generateEpisodeItemId(expandedEpisode.episodeId)
 
-                lifecycleScope.launch {
+                viewLifecycleOwner.lifecycleScope.launch {
                     binding.detailsMotion.transitionToState(R.id.show_details_closed)
                     binding.detailsMotion.awaitTransitionComplete(R.id.show_details_closed)
 
-                    var seasonPosition = RecyclerView.NO_POSITION
-                    var episodePosition = RecyclerView.NO_POSITION
+                    val seasonItemPosition = controller.adapter.awaitItemIdPosition(seasonItemId)
+                    controller.adapter.awaitItemIdPosition(episodeItemId)
 
-                    while (seasonPosition < 0 || episodePosition < 0) {
-                        delay(16)
-
-                        seasonPosition = controller.adapter.findPositionOfItemId(seasonItemId)
-                        episodePosition = controller.adapter.findPositionOfItemId(episodeItemId)
-                    }
-
-                    binding.detailsRv.smoothScrollToItemPosition(seasonPosition)
+                    binding.detailsRv.smoothScrollToItemPosition(seasonItemPosition)
                     binding.detailsRv.awaitScrollEnd()
 
                     binding.detailsRv.expandItem(episodeItemId)

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragment.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragment.kt
@@ -38,6 +38,8 @@ import app.tivi.data.entities.Episode
 import app.tivi.data.entities.Season
 import app.tivi.data.entities.TiviShow
 import app.tivi.episodedetails.EpisodeDetailsFragment
+import app.tivi.extensions.awaitScrollEnd
+import app.tivi.extensions.awaitTransitionComplete
 import app.tivi.extensions.doOnLayouts
 import app.tivi.extensions.resolveThemeColor
 import app.tivi.extensions.scheduleStartPostponedTransitions
@@ -147,12 +149,13 @@ class ShowDetailsFragment : TiviFragmentWithBinding<FragmentShowDetailsBinding>(
                             EpisodeDetailsFragment.create(expandedEpisode.episodeId))
                 }
 
-                binding.detailsMotion.transitionToState(R.id.show_details_closed)
-
                 val seasonItemId = generateSeasonItemId(expandedEpisode.seasonId)
                 val episodeItemId = generateEpisodeItemId(expandedEpisode.episodeId)
 
                 lifecycleScope.launch {
+                    binding.detailsMotion.transitionToState(R.id.show_details_closed)
+                    binding.detailsMotion.awaitTransitionComplete(R.id.show_details_closed)
+
                     var seasonPosition = RecyclerView.NO_POSITION
                     var episodePosition = RecyclerView.NO_POSITION
 
@@ -163,10 +166,8 @@ class ShowDetailsFragment : TiviFragmentWithBinding<FragmentShowDetailsBinding>(
                         episodePosition = controller.adapter.findPositionOfItemId(episodeItemId)
                     }
 
-                    val scroller = binding.detailsRv.smoothScrollToItemPosition(seasonPosition)
-                    while (scroller.isRunning) {
-                        delay(16)
-                    }
+                    binding.detailsRv.smoothScrollToItemPosition(seasonPosition)
+                    binding.detailsRv.awaitScrollEnd()
 
                     binding.detailsRv.expandItem(episodeItemId)
                 }

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragment.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragment.kt
@@ -36,7 +36,7 @@ import app.tivi.data.entities.Episode
 import app.tivi.data.entities.Season
 import app.tivi.data.entities.TiviShow
 import app.tivi.episodedetails.EpisodeDetailsFragment
-import app.tivi.extensions.awaitItemIdPosition
+import app.tivi.extensions.awaitItemIdExists
 import app.tivi.extensions.awaitScrollEnd
 import app.tivi.extensions.awaitTransitionComplete
 import app.tivi.extensions.doOnLayouts
@@ -155,7 +155,7 @@ class ShowDetailsFragment : TiviFragmentWithBinding<FragmentShowDetailsBinding>(
                     binding.detailsMotion.transitionToState(R.id.show_details_closed)
                     binding.detailsMotion.awaitTransitionComplete(R.id.show_details_closed)
 
-                    controller.adapter.awaitItemIdPosition(episodeItemId)
+                    controller.adapter.awaitItemIdExists(episodeItemId)
                     val seasonItemPosition = controller.adapter.findItemIdPosition(seasonItemId)
 
                     binding.detailsRv.smoothScrollToItemPosition(seasonItemPosition)

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragment.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragment.kt
@@ -40,6 +40,7 @@ import app.tivi.extensions.awaitItemIdPosition
 import app.tivi.extensions.awaitScrollEnd
 import app.tivi.extensions.awaitTransitionComplete
 import app.tivi.extensions.doOnLayouts
+import app.tivi.extensions.findItemIdPosition
 import app.tivi.extensions.resolveThemeColor
 import app.tivi.extensions.scheduleStartPostponedTransitions
 import app.tivi.extensions.scrollToItemId
@@ -154,8 +155,8 @@ class ShowDetailsFragment : TiviFragmentWithBinding<FragmentShowDetailsBinding>(
                     binding.detailsMotion.transitionToState(R.id.show_details_closed)
                     binding.detailsMotion.awaitTransitionComplete(R.id.show_details_closed)
 
-                    val seasonItemPosition = controller.adapter.awaitItemIdPosition(seasonItemId)
                     controller.adapter.awaitItemIdPosition(episodeItemId)
+                    val seasonItemPosition = controller.adapter.findItemIdPosition(seasonItemId)
 
                     binding.detailsRv.smoothScrollToItemPosition(seasonItemPosition)
                     binding.detailsRv.awaitScrollEnd()

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentViewModel.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentViewModel.kt
@@ -161,7 +161,7 @@ class ShowDetailsFragmentViewModel @AssistedInject constructor(
     }
 
     private fun openEpisodeDetails(action: OpenEpisodeDetails) {
-        setState { copy(expandedEpisodeId = action.episodeId) }
+        setState { copy(expandedEpisodeId = PendingOpenEpisodeUiEffect(action.episodeId)) }
     }
 
     fun clearExpandedEpisode() {
@@ -178,10 +178,9 @@ class ShowDetailsFragmentViewModel @AssistedInject constructor(
 
     private fun onChangeSeasonExpandState(action: ChangeSeasonExpandedAction) {
         if (action.expanded) {
-            // Since focusedSeasonId is a transient piece of state, we run the reducer twice.
-            // First with our 'event', and second clearing the 'event'.
             setState {
-                copy(focusedSeasonId = action.seasonId, expandedSeasonIds = expandedSeasonIds + action.seasonId)
+                copy(focusedSeason = PendingFocusSeasonUiEffect(action.seasonId, true),
+                        expandedSeasonIds = expandedSeasonIds + action.seasonId)
             }
         } else {
             setState {
@@ -191,7 +190,7 @@ class ShowDetailsFragmentViewModel @AssistedInject constructor(
     }
 
     fun clearFocusedSeason() {
-        setState { copy(focusedSeasonId = null) }
+        setState { copy(focusedSeason = null) }
     }
 
     private fun onChangeSeasonFollowState(action: ChangeSeasonFollowedAction) {

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentViewModel.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentViewModel.kt
@@ -43,7 +43,6 @@ import com.airbnb.mvrx.ViewModelContext
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.sendBlocking
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
@@ -151,7 +150,9 @@ class ShowDetailsFragmentViewModel @AssistedInject constructor(
         }
     }
 
-    fun submitAction(action: ShowDetailsAction) = pendingActions.sendBlocking(action)
+    fun submitAction(action: ShowDetailsAction) = viewModelScope.launch {
+        pendingActions.send(action)
+    }
 
     private fun onToggleMyShowsButtonClicked() = withState {
         changeShowFollowStatus(ChangeShowFollowStatus.Params(it.showId, TOGGLE)).also {

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentViewModel.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentViewModel.kt
@@ -162,6 +162,9 @@ class ShowDetailsFragmentViewModel @AssistedInject constructor(
 
     private fun openEpisodeDetails(action: OpenEpisodeDetails) {
         setState { copy(expandedEpisodeId = action.episodeId) }
+    }
+
+    fun clearExpandedEpisode() {
         setState { copy(expandedEpisodeId = null) }
     }
 
@@ -180,12 +183,15 @@ class ShowDetailsFragmentViewModel @AssistedInject constructor(
             setState {
                 copy(focusedSeasonId = action.seasonId, expandedSeasonIds = expandedSeasonIds + action.seasonId)
             }
-            setState { copy(focusedSeasonId = null) }
         } else {
             setState {
                 copy(expandedSeasonIds = expandedSeasonIds - action.seasonId)
             }
         }
+    }
+
+    fun clearFocusedSeason() {
+        setState { copy(focusedSeasonId = null) }
     }
 
     private fun onChangeSeasonFollowState(action: ChangeSeasonFollowedAction) {

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentViewModel.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentViewModel.kt
@@ -106,17 +106,15 @@ class ShowDetailsFragmentViewModel @AssistedInject constructor(
         }
 
         viewModelScope.launch {
-            for (action in pendingActions) {
-                when (action) {
-                    is RefreshAction -> refresh(true)
-                    FollowShowToggleAction -> onToggleMyShowsButtonClicked()
-                    is MarkSeasonWatchedAction -> onMarkSeasonWatched(action)
-                    is MarkSeasonUnwatchedAction -> onMarkSeasonUnwatched(action)
-                    is ChangeSeasonFollowedAction -> onChangeSeasonFollowState(action)
-                    is ChangeSeasonExpandedAction -> onChangeSeasonExpandState(action)
-                    is UnfollowPreviousSeasonsFollowedAction -> onUnfollowPreviousSeasonsFollowState(action)
-                    is OpenEpisodeDetails -> openEpisodeDetails(action)
-                }
+            for (action in pendingActions) when (action) {
+                is RefreshAction -> refresh(true)
+                FollowShowToggleAction -> onToggleMyShowsButtonClicked()
+                is MarkSeasonWatchedAction -> onMarkSeasonWatched(action)
+                is MarkSeasonUnwatchedAction -> onMarkSeasonUnwatched(action)
+                is ChangeSeasonFollowedAction -> onChangeSeasonFollowState(action)
+                is ChangeSeasonExpandedAction -> onChangeSeasonExpandState(action)
+                is UnfollowPreviousSeasonsFollowedAction -> onUnfollowPreviousSeasonsFollowState(action)
+                is OpenEpisodeDetails -> openEpisodeDetails(action)
             }
         }
 

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentViewModel.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentViewModel.kt
@@ -193,7 +193,7 @@ class ShowDetailsFragmentViewModel @AssistedInject constructor(
     private fun onChangeSeasonExpandState(action: ChangeSeasonExpandedAction) {
         if (action.expanded) {
             setState {
-                copy(focusedSeason = PendingFocusSeasonUiEffect(action.seasonId, true),
+                copy(focusedSeason = FocusSeasonUiEffect(action.seasonId),
                         expandedSeasonIds = expandedSeasonIds + action.seasonId)
             }
         } else {

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentViewModel.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentViewModel.kt
@@ -150,8 +150,8 @@ class ShowDetailsFragmentViewModel @AssistedInject constructor(
         }
     }
 
-    fun submitAction(action: ShowDetailsAction) = viewModelScope.launch {
-        pendingActions.send(action)
+    fun submitAction(action: ShowDetailsAction) {
+        viewModelScope.launch { pendingActions.send(action) }
     }
 
     private fun onToggleMyShowsButtonClicked() = withState {

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsViewState.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsViewState.kt
@@ -37,7 +37,7 @@ data class ShowDetailsViewState(
     val viewStats: Async<FollowedShowsWatchStats> = Uninitialized,
     val seasons: Async<List<SeasonWithEpisodesAndWatches>> = Uninitialized,
     val expandedSeasonIds: Set<Long> = emptySet(),
-    val focusedSeason: PendingFocusSeasonUiEffect? = null,
+    val focusedSeason: FocusSeasonUiEffect? = null,
     val openEpisodeUiEffect: OpenEpisodeUiEffect? = null,
     val refreshing: Boolean = false
 ) : MvRxState {
@@ -47,7 +47,7 @@ data class ShowDetailsViewState(
     )
 }
 
-data class PendingFocusSeasonUiEffect(val seasonId: Long, val animatedScroll: Boolean)
+data class FocusSeasonUiEffect(val seasonId: Long)
 
 sealed class OpenEpisodeUiEffect
 data class PendingOpenEpisodeUiEffect(val episodeId: Long) : OpenEpisodeUiEffect()

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsViewState.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsViewState.kt
@@ -37,12 +37,15 @@ data class ShowDetailsViewState(
     val viewStats: Async<FollowedShowsWatchStats> = Uninitialized,
     val seasons: Async<List<SeasonWithEpisodesAndWatches>> = Uninitialized,
     val expandedSeasonIds: Set<Long> = emptySet(),
-    val focusedSeasonId: Long? = null,
-    val expandedEpisodeId: Long? = null,
+    val focusedSeason: PendingFocusSeasonUiEffect? = null,
+    val expandedEpisodeId: PendingOpenEpisodeUiEffect? = null,
     val refreshing: Boolean = false
 ) : MvRxState {
     internal constructor(args: ShowDetailsFragment.Arguments) : this(
             showId = args.showId,
-            expandedEpisodeId = args.episodeToExpand
+            expandedEpisodeId = args.episodeToExpand?.let(::PendingOpenEpisodeUiEffect)
     )
 }
+
+data class PendingFocusSeasonUiEffect(val seasonId: Long, val animatedScroll: Boolean)
+data class PendingOpenEpisodeUiEffect(val episodeId: Long)

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsViewState.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsViewState.kt
@@ -38,14 +38,17 @@ data class ShowDetailsViewState(
     val seasons: Async<List<SeasonWithEpisodesAndWatches>> = Uninitialized,
     val expandedSeasonIds: Set<Long> = emptySet(),
     val focusedSeason: PendingFocusSeasonUiEffect? = null,
-    val expandedEpisodeId: PendingOpenEpisodeUiEffect? = null,
+    val openEpisodeUiEffect: OpenEpisodeUiEffect? = null,
     val refreshing: Boolean = false
 ) : MvRxState {
     internal constructor(args: ShowDetailsFragment.Arguments) : this(
             showId = args.showId,
-            expandedEpisodeId = args.episodeToExpand?.let(::PendingOpenEpisodeUiEffect)
+            openEpisodeUiEffect = args.episodeToExpand?.let(::PendingOpenEpisodeUiEffect)
     )
 }
 
 data class PendingFocusSeasonUiEffect(val seasonId: Long, val animatedScroll: Boolean)
-data class PendingOpenEpisodeUiEffect(val episodeId: Long)
+
+sealed class OpenEpisodeUiEffect
+data class PendingOpenEpisodeUiEffect(val episodeId: Long) : OpenEpisodeUiEffect()
+data class ExecutableOpenEpisodeUiEffect(val episodeId: Long, val seasonId: Long) : OpenEpisodeUiEffect()

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsViewState.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsViewState.kt
@@ -41,5 +41,8 @@ data class ShowDetailsViewState(
     val expandedEpisodeId: Long? = null,
     val refreshing: Boolean = false
 ) : MvRxState {
-    constructor(args: ShowDetailsFragment.Arguments) : this(args.showId)
+    internal constructor(args: ShowDetailsFragment.Arguments) : this(
+            showId = args.showId,
+            expandedEpisodeId = args.episodeToExpand
+    )
 }


### PR DESCRIPTION
All actions and state changes are now provided through the ViewModel and it's state observable.

Since we've now centralised the logic, opening the new episode to watch from 'Discover' now correctly deeplinks to the episode.