### PR TITLE
GitHub Actions improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
       - uses: actions/cache@v1.1.0
+        timeout-minutes: 5
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('checksum.txt') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,11 @@ jobs:
       ORG_GRADLE_PROJECT_TIVI_PLAY_PUBLISHER_ACCOUNT: ${{ secrets.ORG_GRADLE_PROJECT_TIVI_PLAY_PUBLISHER_ACCOUNT }}
 
     steps:
+      - name: Generate build number
+        shell: bash
+        run: |
+          echo "::set-env name=BUILD_NUMBER::$(expr $GITHUB_RUN_NUMBER + 5200)"
+
       - uses: actions/checkout@v2
 
       - name: set up JDK 1.8
@@ -42,12 +47,6 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('checksum.txt') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-
-      - name: Generate build number
-        id: buildnumber
-        uses: einaregilsson/build-number@v1
-        with:
-          token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Build debug and check
         run: ./gradlew spotlessCheck app:assembleDebug app:lintDebug testDebug -Ptivi.versioncode=$BUILD_NUMBER --scan

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,16 +48,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Build debug and check
-        run: ./gradlew spotlessCheck app:assembleDebug app:lintDebug testDebug -Ptivi.versioncode=$BUILD_NUMBER --scan
-
-      - name: Build release
-        if: github.ref != 'refs/heads/master'
-        run: ./gradlew assembleRelease bundleRelease -Ptivi.versioncode=$BUILD_NUMBER --scan
+      - name: Build and check
+        run: ./gradlew spotlessCheck assembleDebug assembleRelease bundleRelease app:lintDebug testDebug -Ptivi.versioncode=$BUILD_NUMBER --scan
 
       - name: Publish to Play Store
         if: github.ref == 'refs/heads/master'
-        run: ./gradlew assembleRelease publishRelease -Ptivi.versioncode=$BUILD_NUMBER --scan
+        run: ./gradlew publishRelease -Ptivi.versioncode=$BUILD_NUMBER --scan
 
       - name: Create release for tags
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,15 @@ jobs:
       ORG_GRADLE_PROJECT_TIVI_RELEASE_KEYSTORE_PWD: ${{ secrets.ORG_GRADLE_PROJECT_TIVI_RELEASE_KEYSTORE_PWD }}
       ORG_GRADLE_PROJECT_TIVI_RELEASE_KEY_PWD: ${{ secrets.ORG_GRADLE_PROJECT_TIVI_RELEASE_KEY_PWD }}
       ORG_GRADLE_PROJECT_TIVI_PLAY_PUBLISHER_ACCOUNT: ${{ secrets.ORG_GRADLE_PROJECT_TIVI_PLAY_PUBLISHER_ACCOUNT }}
+
     steps:
       - uses: actions/checkout@v2
+
       - name: set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+
       - name: Decrypt secrets
         run: release/signing-setup.sh $ENCRYPT_KEY
         env:
@@ -47,15 +50,15 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Build debug and check
-        run: ./gradlew spotlessCheck app:assembleDebug app:lintDebug testDebug dependencyUpdates -Ptivi.versioncode=$BUILD_NUMBER --scan
+        run: ./gradlew spotlessCheck app:assembleDebug app:lintDebug testDebug -Ptivi.versioncode=$BUILD_NUMBER --scan
 
       - name: Build release
         if: github.ref != 'refs/heads/master'
-        run: ./gradlew bundleRelease assembleRelease -Ptivi.versioncode=$BUILD_NUMBER --scan
+        run: ./gradlew assembleRelease bundleRelease -Ptivi.versioncode=$BUILD_NUMBER --scan
 
       - name: Publish to Play Store
         if: github.ref == 'refs/heads/master'
-        run: ./gradlew publishRelease -Ptivi.versioncode=$BUILD_NUMBER --scan
+        run: ./gradlew assembleRelease publishRelease -Ptivi.versioncode=$BUILD_NUMBER --scan
 
       - name: Create release for tags
         uses: softprops/action-gh-release@v1
@@ -84,12 +87,6 @@ jobs:
         with:
           name: build-reports
           path: app/build/reports
-
-      - name: Upload dependency updates report
-        uses: actions/upload-artifact@v1
-        with:
-          name: dependency-updates
-          path: build/dependencyUpdates
 
       - name: Copy test results
         if: always()

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: toolmantim/release-drafter@v5.2.0
+      - uses: toolmantim/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,33 @@
+name: Nightly tasks
+
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      TERM: dumb
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - name: Check dependency updates
+        run: ./gradlew dependencyUpdates
+
+      - name: Upload dependency updates report
+        uses: actions/upload-artifact@v1
+        with:
+          name: dependency-updates
+          path: build/dependencyUpdates


### PR DESCRIPTION
- Use `$GITHUB_RUN_NUMBER` for version code
- Add timeout to cache action
- Split out dependency update check to nightly task
- Collapse most of release tasks into main build step