### PR TITLE
No need of workaround for ConstraintLayout as issue has been fixed already

### DIFF
--- a/common-ui-view/src/main/res/values/attrs.xml
+++ b/common-ui-view/src/main/res/values/attrs.xml
@@ -43,13 +43,4 @@
         <attr name="materialBackgroundColor" />
     </declare-styleable>
 
-    <!-- Remove these once ConstraintLayout 2.0.0-beta3 is out
-         https://issuetracker.google.com/136103084 -->
-    <attr name="flow_horizontalSeparator" />
-    <attr name="flow_verticalSeparator" />
-    <attr name="motionProgress" />
-    <attr name="waveDecay" />
-    <attr name="motionPathRotate" />
-    <attr name="duration" />
-
 </resources>


### PR DESCRIPTION
No need of workaround for ConstraintLayout as issue has been fixed already. Also, using the latest version of constraintLayout 2.0.0-beta4.

**Reference revision:**
Update to AGP 3.6.0-alpha12
Required a workaround for ConstraintLayout
Revision - f57a8e10332dccc0c5f9bc3f325244dbe367c883