### PR TITLE
Setup TraktV2 for automatic refresh tokens

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,10 +53,16 @@
             android:name="net.openid.appauth.RedirectUriReceiverActivity"
             tools:node="replace">
             <intent-filter>
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="${applicationId}" />
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="auth"
+                    android:path="/oauth2callback"
+                    android:scheme="${applicationId}" />
+
             </intent-filter>
         </activity>
 

--- a/data/src/main/java/app/tivi/data/repositories/episodes/TraktSeasonsEpisodesDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/episodes/TraktSeasonsEpisodesDataSource.kt
@@ -91,10 +91,16 @@ class TraktSeasonsEpisodesDataSource @Inject constructor(
         episodeId: Long,
         since: OffsetDateTime?
     ): Result<List<EpisodeWatchEntry>> {
-        return usersService.get().history(UserSlug.ME, HistoryType.EPISODES, episodeIdToTraktIdMapper.map(episodeId),
-            0, 10000, Extended.NOSEASONS, since, null)
-            .executeWithRetry()
-            .toResult(historyItemMapper.forLists())
+        return usersService.get().history(
+            UserSlug.ME,
+            HistoryType.EPISODES,
+            episodeIdToTraktIdMapper.map(episodeId),
+            0, // page
+            10000, // limit
+            Extended.NOSEASONS, // extended info
+            since, // since date
+            null // end date
+        ).executeWithRetry().toResult(historyItemMapper.forLists())
     }
 
     override suspend fun addEpisodeWatches(watches: List<EpisodeWatchEntry>): Result<Unit> {
@@ -112,7 +118,8 @@ class TraktSeasonsEpisodesDataSource @Inject constructor(
     override suspend fun removeEpisodeWatches(watches: List<EpisodeWatchEntry>): Result<Unit> {
         val items = SyncItems()
         items.ids = watches.mapNotNull { it.traktId }
-        return syncService.get().deleteItemsFromWatchedHistory(items).executeWithRetry()
+        return syncService.get().deleteItemsFromWatchedHistory(items)
+            .executeWithRetry()
             .toResultUnit()
     }
 }

--- a/trakt-auth/src/main/java/app/tivi/trakt/TraktAuthModule.kt
+++ b/trakt-auth/src/main/java/app/tivi/trakt/TraktAuthModule.kt
@@ -19,6 +19,7 @@ package app.tivi.trakt
 import android.content.Context
 import android.content.SharedPreferences
 import android.net.Uri
+import androidx.core.net.toUri
 import app.tivi.inject.ApplicationId
 import dagger.Module
 import dagger.Provides
@@ -52,19 +53,28 @@ class TraktAuthModule {
     fun provideAuthRequest(
         serviceConfig: AuthorizationServiceConfiguration,
         @Named("trakt-client-id") clientId: String,
-        @ApplicationId applicationId: String
+        @Named("trakt-auth-redirect-uri") redirectUri: String
     ): AuthorizationRequest {
         return AuthorizationRequest.Builder(
             serviceConfig,
             clientId,
             ResponseTypeValues.CODE,
-            Uri.parse("$applicationId://${TraktConstants.URI_AUTH_CALLBACK_PATH}")
+            redirectUri.toUri()
         ).build()
     }
 
     @Singleton
+    @Named("trakt-auth-redirect-uri")
     @Provides
-    fun provideClientAuth(@Named("trakt-client-secret") clientSecret: String): ClientAuthentication {
+    fun provideAuthRedirectUri(
+        @ApplicationId applicationId: String
+    ): String = "$applicationId://${TraktConstants.URI_AUTH_CALLBACK_PATH}"
+
+    @Singleton
+    @Provides
+    fun provideClientAuth(
+        @Named("trakt-client-secret") clientSecret: String
+    ): ClientAuthentication {
         return ClientSecretBasic(clientSecret)
     }
 

--- a/trakt-auth/src/main/java/app/tivi/trakt/TraktManager.kt
+++ b/trakt-auth/src/main/java/app/tivi/trakt/TraktManager.kt
@@ -77,9 +77,7 @@ class TraktManager @Inject constructor(
 
         // Read the auth state from prefs
         processScope.launch {
-            val state = withContext(dispatchers.io) {
-                readAuthState()
-            }
+            val state = withContext(dispatchers.io) { readAuthState() }
             authState.send(state)
         }
     }
@@ -134,7 +132,7 @@ class TraktManager @Inject constructor(
     }
 
     private fun persistAuthState(state: AuthState) {
-        authPrefs.edit {
+        authPrefs.edit(commit = true) {
             putString("stateJson", state.jsonSerializeString())
         }
     }

--- a/trakt/src/main/java/app/tivi/trakt/TraktModule.kt
+++ b/trakt/src/main/java/app/tivi/trakt/TraktModule.kt
@@ -34,18 +34,18 @@ class TraktModule {
     fun provideTrakt(
         @Named("cache") cacheDir: File,
         interceptor: HttpLoggingInterceptor,
-        @Named("trakt-client-id") clientId: String
-    ): TraktV2 {
-        return object : TraktV2(clientId) {
-            override fun setOkHttpClientDefaults(builder: OkHttpClient.Builder) {
-                super.setOkHttpClientDefaults(builder)
-                builder.apply {
-                    addInterceptor(interceptor)
-                    cache(Cache(File(cacheDir, "trakt_cache"), 10 * 1024 * 1024))
-                    connectTimeout(20, TimeUnit.SECONDS)
-                    readTimeout(20, TimeUnit.SECONDS)
-                    writeTimeout(20, TimeUnit.SECONDS)
-                }
+        @Named("trakt-client-id") clientId: String,
+        @Named("trakt-client-secret") clientSecret: String,
+        @Named("trakt-auth-redirect-uri") redirectUri: String
+    ): TraktV2 = object : TraktV2(clientId, clientSecret, redirectUri) {
+        override fun setOkHttpClientDefaults(builder: OkHttpClient.Builder) {
+            super.setOkHttpClientDefaults(builder)
+            builder.apply {
+                addInterceptor(interceptor)
+                cache(Cache(File(cacheDir, "trakt_cache"), 10 * 1024 * 1024))
+                connectTimeout(20, TimeUnit.SECONDS)
+                readTimeout(20, TimeUnit.SECONDS)
+                writeTimeout(20, TimeUnit.SECONDS)
             }
         }
     }


### PR DESCRIPTION
Currently we do not pass in the client secret or redirect URI to TraktV2, which means that the auto token
is never refreshed.

This commit fixes that by passing through the correct information, to enable TraktV2 to refresh the token as necessary.