### PR TITLE
Re-enable Kotlin incremental compilation

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -19,5 +19,6 @@ org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx5120m
 org.gradle.workers.max=2
 
-kotlin.incremental=false
+# Tell Kotlin to run in-process so we can limit the total heap size
+# more easily
 kotlin.compiler.execution.strategy=in-process


### PR DESCRIPTION
It was previously disabled on CI due to memory pressure, but that is no
longer an issue on GitHub Actions.