### PR TITLE
Render ER diagrams with FloorPlan

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ buildscript {
         classpath Libs.AndroidX.Navigation.safeArgs
 
         classpath "com.github.triplet.gradle:play-publisher:2.8.0-SNAPSHOT"
+
+        classpath Libs.FloorPlan.plugin
     }
 }
 

--- a/buildSrc/src/main/java/app/tivi/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/app/tivi/buildsrc/dependencies.kt
@@ -219,4 +219,9 @@ object Libs {
         const val library = "com.github.MatrixDev.Roomigrant:RoomigrantLib:$version"
         const val compiler = "com.github.MatrixDev.Roomigrant:RoomigrantCompiler:$version"
     }
+
+    object FloorPlan {
+        private const val version = "0.1"
+        const val plugin = "com.juliozynger.floorplan:floorplan-gradle-plugin:$version"
+    }
 }

--- a/data-android/build.gradle
+++ b/data-android/build.gradle
@@ -18,6 +18,7 @@
 import app.tivi.buildsrc.Libs
 
 apply plugin: 'com.android.library'
+apply plugin: 'com.juliozynger.floorplan'
 
 apply plugin: 'kotlin-android'
 
@@ -58,6 +59,16 @@ android {
                 minHeapSize = "64m"
                 maxHeapSize = "128m"
             }
+        }
+    }
+}
+
+floorPlan {
+    schemaLocation = "$projectDir/schemas".toString()
+    outputLocation = "$projectDir/floorplan-output".toString()
+    outputFormat {
+        svg {
+            enabled = true
         }
     }
 }

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/1.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/1.svg
@@ -1,0 +1,424 @@
+<svg width="1385px" height="1418px"
+ viewBox="0.00 0.00 1384.98 1418.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1382)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1382 1348.98,-1382 1348.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1144.98,-754 1144.98,-776 1312.98,-776 1312.98,-754 1144.98,-754"/>
+<polygon fill="none" stroke="black" points="1144.98,-754 1144.98,-776 1312.98,-776 1312.98,-754 1144.98,-754"/>
+<text text-anchor="start" x="1211.48" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1144.98,-732 1144.98,-754 1312.98,-754 1312.98,-732 1144.98,-732"/>
+<text text-anchor="start" x="1189.91" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1208.19" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-710 1144.98,-732 1312.98,-732 1312.98,-710 1144.98,-710"/>
+<text text-anchor="start" x="1196.52" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1225.68" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-688 1144.98,-710 1312.98,-710 1312.98,-688 1144.98,-688"/>
+<text text-anchor="start" x="1171.24" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1250.96" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-666 1144.98,-688 1312.98,-688 1312.98,-666 1144.98,-666"/>
+<text text-anchor="start" x="1173.58" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1224.52" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-644 1144.98,-666 1312.98,-666 1312.98,-644 1144.98,-644"/>
+<text text-anchor="start" x="1172.02" y="-651.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1226.08" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-622 1144.98,-644 1312.98,-644 1312.98,-622 1144.98,-622"/>
+<text text-anchor="start" x="1156.86" y="-629.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1265.34" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-600 1144.98,-622 1312.98,-622 1312.98,-600 1144.98,-600"/>
+<text text-anchor="start" x="1147.92" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1274.28" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-578 1144.98,-600 1312.98,-600 1312.98,-578 1144.98,-578"/>
+<text text-anchor="start" x="1168.92" y="-585.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="1253.28" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-556 1144.98,-578 1312.98,-578 1312.98,-556 1144.98,-556"/>
+<text text-anchor="start" x="1167.35" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="1254.85" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-534 1144.98,-556 1312.98,-556 1312.98,-534 1144.98,-534"/>
+<text text-anchor="start" x="1181.36" y="-541.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1240.84" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-512 1144.98,-534 1312.98,-534 1312.98,-512 1144.98,-512"/>
+<text text-anchor="start" x="1178.64" y="-519.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1243.56" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-490 1144.98,-512 1312.98,-512 1312.98,-490 1144.98,-490"/>
+<text text-anchor="start" x="1190.68" y="-497.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="1230.73" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1144.98,-468 1144.98,-490 1312.98,-490 1312.98,-468 1144.98,-468"/>
+<text text-anchor="start" x="1173.59" y="-475.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1248.61" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-446 1144.98,-468 1312.98,-468 1312.98,-446 1144.98,-446"/>
+<text text-anchor="start" x="1186.02" y="-453.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1236.18" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-424 1144.98,-446 1312.98,-446 1312.98,-424 1144.98,-424"/>
+<text text-anchor="start" x="1184.47" y="-431.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1237.73" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-402 1144.98,-424 1312.98,-424 1312.98,-402 1144.98,-402"/>
+<text text-anchor="start" x="1173.58" y="-409.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1224.52" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-380 1144.98,-402 1312.98,-402 1312.98,-380 1144.98,-380"/>
+<text text-anchor="start" x="1189.14" y="-387.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1233.06" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<polygon fill="none" stroke="black" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<text text-anchor="start" x="1208.77" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<text text-anchor="start" x="1167.16" y="-342.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1144.98,-314 1144.98,-336 1312.98,-336 1312.98,-314 1144.98,-314"/>
+<text text-anchor="start" x="1165.6" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="782.32,-1324 782.32,-1346 969.32,-1346 969.32,-1324 782.32,-1324"/>
+<polygon fill="none" stroke="black" points="782.32,-1324 782.32,-1346 969.32,-1346 969.32,-1324 782.32,-1324"/>
+<text text-anchor="start" x="831.5" y="-1331.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="782.32,-1302 782.32,-1324 969.32,-1324 969.32,-1302 782.32,-1302"/>
+<text text-anchor="start" x="836.75" y="-1309.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1309.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<text text-anchor="start" x="818.47" y="-1287.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1258 782.32,-1280 969.32,-1280 969.32,-1258 782.32,-1258"/>
+<text text-anchor="start" x="828.98" y="-1265.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1236 782.32,-1258 969.32,-1258 969.32,-1236 782.32,-1236"/>
+<text text-anchor="start" x="817.32" y="-1243.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="874.46" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<polygon fill="none" stroke="black" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<text text-anchor="start" x="855.61" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="782.32,-1192 782.32,-1214 969.32,-1214 969.32,-1192 782.32,-1192"/>
+<text text-anchor="start" x="785.22" y="-1198.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M970.32,-1291C1000.15,-1291 1098.67,-813.36 1137.62,-749.93"/>
+<polygon fill="black" stroke="black" points="1140.1,-752.4 1144.98,-743 1135.3,-747.3 1140.1,-752.4"/>
+<text text-anchor="middle" x="1063.65" y="-1021.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="784.32,-1134 784.32,-1156 967.32,-1156 967.32,-1134 784.32,-1134"/>
+<polygon fill="none" stroke="black" points="784.32,-1134 784.32,-1156 967.32,-1156 967.32,-1134 784.32,-1134"/>
+<text text-anchor="start" x="833.44" y="-1141.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="784.32,-1112 784.32,-1134 967.32,-1134 967.32,-1112 784.32,-1112"/>
+<text text-anchor="start" x="836.75" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1119.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<text text-anchor="start" x="818.47" y="-1097.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1068 784.32,-1090 967.32,-1090 967.32,-1068 784.32,-1068"/>
+<text text-anchor="start" x="828.98" y="-1075.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1046 784.32,-1068 967.32,-1068 967.32,-1046 784.32,-1046"/>
+<text text-anchor="start" x="810.71" y="-1053.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="881.06" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<polygon fill="none" stroke="black" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<text text-anchor="start" x="855.61" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="784.32,-1002 784.32,-1024 967.32,-1024 967.32,-1002 784.32,-1002"/>
+<text text-anchor="start" x="787.17" y="-1008.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M968.32,-1101C1053.57,-1101 1056.19,-770.42 1134.98,-744.6"/>
+<polygon fill="black" stroke="black" points="1135.66,-748.03 1144.98,-743 1134.56,-741.12 1135.66,-748.03"/>
+<text text-anchor="middle" x="1063.65" y="-926.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="62.5,-886 62.5,-908 176.5,-908 176.5,-886 62.5,-886"/>
+<polygon fill="none" stroke="black" points="62.5,-886 62.5,-908 176.5,-908 176.5,-886 62.5,-886"/>
+<text text-anchor="start" x="105.12" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="62.5,-864 62.5,-886 176.5,-886 176.5,-864 62.5,-864"/>
+<text text-anchor="start" x="80.43" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-871.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="62.5,-842 62.5,-864 176.5,-864 176.5,-842 62.5,-842"/>
+<text text-anchor="start" x="71.1" y="-849.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.13" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-820 62.5,-842 176.5,-842 176.5,-820 62.5,-820"/>
+<text text-anchor="start" x="82.76" y="-827.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.47" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-798 62.5,-820 176.5,-820 176.5,-798 62.5,-798"/>
+<text text-anchor="start" x="65.26" y="-805.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="137.97" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-776 62.5,-798 176.5,-798 176.5,-776 62.5,-776"/>
+<text text-anchor="start" x="75.37" y="-783.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="127.86" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-754 62.5,-776 176.5,-776 176.5,-754 62.5,-754"/>
+<text text-anchor="start" x="82.37" y="-761.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="120.87" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-732 62.5,-754 176.5,-754 176.5,-732 62.5,-732"/>
+<text text-anchor="start" x="69.55" y="-739.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="133.69" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="781.32,-944 781.32,-966 970.32,-966 970.32,-944 781.32,-944"/>
+<polygon fill="none" stroke="black" points="781.32,-944 781.32,-966 970.32,-966 970.32,-944 781.32,-944"/>
+<text text-anchor="start" x="830.34" y="-951.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="781.32,-922 781.32,-944 970.32,-944 970.32,-922 781.32,-922"/>
+<text text-anchor="start" x="836.75" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-929.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<text text-anchor="start" x="818.47" y="-907.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-878 781.32,-900 970.32,-900 970.32,-878 781.32,-878"/>
+<text text-anchor="start" x="817.7" y="-885.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="898.17" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<polygon fill="none" stroke="black" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<text text-anchor="start" x="855.61" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="781.32,-834 781.32,-856 970.32,-856 970.32,-834 781.32,-834"/>
+<text text-anchor="start" x="784.07" y="-840.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M971.32,-911C1075.14,-911 1040.16,-753.97 1134.77,-743.54"/>
+<polygon fill="black" stroke="black" points="1135.18,-747.03 1144.98,-743 1134.81,-740.04 1135.18,-747.03"/>
+<text text-anchor="middle" x="1063.65" y="-836.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="778.32,-776 778.32,-798 973.32,-798 973.32,-776 778.32,-776"/>
+<polygon fill="none" stroke="black" points="778.32,-776 778.32,-798 973.32,-798 973.32,-776 778.32,-776"/>
+<text text-anchor="start" x="827.22" y="-783.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="778.32,-754 778.32,-776 973.32,-776 973.32,-754 778.32,-754"/>
+<text text-anchor="start" x="836.75" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-761.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<text text-anchor="start" x="818.47" y="-739.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<polygon fill="none" stroke="black" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<text text-anchor="start" x="855.61" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="778.32,-688 778.32,-710 973.32,-710 973.32,-688 778.32,-688"/>
+<text text-anchor="start" x="780.95" y="-694.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M974.32,-743C1046.61,-743 1067.23,-743 1134.68,-743"/>
+<polygon fill="black" stroke="black" points="1134.98,-746.5 1144.98,-743 1134.98,-739.5 1134.98,-746.5"/>
+<text text-anchor="middle" x="1063.65" y="-748.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="780.32,-630 780.32,-652 971.32,-652 971.32,-630 780.32,-630"/>
+<polygon fill="none" stroke="black" points="780.32,-630 780.32,-652 971.32,-652 971.32,-630 780.32,-630"/>
+<text text-anchor="start" x="854.44" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="780.32,-608 780.32,-630 971.32,-630 971.32,-608 780.32,-608"/>
+<text text-anchor="start" x="836.75" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-615.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-586 780.32,-608 971.32,-608 971.32,-586 780.32,-586"/>
+<text text-anchor="start" x="818.47" y="-593.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<text text-anchor="start" x="820.42" y="-571.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="871.36" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-542 780.32,-564 971.32,-564 971.32,-542 780.32,-542"/>
+<text text-anchor="start" x="818.86" y="-549.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="872.92" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-520 780.32,-542 971.32,-542 971.32,-520 780.32,-520"/>
+<text text-anchor="start" x="843.36" y="-527.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="872.52" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-498 780.32,-520 971.32,-520 971.32,-498 780.32,-498"/>
+<text text-anchor="start" x="828.2" y="-505.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="887.68" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-476 780.32,-498 971.32,-498 971.32,-476 780.32,-476"/>
+<text text-anchor="start" x="820.81" y="-483.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="870.97" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-454 780.32,-476 971.32,-476 971.32,-454 780.32,-454"/>
+<text text-anchor="start" x="816.53" y="-461.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="875.24" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-432 780.32,-454 971.32,-454 971.32,-432 780.32,-432"/>
+<text text-anchor="start" x="818.09" y="-439.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="873.68" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-410 780.32,-432 971.32,-432 971.32,-410 780.32,-410"/>
+<text text-anchor="start" x="837.52" y="-417.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="877.57" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="780.32,-388 780.32,-410 971.32,-410 971.32,-388 780.32,-388"/>
+<text text-anchor="start" x="831.31" y="-395.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="884.57" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-366 780.32,-388 971.32,-388 971.32,-366 780.32,-366"/>
+<text text-anchor="start" x="827.42" y="-373.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="864.36" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-344 780.32,-366 971.32,-366 971.32,-344 780.32,-344"/>
+<text text-anchor="start" x="803.7" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="912.18" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-322 780.32,-344 971.32,-344 971.32,-322 780.32,-322"/>
+<text text-anchor="start" x="794.76" y="-329.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="921.12" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-300 780.32,-322 971.32,-322 971.32,-300 780.32,-300"/>
+<text text-anchor="start" x="815.76" y="-307.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="900.12" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-278 780.32,-300 971.32,-300 971.32,-278 780.32,-278"/>
+<text text-anchor="start" x="814.19" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="901.68" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-256 780.32,-278 971.32,-278 971.32,-256 780.32,-256"/>
+<text text-anchor="start" x="804.48" y="-263.4" font-family="Times,serif" font-size="14.00">episodes_updated: </text>
+<text text-anchor="start" x="911.4" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<polygon fill="none" stroke="black" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<text text-anchor="start" x="855.61" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="780.32,-212 780.32,-234 971.32,-234 971.32,-212 780.32,-212"/>
+<text text-anchor="start" x="783.28" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M972.32,-597C1030.65,-597 1028.48,-643.49 1072.98,-681.2 1102.27,-706.01 1102.95,-736.85 1134.64,-742.19"/>
+<polygon fill="black" stroke="black" points="1134.74,-745.71 1144.98,-743 1135.28,-738.73 1134.74,-745.71"/>
+<text text-anchor="middle" x="1063.65" y="-686.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="401.66,-652 401.66,-674 605.66,-674 605.66,-652 401.66,-652"/>
+<polygon fill="none" stroke="black" points="401.66,-652 401.66,-674 605.66,-674 605.66,-652 401.66,-652"/>
+<text text-anchor="start" x="479.56" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="401.66,-630 401.66,-652 605.66,-652 605.66,-630 401.66,-630"/>
+<text text-anchor="start" x="464.59" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="482.87" y="-637.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-608 401.66,-630 605.66,-630 605.66,-608 401.66,-608"/>
+<text text-anchor="start" x="442.43" y="-615.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="505.03" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<text text-anchor="start" x="448.26" y="-593.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="499.2" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-564 401.66,-586 605.66,-586 605.66,-564 401.66,-564"/>
+<text text-anchor="start" x="446.7" y="-571.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="500.76" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-542 401.66,-564 605.66,-564 605.66,-542 401.66,-542"/>
+<text text-anchor="start" x="471.19" y="-549.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="500.36" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-520 401.66,-542 605.66,-542 605.66,-520 401.66,-520"/>
+<text text-anchor="start" x="456.04" y="-527.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="515.52" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-498 401.66,-520 605.66,-520 605.66,-498 401.66,-498"/>
+<text text-anchor="start" x="448.65" y="-505.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="498.8" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-476 401.66,-498 605.66,-498 605.66,-476 401.66,-476"/>
+<text text-anchor="start" x="453.32" y="-483.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="518.24" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-454 401.66,-476 605.66,-476 605.66,-454 401.66,-454"/>
+<text text-anchor="start" x="465.36" y="-461.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="505.41" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="401.66,-432 401.66,-454 605.66,-454 605.66,-432 401.66,-432"/>
+<text text-anchor="start" x="455.26" y="-439.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="492.2" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-410 401.66,-432 605.66,-432 605.66,-410 401.66,-410"/>
+<text text-anchor="start" x="431.53" y="-417.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="540.02" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-388 401.66,-410 605.66,-410 605.66,-388 401.66,-388"/>
+<text text-anchor="start" x="422.59" y="-395.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="548.96" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-366 401.66,-388 605.66,-388 605.66,-366 401.66,-366"/>
+<text text-anchor="start" x="443.59" y="-373.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="527.96" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-344 401.66,-366 605.66,-366 605.66,-344 401.66,-344"/>
+<text text-anchor="start" x="442.03" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="529.52" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<text text-anchor="start" x="436.99" y="-329.4" font-family="Times,serif" font-size="14.00">last_watched_at: </text>
+<text text-anchor="start" x="534.57" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<polygon fill="none" stroke="black" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<text text-anchor="start" x="483.45" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="401.66,-278 401.66,-300 605.66,-300 605.66,-278 401.66,-278"/>
+<text text-anchor="start" x="404.52" y="-284.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M605.66,-619C679.38,-619 700.29,-619 769.26,-619"/>
+<polygon fill="black" stroke="black" points="769.32,-622.5 779.32,-619 769.32,-615.5 769.32,-622.5"/>
+<text text-anchor="middle" x="686.99" y="-623.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<polygon fill="none" stroke="black" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<text text-anchor="start" x="835.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="768.32,-132 768.32,-154 982.32,-154 982.32,-132 768.32,-132"/>
+<text text-anchor="start" x="836.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="854.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-110 768.32,-132 982.32,-132 982.32,-110 768.32,-110"/>
+<text text-anchor="start" x="817.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="872.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-88 768.32,-110 982.32,-110 982.32,-88 768.32,-88"/>
+<text text-anchor="start" x="800.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="890.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-66 768.32,-88 982.32,-88 982.32,-66 768.32,-66"/>
+<text text-anchor="start" x="807.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="882.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<polygon fill="none" stroke="black" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<text text-anchor="start" x="855.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="768.32,-22 768.32,-44 982.32,-44 982.32,-22 768.32,-22"/>
+<text text-anchor="start" x="789.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="768.32,0 768.32,-22 982.32,-22 982.32,0 768.32,0"/>
+<text text-anchor="start" x="771.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-99C1123.82,-99 1038.1,-267.06 1072.98,-404.2 1091.07,-475.3 1070.16,-718.65 1134.81,-741.31"/>
+<polygon fill="black" stroke="black" points="1134.54,-744.81 1144.98,-743 1135.69,-737.9 1134.54,-744.81"/>
+<text text-anchor="middle" x="1063.65" y="-409.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-121C1051.96,-121 1036.74,-358.61 1054.32,-426 1071.91,-493.43 1071.77,-719.38 1134.77,-741.29"/>
+<polygon fill="black" stroke="black" points="1134.54,-744.8 1144.98,-743 1135.7,-737.9 1134.54,-744.8"/>
+<text text-anchor="middle" x="1063.65" y="-564.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node10" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-674 0.5,-696 239.5,-696 239.5,-674 0.5,-674"/>
+<polygon fill="none" stroke="black" points="0.5,-674 0.5,-696 239.5,-696 239.5,-674 0.5,-674"/>
+<text text-anchor="start" x="56.25" y="-681.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-652 0.5,-674 239.5,-674 239.5,-652 0.5,-652"/>
+<text text-anchor="start" x="80.93" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-659.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<text text-anchor="start" x="56.04" y="-637.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-637.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="64.6" y="-615.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="66.55" y="-593.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="68.1" y="-571.4" font-family="Times,serif" font-size="14.00">source: </text>
+<text text-anchor="start" x="112.03" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="99.79" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="3.37" y="-526.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="11.92" y="-504.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-641C307.76,-641 327.47,-641 391.45,-641"/>
+<polygon fill="black" stroke="black" points="391.66,-644.5 401.66,-641 391.66,-637.5 391.66,-644.5"/>
+<text text-anchor="middle" x="320.33" y="-645.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/10.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/10.svg
@@ -1,0 +1,427 @@
+<svg width="1385px" height="1374px"
+ viewBox="0.00 0.00 1384.98 1374.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1338)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1338 1348.98,-1338 1348.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1144.98,-710 1144.98,-732 1312.98,-732 1312.98,-710 1144.98,-710"/>
+<polygon fill="none" stroke="black" points="1144.98,-710 1144.98,-732 1312.98,-732 1312.98,-710 1144.98,-710"/>
+<text text-anchor="start" x="1211.48" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1144.98,-688 1144.98,-710 1312.98,-710 1312.98,-688 1144.98,-688"/>
+<text text-anchor="start" x="1189.91" y="-695.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1208.19" y="-695.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-666 1144.98,-688 1312.98,-688 1312.98,-666 1144.98,-666"/>
+<text text-anchor="start" x="1196.52" y="-673.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1225.68" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-644 1144.98,-666 1312.98,-666 1312.98,-644 1144.98,-644"/>
+<text text-anchor="start" x="1171.24" y="-651.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1250.96" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-622 1144.98,-644 1312.98,-644 1312.98,-622 1144.98,-622"/>
+<text text-anchor="start" x="1173.58" y="-629.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1224.52" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-600 1144.98,-622 1312.98,-622 1312.98,-600 1144.98,-600"/>
+<text text-anchor="start" x="1172.02" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1226.08" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-578 1144.98,-600 1312.98,-600 1312.98,-578 1144.98,-578"/>
+<text text-anchor="start" x="1156.86" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1265.34" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-556 1144.98,-578 1312.98,-578 1312.98,-556 1144.98,-556"/>
+<text text-anchor="start" x="1147.92" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1274.28" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-534 1144.98,-556 1312.98,-556 1312.98,-534 1144.98,-534"/>
+<text text-anchor="start" x="1181.36" y="-541.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1240.84" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-512 1144.98,-534 1312.98,-534 1312.98,-512 1144.98,-512"/>
+<text text-anchor="start" x="1178.64" y="-519.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1243.56" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-490 1144.98,-512 1312.98,-512 1312.98,-490 1144.98,-490"/>
+<text text-anchor="start" x="1174.36" y="-497.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1247.06" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1144.98,-468 1144.98,-490 1312.98,-490 1312.98,-468 1144.98,-468"/>
+<text text-anchor="start" x="1173.59" y="-475.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1248.61" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-446 1144.98,-468 1312.98,-468 1312.98,-446 1144.98,-446"/>
+<text text-anchor="start" x="1178.64" y="-453.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1243.56" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-424 1144.98,-446 1312.98,-446 1312.98,-424 1144.98,-424"/>
+<text text-anchor="start" x="1186.02" y="-431.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1236.18" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-402 1144.98,-424 1312.98,-424 1312.98,-402 1144.98,-402"/>
+<text text-anchor="start" x="1184.47" y="-409.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1237.73" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-380 1144.98,-402 1312.98,-402 1312.98,-380 1144.98,-380"/>
+<text text-anchor="start" x="1173.58" y="-387.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1224.52" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<text text-anchor="start" x="1189.14" y="-365.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1233.06" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<polygon fill="none" stroke="black" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<text text-anchor="start" x="1208.77" y="-343.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1144.98,-314 1144.98,-336 1312.98,-336 1312.98,-314 1144.98,-314"/>
+<text text-anchor="start" x="1167.16" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1144.98,-292 1144.98,-314 1312.98,-314 1312.98,-292 1144.98,-292"/>
+<text text-anchor="start" x="1165.6" y="-298.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<polygon fill="none" stroke="black" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<text text-anchor="start" x="831.5" y="-1287.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="782.32,-1258 782.32,-1280 969.32,-1280 969.32,-1258 782.32,-1258"/>
+<text text-anchor="start" x="836.75" y="-1265.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1265.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1236 782.32,-1258 969.32,-1258 969.32,-1236 782.32,-1236"/>
+<text text-anchor="start" x="818.47" y="-1243.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<text text-anchor="start" x="828.98" y="-1221.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1192 782.32,-1214 969.32,-1214 969.32,-1192 782.32,-1192"/>
+<text text-anchor="start" x="817.32" y="-1199.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="874.46" y="-1199.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="782.32,-1170 782.32,-1192 969.32,-1192 969.32,-1170 782.32,-1170"/>
+<polygon fill="none" stroke="black" points="782.32,-1170 782.32,-1192 969.32,-1192 969.32,-1170 782.32,-1170"/>
+<text text-anchor="start" x="855.61" y="-1177.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="782.32,-1148 782.32,-1170 969.32,-1170 969.32,-1148 782.32,-1148"/>
+<text text-anchor="start" x="785.22" y="-1154.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M970.32,-1247C1000.15,-1247 1098.67,-769.36 1137.62,-705.93"/>
+<polygon fill="black" stroke="black" points="1140.1,-708.4 1144.98,-699 1135.3,-703.3 1140.1,-708.4"/>
+<text text-anchor="middle" x="1063.65" y="-977.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<polygon fill="none" stroke="black" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<text text-anchor="start" x="833.44" y="-1097.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="784.32,-1068 784.32,-1090 967.32,-1090 967.32,-1068 784.32,-1068"/>
+<text text-anchor="start" x="836.75" y="-1075.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1075.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1046 784.32,-1068 967.32,-1068 967.32,-1046 784.32,-1046"/>
+<text text-anchor="start" x="818.47" y="-1053.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<text text-anchor="start" x="828.98" y="-1031.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1002 784.32,-1024 967.32,-1024 967.32,-1002 784.32,-1002"/>
+<text text-anchor="start" x="810.71" y="-1009.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="881.06" y="-1009.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="784.32,-980 784.32,-1002 967.32,-1002 967.32,-980 784.32,-980"/>
+<polygon fill="none" stroke="black" points="784.32,-980 784.32,-1002 967.32,-1002 967.32,-980 784.32,-980"/>
+<text text-anchor="start" x="855.61" y="-987.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="784.32,-958 784.32,-980 967.32,-980 967.32,-958 784.32,-958"/>
+<text text-anchor="start" x="787.17" y="-964.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M968.32,-1057C1053.57,-1057 1056.19,-726.42 1134.98,-700.6"/>
+<polygon fill="black" stroke="black" points="1135.66,-704.03 1144.98,-699 1134.56,-697.12 1135.66,-704.03"/>
+<text text-anchor="middle" x="1063.65" y="-882.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="62.5,-820 62.5,-842 176.5,-842 176.5,-820 62.5,-820"/>
+<polygon fill="none" stroke="black" points="62.5,-820 62.5,-842 176.5,-842 176.5,-820 62.5,-820"/>
+<text text-anchor="start" x="105.12" y="-827.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="62.5,-798 62.5,-820 176.5,-820 176.5,-798 62.5,-798"/>
+<text text-anchor="start" x="80.43" y="-805.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-805.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="62.5,-776 62.5,-798 176.5,-798 176.5,-776 62.5,-776"/>
+<text text-anchor="start" x="71.1" y="-783.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.13" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-754 62.5,-776 176.5,-776 176.5,-754 62.5,-754"/>
+<text text-anchor="start" x="82.76" y="-761.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.47" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-732 62.5,-754 176.5,-754 176.5,-732 62.5,-732"/>
+<text text-anchor="start" x="65.26" y="-739.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="137.97" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-710 62.5,-732 176.5,-732 176.5,-710 62.5,-710"/>
+<text text-anchor="start" x="75.37" y="-717.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="127.86" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-688 62.5,-710 176.5,-710 176.5,-688 62.5,-688"/>
+<text text-anchor="start" x="82.37" y="-695.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="120.87" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-666 62.5,-688 176.5,-688 176.5,-666 62.5,-666"/>
+<text text-anchor="start" x="69.55" y="-673.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="133.69" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<polygon fill="none" stroke="black" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<text text-anchor="start" x="830.34" y="-907.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="781.32,-878 781.32,-900 970.32,-900 970.32,-878 781.32,-878"/>
+<text text-anchor="start" x="836.75" y="-885.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-885.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<text text-anchor="start" x="818.47" y="-863.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-834 781.32,-856 970.32,-856 970.32,-834 781.32,-834"/>
+<text text-anchor="start" x="817.7" y="-841.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="898.17" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="781.32,-812 781.32,-834 970.32,-834 970.32,-812 781.32,-812"/>
+<polygon fill="none" stroke="black" points="781.32,-812 781.32,-834 970.32,-834 970.32,-812 781.32,-812"/>
+<text text-anchor="start" x="855.61" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="781.32,-790 781.32,-812 970.32,-812 970.32,-790 781.32,-790"/>
+<text text-anchor="start" x="784.07" y="-796.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M971.32,-867C1075.14,-867 1040.16,-709.97 1134.77,-699.54"/>
+<polygon fill="black" stroke="black" points="1135.18,-703.03 1144.98,-699 1134.81,-696.04 1135.18,-703.03"/>
+<text text-anchor="middle" x="1063.65" y="-792.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<polygon fill="none" stroke="black" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<text text-anchor="start" x="827.22" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<text text-anchor="start" x="836.75" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-717.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-688 778.32,-710 973.32,-710 973.32,-688 778.32,-688"/>
+<text text-anchor="start" x="818.47" y="-695.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-666 778.32,-688 973.32,-688 973.32,-666 778.32,-666"/>
+<text text-anchor="start" x="811.09" y="-673.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="904.79" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="778.32,-644 778.32,-666 973.32,-666 973.32,-644 778.32,-644"/>
+<polygon fill="none" stroke="black" points="778.32,-644 778.32,-666 973.32,-666 973.32,-644 778.32,-644"/>
+<text text-anchor="start" x="855.61" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="778.32,-622 778.32,-644 973.32,-644 973.32,-622 778.32,-622"/>
+<text text-anchor="start" x="780.95" y="-628.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M974.32,-699C1046.61,-699 1067.23,-699 1134.68,-699"/>
+<polygon fill="black" stroke="black" points="1134.98,-702.5 1144.98,-699 1134.98,-695.5 1134.98,-702.5"/>
+<text text-anchor="middle" x="1063.65" y="-704.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<polygon fill="none" stroke="black" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<text text-anchor="start" x="854.44" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="780.32,-542 780.32,-564 971.32,-564 971.32,-542 780.32,-542"/>
+<text text-anchor="start" x="836.75" y="-549.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-549.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-520 780.32,-542 971.32,-542 971.32,-520 780.32,-520"/>
+<text text-anchor="start" x="818.47" y="-527.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-498 780.32,-520 971.32,-520 971.32,-498 780.32,-498"/>
+<text text-anchor="start" x="820.42" y="-505.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="871.36" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-476 780.32,-498 971.32,-498 971.32,-476 780.32,-476"/>
+<text text-anchor="start" x="818.86" y="-483.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="872.92" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-454 780.32,-476 971.32,-476 971.32,-454 780.32,-454"/>
+<text text-anchor="start" x="843.36" y="-461.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="872.52" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-432 780.32,-454 971.32,-454 971.32,-432 780.32,-432"/>
+<text text-anchor="start" x="828.2" y="-439.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="887.68" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-410 780.32,-432 971.32,-432 971.32,-410 780.32,-410"/>
+<text text-anchor="start" x="820.81" y="-417.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="870.97" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-388 780.32,-410 971.32,-410 971.32,-388 780.32,-388"/>
+<text text-anchor="start" x="831.31" y="-395.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="884.57" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-366 780.32,-388 971.32,-388 971.32,-366 780.32,-366"/>
+<text text-anchor="start" x="816.53" y="-373.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="875.24" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-344 780.32,-366 971.32,-366 971.32,-344 780.32,-344"/>
+<text text-anchor="start" x="818.09" y="-351.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="873.68" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-322 780.32,-344 971.32,-344 971.32,-322 780.32,-322"/>
+<text text-anchor="start" x="821.2" y="-329.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="893.9" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="780.32,-300 780.32,-322 971.32,-322 971.32,-300 780.32,-300"/>
+<text text-anchor="start" x="811.09" y="-307.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="880.69" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-278 780.32,-300 971.32,-300 971.32,-278 780.32,-278"/>
+<text text-anchor="start" x="803.7" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="912.18" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-256 780.32,-278 971.32,-278 971.32,-256 780.32,-256"/>
+<text text-anchor="start" x="794.76" y="-263.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="921.12" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<polygon fill="none" stroke="black" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<text text-anchor="start" x="855.61" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="780.32,-212 780.32,-234 971.32,-234 971.32,-212 780.32,-212"/>
+<text text-anchor="start" x="783.28" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M972.32,-531C1022.61,-531 1083.55,-679.27 1135.13,-697.23"/>
+<polygon fill="black" stroke="black" points="1134.52,-700.67 1144.98,-699 1135.76,-693.78 1134.52,-700.67"/>
+<text text-anchor="middle" x="1063.65" y="-639.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<polygon fill="none" stroke="black" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<text text-anchor="start" x="479.56" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="401.66,-564 401.66,-586 605.66,-586 605.66,-564 401.66,-564"/>
+<text text-anchor="start" x="464.59" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="482.87" y="-571.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-542 401.66,-564 605.66,-564 605.66,-542 401.66,-542"/>
+<text text-anchor="start" x="442.43" y="-549.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="505.03" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-520 401.66,-542 605.66,-542 605.66,-520 401.66,-520"/>
+<text text-anchor="start" x="448.26" y="-527.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="499.2" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-498 401.66,-520 605.66,-520 605.66,-498 401.66,-498"/>
+<text text-anchor="start" x="446.7" y="-505.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="500.76" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-476 401.66,-498 605.66,-498 605.66,-476 401.66,-476"/>
+<text text-anchor="start" x="471.19" y="-483.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="500.36" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-454 401.66,-476 605.66,-476 605.66,-454 401.66,-454"/>
+<text text-anchor="start" x="456.04" y="-461.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="515.52" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-432 401.66,-454 605.66,-454 605.66,-432 401.66,-432"/>
+<text text-anchor="start" x="448.65" y="-439.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="498.8" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-410 401.66,-432 605.66,-432 605.66,-410 401.66,-410"/>
+<text text-anchor="start" x="453.32" y="-417.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="518.24" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-388 401.66,-410 605.66,-410 605.66,-388 401.66,-388"/>
+<text text-anchor="start" x="449.03" y="-395.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="521.74" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="401.66,-366 401.66,-388 605.66,-388 605.66,-366 401.66,-366"/>
+<text text-anchor="start" x="419.1" y="-373.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="528.35" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-344 401.66,-366 605.66,-366 605.66,-344 401.66,-344"/>
+<text text-anchor="start" x="422.59" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="548.96" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<polygon fill="none" stroke="black" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<text text-anchor="start" x="483.45" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<text text-anchor="start" x="404.52" y="-306.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M605.66,-553C679.38,-553 700.29,-553 769.26,-553"/>
+<polygon fill="black" stroke="black" points="769.32,-556.5 779.32,-553 769.32,-549.5 769.32,-556.5"/>
+<text text-anchor="middle" x="686.99" y="-557.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<polygon fill="none" stroke="black" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<text text-anchor="start" x="835.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="768.32,-132 768.32,-154 982.32,-154 982.32,-132 768.32,-132"/>
+<text text-anchor="start" x="836.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="854.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-110 768.32,-132 982.32,-132 982.32,-110 768.32,-110"/>
+<text text-anchor="start" x="817.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="872.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-88 768.32,-110 982.32,-110 982.32,-88 768.32,-88"/>
+<text text-anchor="start" x="800.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="890.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-66 768.32,-88 982.32,-88 982.32,-66 768.32,-66"/>
+<text text-anchor="start" x="807.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="882.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<polygon fill="none" stroke="black" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<text text-anchor="start" x="855.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="768.32,-22 768.32,-44 982.32,-44 982.32,-22 768.32,-22"/>
+<text text-anchor="start" x="789.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="768.32,0 768.32,-22 982.32,-22 982.32,0 768.32,0"/>
+<text text-anchor="start" x="771.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-99C1106.04,-99 1039.84,-243 1072.98,-362.2 1092.52,-432.48 1070.69,-674.75 1134.87,-697.31"/>
+<polygon fill="black" stroke="black" points="1134.54,-700.81 1144.98,-699 1135.69,-693.9 1134.54,-700.81"/>
+<text text-anchor="middle" x="1063.65" y="-367.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-121C1103.51,-121 1021.56,-267.32 1054.32,-384 1073.05,-450.71 1072.27,-675.5 1134.83,-697.3"/>
+<polygon fill="black" stroke="black" points="1134.54,-700.8 1144.98,-699 1135.7,-693.89 1134.54,-700.8"/>
+<text text-anchor="middle" x="1063.65" y="-521.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node10" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="56.25" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="80.93" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-593.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="56.04" y="-571.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="64.6" y="-549.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="66.55" y="-527.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="55.26" y="-505.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<polygon fill="none" stroke="black" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<text text-anchor="start" x="99.79" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-454 0.5,-476 239.5,-476 239.5,-454 0.5,-454"/>
+<text text-anchor="start" x="3.37" y="-460.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-432 0.5,-454 239.5,-454 239.5,-432 0.5,-432"/>
+<text text-anchor="start" x="11.92" y="-438.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-575C307.76,-575 327.47,-575 391.45,-575"/>
+<polygon fill="black" stroke="black" points="391.66,-578.5 401.66,-575 391.66,-571.5 391.66,-578.5"/>
+<text text-anchor="middle" x="320.33" y="-579.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node11" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1010 9.5,-1032 229.5,-1032 229.5,-1010 9.5,-1010"/>
+<polygon fill="none" stroke="black" points="9.5,-1010 9.5,-1032 229.5,-1032 229.5,-1010 9.5,-1010"/>
+<text text-anchor="start" x="83.34" y="-1017.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-988 9.5,-1010 229.5,-1010 229.5,-988 9.5,-988"/>
+<text text-anchor="start" x="80.43" y="-995.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-995.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-966 9.5,-988 229.5,-988 229.5,-966 9.5,-966"/>
+<text text-anchor="start" x="77.71" y="-973.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-944 9.5,-966 229.5,-966 229.5,-944 9.5,-944"/>
+<text text-anchor="start" x="60.98" y="-951.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-922 9.5,-944 229.5,-944 229.5,-922 9.5,-922"/>
+<text text-anchor="start" x="56.71" y="-929.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-900 9.5,-922 229.5,-922 229.5,-900 9.5,-900"/>
+<polygon fill="none" stroke="black" points="9.5,-900 9.5,-922 229.5,-922 229.5,-900 9.5,-900"/>
+<text text-anchor="start" x="99.29" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-878 9.5,-900 229.5,-900 229.5,-878 9.5,-878"/>
+<text text-anchor="start" x="12.19" y="-884.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/11.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/11.svg
@@ -1,0 +1,438 @@
+<svg width="1385px" height="1374px"
+ viewBox="0.00 0.00 1384.98 1374.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1338)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1338 1348.98,-1338 1348.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1144.98,-710 1144.98,-732 1312.98,-732 1312.98,-710 1144.98,-710"/>
+<polygon fill="none" stroke="black" points="1144.98,-710 1144.98,-732 1312.98,-732 1312.98,-710 1144.98,-710"/>
+<text text-anchor="start" x="1211.48" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1144.98,-688 1144.98,-710 1312.98,-710 1312.98,-688 1144.98,-688"/>
+<text text-anchor="start" x="1189.91" y="-695.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1208.19" y="-695.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-666 1144.98,-688 1312.98,-688 1312.98,-666 1144.98,-666"/>
+<text text-anchor="start" x="1196.52" y="-673.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1225.68" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-644 1144.98,-666 1312.98,-666 1312.98,-644 1144.98,-644"/>
+<text text-anchor="start" x="1171.24" y="-651.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1250.96" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-622 1144.98,-644 1312.98,-644 1312.98,-622 1144.98,-622"/>
+<text text-anchor="start" x="1173.58" y="-629.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1224.52" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-600 1144.98,-622 1312.98,-622 1312.98,-600 1144.98,-600"/>
+<text text-anchor="start" x="1172.02" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1226.08" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-578 1144.98,-600 1312.98,-600 1312.98,-578 1144.98,-578"/>
+<text text-anchor="start" x="1156.86" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1265.34" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-556 1144.98,-578 1312.98,-578 1312.98,-556 1144.98,-556"/>
+<text text-anchor="start" x="1147.92" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1274.28" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-534 1144.98,-556 1312.98,-556 1312.98,-534 1144.98,-534"/>
+<text text-anchor="start" x="1181.36" y="-541.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1240.84" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-512 1144.98,-534 1312.98,-534 1312.98,-512 1144.98,-512"/>
+<text text-anchor="start" x="1178.64" y="-519.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1243.56" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-490 1144.98,-512 1312.98,-512 1312.98,-490 1144.98,-490"/>
+<text text-anchor="start" x="1174.36" y="-497.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1247.06" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1144.98,-468 1144.98,-490 1312.98,-490 1312.98,-468 1144.98,-468"/>
+<text text-anchor="start" x="1173.59" y="-475.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1248.61" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-446 1144.98,-468 1312.98,-468 1312.98,-446 1144.98,-446"/>
+<text text-anchor="start" x="1178.64" y="-453.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1243.56" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-424 1144.98,-446 1312.98,-446 1312.98,-424 1144.98,-424"/>
+<text text-anchor="start" x="1186.02" y="-431.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1236.18" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-402 1144.98,-424 1312.98,-424 1312.98,-402 1144.98,-402"/>
+<text text-anchor="start" x="1184.47" y="-409.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1237.73" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-380 1144.98,-402 1312.98,-402 1312.98,-380 1144.98,-380"/>
+<text text-anchor="start" x="1173.58" y="-387.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1224.52" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<text text-anchor="start" x="1189.14" y="-365.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1233.06" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<polygon fill="none" stroke="black" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<text text-anchor="start" x="1208.77" y="-343.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1144.98,-314 1144.98,-336 1312.98,-336 1312.98,-314 1144.98,-314"/>
+<text text-anchor="start" x="1167.16" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1144.98,-292 1144.98,-314 1312.98,-314 1312.98,-292 1144.98,-292"/>
+<text text-anchor="start" x="1165.6" y="-298.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<polygon fill="none" stroke="black" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<text text-anchor="start" x="831.5" y="-1287.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="782.32,-1258 782.32,-1280 969.32,-1280 969.32,-1258 782.32,-1258"/>
+<text text-anchor="start" x="836.75" y="-1265.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1265.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1236 782.32,-1258 969.32,-1258 969.32,-1236 782.32,-1236"/>
+<text text-anchor="start" x="818.47" y="-1243.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<text text-anchor="start" x="828.98" y="-1221.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1192 782.32,-1214 969.32,-1214 969.32,-1192 782.32,-1192"/>
+<text text-anchor="start" x="817.32" y="-1199.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="874.46" y="-1199.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="782.32,-1170 782.32,-1192 969.32,-1192 969.32,-1170 782.32,-1170"/>
+<polygon fill="none" stroke="black" points="782.32,-1170 782.32,-1192 969.32,-1192 969.32,-1170 782.32,-1170"/>
+<text text-anchor="start" x="855.61" y="-1177.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="782.32,-1148 782.32,-1170 969.32,-1170 969.32,-1148 782.32,-1148"/>
+<text text-anchor="start" x="785.22" y="-1154.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M970.32,-1247C1000.15,-1247 1098.67,-769.36 1137.62,-705.93"/>
+<polygon fill="black" stroke="black" points="1140.1,-708.4 1144.98,-699 1135.3,-703.3 1140.1,-708.4"/>
+<text text-anchor="middle" x="1063.65" y="-977.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<polygon fill="none" stroke="black" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<text text-anchor="start" x="833.44" y="-1097.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="784.32,-1068 784.32,-1090 967.32,-1090 967.32,-1068 784.32,-1068"/>
+<text text-anchor="start" x="836.75" y="-1075.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1075.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1046 784.32,-1068 967.32,-1068 967.32,-1046 784.32,-1046"/>
+<text text-anchor="start" x="818.47" y="-1053.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<text text-anchor="start" x="828.98" y="-1031.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1002 784.32,-1024 967.32,-1024 967.32,-1002 784.32,-1002"/>
+<text text-anchor="start" x="810.71" y="-1009.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="881.06" y="-1009.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="784.32,-980 784.32,-1002 967.32,-1002 967.32,-980 784.32,-980"/>
+<polygon fill="none" stroke="black" points="784.32,-980 784.32,-1002 967.32,-1002 967.32,-980 784.32,-980"/>
+<text text-anchor="start" x="855.61" y="-987.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="784.32,-958 784.32,-980 967.32,-980 967.32,-958 784.32,-958"/>
+<text text-anchor="start" x="787.17" y="-964.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M968.32,-1057C1053.57,-1057 1056.19,-726.42 1134.98,-700.6"/>
+<polygon fill="black" stroke="black" points="1135.66,-704.03 1144.98,-699 1134.56,-697.12 1135.66,-704.03"/>
+<text text-anchor="middle" x="1063.65" y="-882.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-908 53.5,-930 186.5,-930 186.5,-908 53.5,-908"/>
+<polygon fill="none" stroke="black" points="53.5,-908 53.5,-930 186.5,-930 186.5,-908 53.5,-908"/>
+<text text-anchor="start" x="105.62" y="-915.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-886 53.5,-908 186.5,-908 186.5,-886 53.5,-886"/>
+<text text-anchor="start" x="80.93" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-893.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-864 53.5,-886 186.5,-886 186.5,-864 53.5,-864"/>
+<text text-anchor="start" x="71.6" y="-871.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-871.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-842 53.5,-864 186.5,-864 186.5,-842 53.5,-842"/>
+<text text-anchor="start" x="83.26" y="-849.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-820 53.5,-842 186.5,-842 186.5,-820 53.5,-820"/>
+<text text-anchor="start" x="65.76" y="-827.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-798 53.5,-820 186.5,-820 186.5,-798 53.5,-798"/>
+<text text-anchor="start" x="75.87" y="-805.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-776 53.5,-798 186.5,-798 186.5,-776 53.5,-776"/>
+<text text-anchor="start" x="82.87" y="-783.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-754 53.5,-776 186.5,-776 186.5,-754 53.5,-754"/>
+<text text-anchor="start" x="70.05" y="-761.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-732 53.5,-754 186.5,-754 186.5,-732 53.5,-732"/>
+<text text-anchor="start" x="77.43" y="-739.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-710 53.5,-732 186.5,-732 186.5,-710 53.5,-710"/>
+<text text-anchor="start" x="69.65" y="-717.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-688 53.5,-710 186.5,-710 186.5,-688 53.5,-688"/>
+<polygon fill="none" stroke="black" points="53.5,-688 53.5,-710 186.5,-710 186.5,-688 53.5,-688"/>
+<text text-anchor="start" x="99.79" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-666 53.5,-688 186.5,-688 186.5,-666 53.5,-666"/>
+<text text-anchor="start" x="56.25" y="-672.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<polygon fill="none" stroke="black" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<text text-anchor="start" x="830.34" y="-907.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="781.32,-878 781.32,-900 970.32,-900 970.32,-878 781.32,-878"/>
+<text text-anchor="start" x="836.75" y="-885.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-885.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<text text-anchor="start" x="818.47" y="-863.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-834 781.32,-856 970.32,-856 970.32,-834 781.32,-834"/>
+<text text-anchor="start" x="817.7" y="-841.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="898.17" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="781.32,-812 781.32,-834 970.32,-834 970.32,-812 781.32,-812"/>
+<polygon fill="none" stroke="black" points="781.32,-812 781.32,-834 970.32,-834 970.32,-812 781.32,-812"/>
+<text text-anchor="start" x="855.61" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="781.32,-790 781.32,-812 970.32,-812 970.32,-790 781.32,-790"/>
+<text text-anchor="start" x="784.07" y="-796.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M971.32,-867C1075.14,-867 1040.16,-709.97 1134.77,-699.54"/>
+<polygon fill="black" stroke="black" points="1135.18,-703.03 1144.98,-699 1134.81,-696.04 1135.18,-703.03"/>
+<text text-anchor="middle" x="1063.65" y="-792.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<polygon fill="none" stroke="black" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<text text-anchor="start" x="827.22" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<text text-anchor="start" x="836.75" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-717.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-688 778.32,-710 973.32,-710 973.32,-688 778.32,-688"/>
+<text text-anchor="start" x="818.47" y="-695.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-666 778.32,-688 973.32,-688 973.32,-666 778.32,-666"/>
+<text text-anchor="start" x="811.09" y="-673.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="904.79" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="778.32,-644 778.32,-666 973.32,-666 973.32,-644 778.32,-644"/>
+<polygon fill="none" stroke="black" points="778.32,-644 778.32,-666 973.32,-666 973.32,-644 778.32,-644"/>
+<text text-anchor="start" x="855.61" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="778.32,-622 778.32,-644 973.32,-644 973.32,-622 778.32,-622"/>
+<text text-anchor="start" x="780.95" y="-628.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M974.32,-699C1046.61,-699 1067.23,-699 1134.68,-699"/>
+<polygon fill="black" stroke="black" points="1134.98,-702.5 1144.98,-699 1134.98,-695.5 1134.98,-702.5"/>
+<text text-anchor="middle" x="1063.65" y="-704.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<polygon fill="none" stroke="black" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<text text-anchor="start" x="854.44" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="780.32,-542 780.32,-564 971.32,-564 971.32,-542 780.32,-542"/>
+<text text-anchor="start" x="836.75" y="-549.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-549.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-520 780.32,-542 971.32,-542 971.32,-520 780.32,-520"/>
+<text text-anchor="start" x="818.47" y="-527.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-498 780.32,-520 971.32,-520 971.32,-498 780.32,-498"/>
+<text text-anchor="start" x="820.42" y="-505.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="871.36" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-476 780.32,-498 971.32,-498 971.32,-476 780.32,-476"/>
+<text text-anchor="start" x="818.86" y="-483.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="872.92" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-454 780.32,-476 971.32,-476 971.32,-454 780.32,-454"/>
+<text text-anchor="start" x="843.36" y="-461.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="872.52" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-432 780.32,-454 971.32,-454 971.32,-432 780.32,-432"/>
+<text text-anchor="start" x="828.2" y="-439.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="887.68" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-410 780.32,-432 971.32,-432 971.32,-410 780.32,-410"/>
+<text text-anchor="start" x="820.81" y="-417.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="870.97" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-388 780.32,-410 971.32,-410 971.32,-388 780.32,-388"/>
+<text text-anchor="start" x="831.31" y="-395.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="884.57" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-366 780.32,-388 971.32,-388 971.32,-366 780.32,-366"/>
+<text text-anchor="start" x="816.53" y="-373.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="875.24" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-344 780.32,-366 971.32,-366 971.32,-344 780.32,-344"/>
+<text text-anchor="start" x="818.09" y="-351.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="873.68" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-322 780.32,-344 971.32,-344 971.32,-322 780.32,-322"/>
+<text text-anchor="start" x="821.2" y="-329.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="893.9" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="780.32,-300 780.32,-322 971.32,-322 971.32,-300 780.32,-300"/>
+<text text-anchor="start" x="811.09" y="-307.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="880.69" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-278 780.32,-300 971.32,-300 971.32,-278 780.32,-278"/>
+<text text-anchor="start" x="803.7" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="912.18" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-256 780.32,-278 971.32,-278 971.32,-256 780.32,-256"/>
+<text text-anchor="start" x="794.76" y="-263.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="921.12" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<polygon fill="none" stroke="black" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<text text-anchor="start" x="855.61" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="780.32,-212 780.32,-234 971.32,-234 971.32,-212 780.32,-212"/>
+<text text-anchor="start" x="783.28" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M972.32,-531C1022.61,-531 1083.55,-679.27 1135.13,-697.23"/>
+<polygon fill="black" stroke="black" points="1134.52,-700.67 1144.98,-699 1135.76,-693.78 1134.52,-700.67"/>
+<text text-anchor="middle" x="1063.65" y="-639.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<polygon fill="none" stroke="black" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<text text-anchor="start" x="479.56" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="401.66,-564 401.66,-586 605.66,-586 605.66,-564 401.66,-564"/>
+<text text-anchor="start" x="464.59" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="482.87" y="-571.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-542 401.66,-564 605.66,-564 605.66,-542 401.66,-542"/>
+<text text-anchor="start" x="442.43" y="-549.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="505.03" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-520 401.66,-542 605.66,-542 605.66,-520 401.66,-520"/>
+<text text-anchor="start" x="448.26" y="-527.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="499.2" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-498 401.66,-520 605.66,-520 605.66,-498 401.66,-498"/>
+<text text-anchor="start" x="446.7" y="-505.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="500.76" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-476 401.66,-498 605.66,-498 605.66,-476 401.66,-476"/>
+<text text-anchor="start" x="471.19" y="-483.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="500.36" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-454 401.66,-476 605.66,-476 605.66,-454 401.66,-454"/>
+<text text-anchor="start" x="456.04" y="-461.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="515.52" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-432 401.66,-454 605.66,-454 605.66,-432 401.66,-432"/>
+<text text-anchor="start" x="448.65" y="-439.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="498.8" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-410 401.66,-432 605.66,-432 605.66,-410 401.66,-410"/>
+<text text-anchor="start" x="453.32" y="-417.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="518.24" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-388 401.66,-410 605.66,-410 605.66,-388 401.66,-388"/>
+<text text-anchor="start" x="449.03" y="-395.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="521.74" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="401.66,-366 401.66,-388 605.66,-388 605.66,-366 401.66,-366"/>
+<text text-anchor="start" x="419.1" y="-373.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="528.35" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-344 401.66,-366 605.66,-366 605.66,-344 401.66,-344"/>
+<text text-anchor="start" x="422.59" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="548.96" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<polygon fill="none" stroke="black" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<text text-anchor="start" x="483.45" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<text text-anchor="start" x="404.52" y="-306.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M605.66,-553C679.38,-553 700.29,-553 769.26,-553"/>
+<polygon fill="black" stroke="black" points="769.32,-556.5 779.32,-553 769.32,-549.5 769.32,-556.5"/>
+<text text-anchor="middle" x="686.99" y="-557.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<polygon fill="none" stroke="black" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<text text-anchor="start" x="835.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="768.32,-132 768.32,-154 982.32,-154 982.32,-132 768.32,-132"/>
+<text text-anchor="start" x="836.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="854.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-110 768.32,-132 982.32,-132 982.32,-110 768.32,-110"/>
+<text text-anchor="start" x="817.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="872.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-88 768.32,-110 982.32,-110 982.32,-88 768.32,-88"/>
+<text text-anchor="start" x="800.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="890.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-66 768.32,-88 982.32,-88 982.32,-66 768.32,-66"/>
+<text text-anchor="start" x="807.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="882.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<polygon fill="none" stroke="black" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<text text-anchor="start" x="855.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="768.32,-22 768.32,-44 982.32,-44 982.32,-22 768.32,-22"/>
+<text text-anchor="start" x="789.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="768.32,0 768.32,-22 982.32,-22 982.32,0 768.32,0"/>
+<text text-anchor="start" x="771.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-99C1106.04,-99 1039.84,-243 1072.98,-362.2 1092.52,-432.48 1070.69,-674.75 1134.87,-697.31"/>
+<polygon fill="black" stroke="black" points="1134.54,-700.81 1144.98,-699 1135.69,-693.9 1134.54,-700.81"/>
+<text text-anchor="middle" x="1063.65" y="-367.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-121C1103.51,-121 1021.56,-267.32 1054.32,-384 1073.05,-450.71 1072.27,-675.5 1134.83,-697.3"/>
+<polygon fill="black" stroke="black" points="1134.54,-700.8 1144.98,-699 1135.7,-693.89 1134.54,-700.8"/>
+<text text-anchor="middle" x="1063.65" y="-521.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node10" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="56.25" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="80.93" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-593.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="56.04" y="-571.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="64.6" y="-549.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="66.55" y="-527.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="55.26" y="-505.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<polygon fill="none" stroke="black" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<text text-anchor="start" x="99.79" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-454 0.5,-476 239.5,-476 239.5,-454 0.5,-454"/>
+<text text-anchor="start" x="3.37" y="-460.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-432 0.5,-454 239.5,-454 239.5,-432 0.5,-432"/>
+<text text-anchor="start" x="11.92" y="-438.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-575C307.76,-575 327.47,-575 391.45,-575"/>
+<polygon fill="black" stroke="black" points="391.66,-578.5 401.66,-575 391.66,-571.5 391.66,-578.5"/>
+<text text-anchor="middle" x="320.33" y="-579.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node11" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1098 9.5,-1120 229.5,-1120 229.5,-1098 9.5,-1098"/>
+<polygon fill="none" stroke="black" points="9.5,-1098 9.5,-1120 229.5,-1120 229.5,-1098 9.5,-1098"/>
+<text text-anchor="start" x="83.34" y="-1105.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1076 9.5,-1098 229.5,-1098 229.5,-1076 9.5,-1076"/>
+<text text-anchor="start" x="80.43" y="-1083.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1083.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1054 9.5,-1076 229.5,-1076 229.5,-1054 9.5,-1054"/>
+<text text-anchor="start" x="77.71" y="-1061.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1061.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1032 9.5,-1054 229.5,-1054 229.5,-1032 9.5,-1032"/>
+<text text-anchor="start" x="60.98" y="-1039.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1039.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1010 9.5,-1032 229.5,-1032 229.5,-1010 9.5,-1010"/>
+<text text-anchor="start" x="56.71" y="-1017.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1017.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-988 9.5,-1010 229.5,-1010 229.5,-988 9.5,-988"/>
+<polygon fill="none" stroke="black" points="9.5,-988 9.5,-1010 229.5,-1010 229.5,-988 9.5,-988"/>
+<text text-anchor="start" x="99.29" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-966 9.5,-988 229.5,-988 229.5,-966 9.5,-966"/>
+<text text-anchor="start" x="12.19" y="-972.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/12.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/12.svg
@@ -1,0 +1,441 @@
+<svg width="1385px" height="1374px"
+ viewBox="0.00 0.00 1384.98 1374.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1338)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1338 1348.98,-1338 1348.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1144.98,-710 1144.98,-732 1312.98,-732 1312.98,-710 1144.98,-710"/>
+<polygon fill="none" stroke="black" points="1144.98,-710 1144.98,-732 1312.98,-732 1312.98,-710 1144.98,-710"/>
+<text text-anchor="start" x="1211.48" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1144.98,-688 1144.98,-710 1312.98,-710 1312.98,-688 1144.98,-688"/>
+<text text-anchor="start" x="1189.91" y="-695.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1208.19" y="-695.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-666 1144.98,-688 1312.98,-688 1312.98,-666 1144.98,-666"/>
+<text text-anchor="start" x="1196.52" y="-673.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1225.68" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-644 1144.98,-666 1312.98,-666 1312.98,-644 1144.98,-644"/>
+<text text-anchor="start" x="1171.24" y="-651.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1250.96" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-622 1144.98,-644 1312.98,-644 1312.98,-622 1144.98,-622"/>
+<text text-anchor="start" x="1173.58" y="-629.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1224.52" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-600 1144.98,-622 1312.98,-622 1312.98,-600 1144.98,-600"/>
+<text text-anchor="start" x="1172.02" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1226.08" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-578 1144.98,-600 1312.98,-600 1312.98,-578 1144.98,-578"/>
+<text text-anchor="start" x="1184.07" y="-585.4" font-family="Times,serif" font-size="14.00">imdb_id: </text>
+<text text-anchor="start" x="1238.13" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-556 1144.98,-578 1312.98,-578 1312.98,-556 1144.98,-556"/>
+<text text-anchor="start" x="1156.86" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1265.34" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-534 1144.98,-556 1312.98,-556 1312.98,-534 1144.98,-534"/>
+<text text-anchor="start" x="1147.92" y="-541.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1274.28" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-512 1144.98,-534 1312.98,-534 1312.98,-512 1144.98,-512"/>
+<text text-anchor="start" x="1181.36" y="-519.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1240.84" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-490 1144.98,-512 1312.98,-512 1312.98,-490 1144.98,-490"/>
+<text text-anchor="start" x="1178.64" y="-497.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1243.56" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-468 1144.98,-490 1312.98,-490 1312.98,-468 1144.98,-468"/>
+<text text-anchor="start" x="1174.36" y="-475.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1247.06" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1144.98,-446 1144.98,-468 1312.98,-468 1312.98,-446 1144.98,-446"/>
+<text text-anchor="start" x="1173.59" y="-453.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1248.61" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-424 1144.98,-446 1312.98,-446 1312.98,-424 1144.98,-424"/>
+<text text-anchor="start" x="1178.64" y="-431.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1243.56" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-402 1144.98,-424 1312.98,-424 1312.98,-402 1144.98,-402"/>
+<text text-anchor="start" x="1186.02" y="-409.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1236.18" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-380 1144.98,-402 1312.98,-402 1312.98,-380 1144.98,-380"/>
+<text text-anchor="start" x="1184.47" y="-387.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1237.73" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<text text-anchor="start" x="1173.58" y="-365.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1224.52" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<text text-anchor="start" x="1189.14" y="-343.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1233.06" y="-343.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1144.98,-314 1144.98,-336 1312.98,-336 1312.98,-314 1144.98,-314"/>
+<polygon fill="none" stroke="black" points="1144.98,-314 1144.98,-336 1312.98,-336 1312.98,-314 1144.98,-314"/>
+<text text-anchor="start" x="1208.77" y="-321.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1144.98,-292 1144.98,-314 1312.98,-314 1312.98,-292 1144.98,-292"/>
+<text text-anchor="start" x="1167.16" y="-298.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1144.98,-270 1144.98,-292 1312.98,-292 1312.98,-270 1144.98,-270"/>
+<text text-anchor="start" x="1165.6" y="-276.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<polygon fill="none" stroke="black" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<text text-anchor="start" x="831.5" y="-1287.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="782.32,-1258 782.32,-1280 969.32,-1280 969.32,-1258 782.32,-1258"/>
+<text text-anchor="start" x="836.75" y="-1265.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1265.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1236 782.32,-1258 969.32,-1258 969.32,-1236 782.32,-1236"/>
+<text text-anchor="start" x="818.47" y="-1243.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<text text-anchor="start" x="828.98" y="-1221.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1192 782.32,-1214 969.32,-1214 969.32,-1192 782.32,-1192"/>
+<text text-anchor="start" x="817.32" y="-1199.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="874.46" y="-1199.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="782.32,-1170 782.32,-1192 969.32,-1192 969.32,-1170 782.32,-1170"/>
+<polygon fill="none" stroke="black" points="782.32,-1170 782.32,-1192 969.32,-1192 969.32,-1170 782.32,-1170"/>
+<text text-anchor="start" x="855.61" y="-1177.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="782.32,-1148 782.32,-1170 969.32,-1170 969.32,-1148 782.32,-1148"/>
+<text text-anchor="start" x="785.22" y="-1154.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M970.32,-1247C1000.15,-1247 1098.67,-769.36 1137.62,-705.93"/>
+<polygon fill="black" stroke="black" points="1140.1,-708.4 1144.98,-699 1135.3,-703.3 1140.1,-708.4"/>
+<text text-anchor="middle" x="1063.65" y="-977.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<polygon fill="none" stroke="black" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<text text-anchor="start" x="833.44" y="-1097.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="784.32,-1068 784.32,-1090 967.32,-1090 967.32,-1068 784.32,-1068"/>
+<text text-anchor="start" x="836.75" y="-1075.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1075.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1046 784.32,-1068 967.32,-1068 967.32,-1046 784.32,-1046"/>
+<text text-anchor="start" x="818.47" y="-1053.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<text text-anchor="start" x="828.98" y="-1031.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1002 784.32,-1024 967.32,-1024 967.32,-1002 784.32,-1002"/>
+<text text-anchor="start" x="810.71" y="-1009.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="881.06" y="-1009.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="784.32,-980 784.32,-1002 967.32,-1002 967.32,-980 784.32,-980"/>
+<polygon fill="none" stroke="black" points="784.32,-980 784.32,-1002 967.32,-1002 967.32,-980 784.32,-980"/>
+<text text-anchor="start" x="855.61" y="-987.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="784.32,-958 784.32,-980 967.32,-980 967.32,-958 784.32,-958"/>
+<text text-anchor="start" x="787.17" y="-964.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M968.32,-1057C1053.57,-1057 1056.19,-726.42 1134.98,-700.6"/>
+<polygon fill="black" stroke="black" points="1135.66,-704.03 1144.98,-699 1134.56,-697.12 1135.66,-704.03"/>
+<text text-anchor="middle" x="1063.65" y="-882.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-908 53.5,-930 186.5,-930 186.5,-908 53.5,-908"/>
+<polygon fill="none" stroke="black" points="53.5,-908 53.5,-930 186.5,-930 186.5,-908 53.5,-908"/>
+<text text-anchor="start" x="105.62" y="-915.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-886 53.5,-908 186.5,-908 186.5,-886 53.5,-886"/>
+<text text-anchor="start" x="80.93" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-893.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-864 53.5,-886 186.5,-886 186.5,-864 53.5,-864"/>
+<text text-anchor="start" x="71.6" y="-871.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-871.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-842 53.5,-864 186.5,-864 186.5,-842 53.5,-842"/>
+<text text-anchor="start" x="83.26" y="-849.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-820 53.5,-842 186.5,-842 186.5,-820 53.5,-820"/>
+<text text-anchor="start" x="65.76" y="-827.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-798 53.5,-820 186.5,-820 186.5,-798 53.5,-798"/>
+<text text-anchor="start" x="75.87" y="-805.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-776 53.5,-798 186.5,-798 186.5,-776 53.5,-776"/>
+<text text-anchor="start" x="82.87" y="-783.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-754 53.5,-776 186.5,-776 186.5,-754 53.5,-754"/>
+<text text-anchor="start" x="70.05" y="-761.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-732 53.5,-754 186.5,-754 186.5,-732 53.5,-732"/>
+<text text-anchor="start" x="77.43" y="-739.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-710 53.5,-732 186.5,-732 186.5,-710 53.5,-710"/>
+<text text-anchor="start" x="69.65" y="-717.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-688 53.5,-710 186.5,-710 186.5,-688 53.5,-688"/>
+<polygon fill="none" stroke="black" points="53.5,-688 53.5,-710 186.5,-710 186.5,-688 53.5,-688"/>
+<text text-anchor="start" x="99.79" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-666 53.5,-688 186.5,-688 186.5,-666 53.5,-666"/>
+<text text-anchor="start" x="56.25" y="-672.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<polygon fill="none" stroke="black" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<text text-anchor="start" x="830.34" y="-907.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="781.32,-878 781.32,-900 970.32,-900 970.32,-878 781.32,-878"/>
+<text text-anchor="start" x="836.75" y="-885.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-885.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<text text-anchor="start" x="818.47" y="-863.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-834 781.32,-856 970.32,-856 970.32,-834 781.32,-834"/>
+<text text-anchor="start" x="817.7" y="-841.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="898.17" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="781.32,-812 781.32,-834 970.32,-834 970.32,-812 781.32,-812"/>
+<polygon fill="none" stroke="black" points="781.32,-812 781.32,-834 970.32,-834 970.32,-812 781.32,-812"/>
+<text text-anchor="start" x="855.61" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="781.32,-790 781.32,-812 970.32,-812 970.32,-790 781.32,-790"/>
+<text text-anchor="start" x="784.07" y="-796.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M971.32,-867C1075.14,-867 1040.16,-709.97 1134.77,-699.54"/>
+<polygon fill="black" stroke="black" points="1135.18,-703.03 1144.98,-699 1134.81,-696.04 1135.18,-703.03"/>
+<text text-anchor="middle" x="1063.65" y="-792.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<polygon fill="none" stroke="black" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<text text-anchor="start" x="827.22" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<text text-anchor="start" x="836.75" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-717.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-688 778.32,-710 973.32,-710 973.32,-688 778.32,-688"/>
+<text text-anchor="start" x="818.47" y="-695.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-666 778.32,-688 973.32,-688 973.32,-666 778.32,-666"/>
+<text text-anchor="start" x="811.09" y="-673.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="904.79" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="778.32,-644 778.32,-666 973.32,-666 973.32,-644 778.32,-644"/>
+<polygon fill="none" stroke="black" points="778.32,-644 778.32,-666 973.32,-666 973.32,-644 778.32,-644"/>
+<text text-anchor="start" x="855.61" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="778.32,-622 778.32,-644 973.32,-644 973.32,-622 778.32,-622"/>
+<text text-anchor="start" x="780.95" y="-628.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M974.32,-699C1046.61,-699 1067.23,-699 1134.68,-699"/>
+<polygon fill="black" stroke="black" points="1134.98,-702.5 1144.98,-699 1134.98,-695.5 1134.98,-702.5"/>
+<text text-anchor="middle" x="1063.65" y="-704.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<polygon fill="none" stroke="black" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<text text-anchor="start" x="854.44" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="780.32,-542 780.32,-564 971.32,-564 971.32,-542 780.32,-542"/>
+<text text-anchor="start" x="836.75" y="-549.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-549.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-520 780.32,-542 971.32,-542 971.32,-520 780.32,-520"/>
+<text text-anchor="start" x="818.47" y="-527.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-498 780.32,-520 971.32,-520 971.32,-498 780.32,-498"/>
+<text text-anchor="start" x="820.42" y="-505.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="871.36" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-476 780.32,-498 971.32,-498 971.32,-476 780.32,-476"/>
+<text text-anchor="start" x="818.86" y="-483.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="872.92" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-454 780.32,-476 971.32,-476 971.32,-454 780.32,-454"/>
+<text text-anchor="start" x="843.36" y="-461.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="872.52" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-432 780.32,-454 971.32,-454 971.32,-432 780.32,-432"/>
+<text text-anchor="start" x="828.2" y="-439.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="887.68" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-410 780.32,-432 971.32,-432 971.32,-410 780.32,-410"/>
+<text text-anchor="start" x="820.81" y="-417.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="870.97" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-388 780.32,-410 971.32,-410 971.32,-388 780.32,-388"/>
+<text text-anchor="start" x="831.31" y="-395.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="884.57" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-366 780.32,-388 971.32,-388 971.32,-366 780.32,-366"/>
+<text text-anchor="start" x="816.53" y="-373.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="875.24" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-344 780.32,-366 971.32,-366 971.32,-344 780.32,-344"/>
+<text text-anchor="start" x="818.09" y="-351.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="873.68" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-322 780.32,-344 971.32,-344 971.32,-322 780.32,-322"/>
+<text text-anchor="start" x="821.2" y="-329.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="893.9" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="780.32,-300 780.32,-322 971.32,-322 971.32,-300 780.32,-300"/>
+<text text-anchor="start" x="811.09" y="-307.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="880.69" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-278 780.32,-300 971.32,-300 971.32,-278 780.32,-278"/>
+<text text-anchor="start" x="803.7" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="912.18" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-256 780.32,-278 971.32,-278 971.32,-256 780.32,-256"/>
+<text text-anchor="start" x="794.76" y="-263.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="921.12" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<polygon fill="none" stroke="black" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<text text-anchor="start" x="855.61" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="780.32,-212 780.32,-234 971.32,-234 971.32,-212 780.32,-212"/>
+<text text-anchor="start" x="783.28" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M972.32,-531C1022.61,-531 1083.55,-679.27 1135.13,-697.23"/>
+<polygon fill="black" stroke="black" points="1134.52,-700.67 1144.98,-699 1135.76,-693.78 1134.52,-700.67"/>
+<text text-anchor="middle" x="1063.65" y="-639.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<polygon fill="none" stroke="black" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<text text-anchor="start" x="479.56" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="401.66,-564 401.66,-586 605.66,-586 605.66,-564 401.66,-564"/>
+<text text-anchor="start" x="464.59" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="482.87" y="-571.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-542 401.66,-564 605.66,-564 605.66,-542 401.66,-542"/>
+<text text-anchor="start" x="442.43" y="-549.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="505.03" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-520 401.66,-542 605.66,-542 605.66,-520 401.66,-520"/>
+<text text-anchor="start" x="448.26" y="-527.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="499.2" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-498 401.66,-520 605.66,-520 605.66,-498 401.66,-498"/>
+<text text-anchor="start" x="446.7" y="-505.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="500.76" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-476 401.66,-498 605.66,-498 605.66,-476 401.66,-476"/>
+<text text-anchor="start" x="471.19" y="-483.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="500.36" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-454 401.66,-476 605.66,-476 605.66,-454 401.66,-454"/>
+<text text-anchor="start" x="456.04" y="-461.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="515.52" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-432 401.66,-454 605.66,-454 605.66,-432 401.66,-432"/>
+<text text-anchor="start" x="448.65" y="-439.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="498.8" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-410 401.66,-432 605.66,-432 605.66,-410 401.66,-410"/>
+<text text-anchor="start" x="453.32" y="-417.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="518.24" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-388 401.66,-410 605.66,-410 605.66,-388 401.66,-388"/>
+<text text-anchor="start" x="449.03" y="-395.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="521.74" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="401.66,-366 401.66,-388 605.66,-388 605.66,-366 401.66,-366"/>
+<text text-anchor="start" x="419.1" y="-373.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="528.35" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-344 401.66,-366 605.66,-366 605.66,-344 401.66,-344"/>
+<text text-anchor="start" x="422.59" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="548.96" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<polygon fill="none" stroke="black" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<text text-anchor="start" x="483.45" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<text text-anchor="start" x="404.52" y="-306.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M605.66,-553C679.38,-553 700.29,-553 769.26,-553"/>
+<polygon fill="black" stroke="black" points="769.32,-556.5 779.32,-553 769.32,-549.5 769.32,-556.5"/>
+<text text-anchor="middle" x="686.99" y="-557.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<polygon fill="none" stroke="black" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<text text-anchor="start" x="835.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="768.32,-132 768.32,-154 982.32,-154 982.32,-132 768.32,-132"/>
+<text text-anchor="start" x="836.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="854.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-110 768.32,-132 982.32,-132 982.32,-110 768.32,-110"/>
+<text text-anchor="start" x="817.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="872.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-88 768.32,-110 982.32,-110 982.32,-88 768.32,-88"/>
+<text text-anchor="start" x="800.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="890.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-66 768.32,-88 982.32,-88 982.32,-66 768.32,-66"/>
+<text text-anchor="start" x="807.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="882.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<polygon fill="none" stroke="black" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<text text-anchor="start" x="855.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="768.32,-22 768.32,-44 982.32,-44 982.32,-22 768.32,-22"/>
+<text text-anchor="start" x="789.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="768.32,0 768.32,-22 982.32,-22 982.32,0 768.32,0"/>
+<text text-anchor="start" x="771.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-99C1106.04,-99 1039.84,-243 1072.98,-362.2 1092.52,-432.48 1070.69,-674.75 1134.87,-697.31"/>
+<polygon fill="black" stroke="black" points="1134.54,-700.81 1144.98,-699 1135.69,-693.9 1134.54,-700.81"/>
+<text text-anchor="middle" x="1063.65" y="-367.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-121C1103.51,-121 1021.56,-267.32 1054.32,-384 1073.05,-450.71 1072.27,-675.5 1134.83,-697.3"/>
+<polygon fill="black" stroke="black" points="1134.54,-700.8 1144.98,-699 1135.7,-693.89 1134.54,-700.8"/>
+<text text-anchor="middle" x="1063.65" y="-521.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node10" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="56.25" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="80.93" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-593.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="56.04" y="-571.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="64.6" y="-549.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="66.55" y="-527.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="55.26" y="-505.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<polygon fill="none" stroke="black" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<text text-anchor="start" x="99.79" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-454 0.5,-476 239.5,-476 239.5,-454 0.5,-454"/>
+<text text-anchor="start" x="3.37" y="-460.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-432 0.5,-454 239.5,-454 239.5,-432 0.5,-432"/>
+<text text-anchor="start" x="11.92" y="-438.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-575C307.76,-575 327.47,-575 391.45,-575"/>
+<polygon fill="black" stroke="black" points="391.66,-578.5 401.66,-575 391.66,-571.5 391.66,-578.5"/>
+<text text-anchor="middle" x="320.33" y="-579.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node11" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1098 9.5,-1120 229.5,-1120 229.5,-1098 9.5,-1098"/>
+<polygon fill="none" stroke="black" points="9.5,-1098 9.5,-1120 229.5,-1120 229.5,-1098 9.5,-1098"/>
+<text text-anchor="start" x="83.34" y="-1105.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1076 9.5,-1098 229.5,-1098 229.5,-1076 9.5,-1076"/>
+<text text-anchor="start" x="80.43" y="-1083.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1083.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1054 9.5,-1076 229.5,-1076 229.5,-1054 9.5,-1054"/>
+<text text-anchor="start" x="77.71" y="-1061.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1061.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1032 9.5,-1054 229.5,-1054 229.5,-1032 9.5,-1032"/>
+<text text-anchor="start" x="60.98" y="-1039.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1039.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1010 9.5,-1032 229.5,-1032 229.5,-1010 9.5,-1010"/>
+<text text-anchor="start" x="56.71" y="-1017.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1017.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-988 9.5,-1010 229.5,-1010 229.5,-988 9.5,-988"/>
+<polygon fill="none" stroke="black" points="9.5,-988 9.5,-1010 229.5,-1010 229.5,-988 9.5,-988"/>
+<text text-anchor="start" x="99.29" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-966 9.5,-988 229.5,-988 229.5,-966 9.5,-966"/>
+<text text-anchor="start" x="12.19" y="-972.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/13.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/13.svg
@@ -1,0 +1,444 @@
+<svg width="1385px" height="1396px"
+ viewBox="0.00 0.00 1384.98 1396.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1360)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1360 1348.98,-1360 1348.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1144.98,-732 1144.98,-754 1312.98,-754 1312.98,-732 1144.98,-732"/>
+<polygon fill="none" stroke="black" points="1144.98,-732 1144.98,-754 1312.98,-754 1312.98,-732 1144.98,-732"/>
+<text text-anchor="start" x="1211.48" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1144.98,-710 1144.98,-732 1312.98,-732 1312.98,-710 1144.98,-710"/>
+<text text-anchor="start" x="1189.91" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1208.19" y="-717.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-688 1144.98,-710 1312.98,-710 1312.98,-688 1144.98,-688"/>
+<text text-anchor="start" x="1196.52" y="-695.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1225.68" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-666 1144.98,-688 1312.98,-688 1312.98,-666 1144.98,-666"/>
+<text text-anchor="start" x="1171.24" y="-673.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1250.96" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-644 1144.98,-666 1312.98,-666 1312.98,-644 1144.98,-644"/>
+<text text-anchor="start" x="1173.58" y="-651.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1224.52" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-622 1144.98,-644 1312.98,-644 1312.98,-622 1144.98,-622"/>
+<text text-anchor="start" x="1172.02" y="-629.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1226.08" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-600 1144.98,-622 1312.98,-622 1312.98,-600 1144.98,-600"/>
+<text text-anchor="start" x="1184.07" y="-607.4" font-family="Times,serif" font-size="14.00">imdb_id: </text>
+<text text-anchor="start" x="1238.13" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-578 1144.98,-600 1312.98,-600 1312.98,-578 1144.98,-578"/>
+<text text-anchor="start" x="1156.86" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1265.34" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-556 1144.98,-578 1312.98,-578 1312.98,-556 1144.98,-556"/>
+<text text-anchor="start" x="1147.92" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1274.28" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-534 1144.98,-556 1312.98,-556 1312.98,-534 1144.98,-534"/>
+<text text-anchor="start" x="1181.36" y="-541.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1240.84" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-512 1144.98,-534 1312.98,-534 1312.98,-512 1144.98,-512"/>
+<text text-anchor="start" x="1178.64" y="-519.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1243.56" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-490 1144.98,-512 1312.98,-512 1312.98,-490 1144.98,-490"/>
+<text text-anchor="start" x="1174.36" y="-497.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1247.06" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1144.98,-468 1144.98,-490 1312.98,-490 1312.98,-468 1144.98,-468"/>
+<text text-anchor="start" x="1173.59" y="-475.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1248.61" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-446 1144.98,-468 1312.98,-468 1312.98,-446 1144.98,-446"/>
+<text text-anchor="start" x="1178.64" y="-453.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1243.56" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-424 1144.98,-446 1312.98,-446 1312.98,-424 1144.98,-424"/>
+<text text-anchor="start" x="1186.02" y="-431.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1236.18" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-402 1144.98,-424 1312.98,-424 1312.98,-402 1144.98,-402"/>
+<text text-anchor="start" x="1184.47" y="-409.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1237.73" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-380 1144.98,-402 1312.98,-402 1312.98,-380 1144.98,-380"/>
+<text text-anchor="start" x="1173.58" y="-387.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1224.52" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<text text-anchor="start" x="1189.14" y="-365.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1233.06" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<polygon fill="none" stroke="black" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<text text-anchor="start" x="1208.77" y="-343.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1144.98,-314 1144.98,-336 1312.98,-336 1312.98,-314 1144.98,-314"/>
+<text text-anchor="start" x="1167.16" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1144.98,-292 1144.98,-314 1312.98,-314 1312.98,-292 1144.98,-292"/>
+<text text-anchor="start" x="1165.6" y="-298.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="782.32,-1302 782.32,-1324 969.32,-1324 969.32,-1302 782.32,-1302"/>
+<polygon fill="none" stroke="black" points="782.32,-1302 782.32,-1324 969.32,-1324 969.32,-1302 782.32,-1302"/>
+<text text-anchor="start" x="831.5" y="-1309.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<text text-anchor="start" x="836.75" y="-1287.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1287.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1258 782.32,-1280 969.32,-1280 969.32,-1258 782.32,-1258"/>
+<text text-anchor="start" x="818.47" y="-1265.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1236 782.32,-1258 969.32,-1258 969.32,-1236 782.32,-1236"/>
+<text text-anchor="start" x="828.98" y="-1243.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<text text-anchor="start" x="817.32" y="-1221.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="874.46" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="782.32,-1192 782.32,-1214 969.32,-1214 969.32,-1192 782.32,-1192"/>
+<polygon fill="none" stroke="black" points="782.32,-1192 782.32,-1214 969.32,-1214 969.32,-1192 782.32,-1192"/>
+<text text-anchor="start" x="855.61" y="-1199.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="782.32,-1170 782.32,-1192 969.32,-1192 969.32,-1170 782.32,-1170"/>
+<text text-anchor="start" x="785.22" y="-1176.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M970.32,-1269C1000.15,-1269 1098.67,-791.36 1137.62,-727.93"/>
+<polygon fill="black" stroke="black" points="1140.1,-730.4 1144.98,-721 1135.3,-725.3 1140.1,-730.4"/>
+<text text-anchor="middle" x="1063.65" y="-999.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="784.32,-1112 784.32,-1134 967.32,-1134 967.32,-1112 784.32,-1112"/>
+<polygon fill="none" stroke="black" points="784.32,-1112 784.32,-1134 967.32,-1134 967.32,-1112 784.32,-1112"/>
+<text text-anchor="start" x="833.44" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<text text-anchor="start" x="836.75" y="-1097.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1097.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1068 784.32,-1090 967.32,-1090 967.32,-1068 784.32,-1068"/>
+<text text-anchor="start" x="818.47" y="-1075.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1046 784.32,-1068 967.32,-1068 967.32,-1046 784.32,-1046"/>
+<text text-anchor="start" x="828.98" y="-1053.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<text text-anchor="start" x="810.71" y="-1031.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="881.06" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="784.32,-1002 784.32,-1024 967.32,-1024 967.32,-1002 784.32,-1002"/>
+<polygon fill="none" stroke="black" points="784.32,-1002 784.32,-1024 967.32,-1024 967.32,-1002 784.32,-1002"/>
+<text text-anchor="start" x="855.61" y="-1009.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="784.32,-980 784.32,-1002 967.32,-1002 967.32,-980 784.32,-980"/>
+<text text-anchor="start" x="787.17" y="-986.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M968.32,-1079C1053.57,-1079 1056.19,-748.42 1134.98,-722.6"/>
+<polygon fill="black" stroke="black" points="1135.66,-726.03 1144.98,-721 1134.56,-719.12 1135.66,-726.03"/>
+<text text-anchor="middle" x="1063.65" y="-904.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-908 53.5,-930 186.5,-930 186.5,-908 53.5,-908"/>
+<polygon fill="none" stroke="black" points="53.5,-908 53.5,-930 186.5,-930 186.5,-908 53.5,-908"/>
+<text text-anchor="start" x="105.62" y="-915.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-886 53.5,-908 186.5,-908 186.5,-886 53.5,-886"/>
+<text text-anchor="start" x="80.93" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-893.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-864 53.5,-886 186.5,-886 186.5,-864 53.5,-864"/>
+<text text-anchor="start" x="71.6" y="-871.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-871.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-842 53.5,-864 186.5,-864 186.5,-842 53.5,-842"/>
+<text text-anchor="start" x="83.26" y="-849.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-820 53.5,-842 186.5,-842 186.5,-820 53.5,-820"/>
+<text text-anchor="start" x="65.76" y="-827.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-798 53.5,-820 186.5,-820 186.5,-798 53.5,-798"/>
+<text text-anchor="start" x="75.87" y="-805.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-776 53.5,-798 186.5,-798 186.5,-776 53.5,-776"/>
+<text text-anchor="start" x="82.87" y="-783.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-754 53.5,-776 186.5,-776 186.5,-754 53.5,-754"/>
+<text text-anchor="start" x="70.05" y="-761.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-732 53.5,-754 186.5,-754 186.5,-732 53.5,-732"/>
+<text text-anchor="start" x="77.43" y="-739.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-710 53.5,-732 186.5,-732 186.5,-710 53.5,-710"/>
+<text text-anchor="start" x="69.65" y="-717.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-688 53.5,-710 186.5,-710 186.5,-688 53.5,-688"/>
+<polygon fill="none" stroke="black" points="53.5,-688 53.5,-710 186.5,-710 186.5,-688 53.5,-688"/>
+<text text-anchor="start" x="99.79" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-666 53.5,-688 186.5,-688 186.5,-666 53.5,-666"/>
+<text text-anchor="start" x="56.25" y="-672.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="781.32,-922 781.32,-944 970.32,-944 970.32,-922 781.32,-922"/>
+<polygon fill="none" stroke="black" points="781.32,-922 781.32,-944 970.32,-944 970.32,-922 781.32,-922"/>
+<text text-anchor="start" x="830.34" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<text text-anchor="start" x="836.75" y="-907.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-907.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-878 781.32,-900 970.32,-900 970.32,-878 781.32,-878"/>
+<text text-anchor="start" x="818.47" y="-885.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<text text-anchor="start" x="817.7" y="-863.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="898.17" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="781.32,-834 781.32,-856 970.32,-856 970.32,-834 781.32,-834"/>
+<polygon fill="none" stroke="black" points="781.32,-834 781.32,-856 970.32,-856 970.32,-834 781.32,-834"/>
+<text text-anchor="start" x="855.61" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="781.32,-812 781.32,-834 970.32,-834 970.32,-812 781.32,-812"/>
+<text text-anchor="start" x="784.07" y="-818.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M971.32,-889C1075.14,-889 1040.16,-731.97 1134.77,-721.54"/>
+<polygon fill="black" stroke="black" points="1135.18,-725.03 1144.98,-721 1134.81,-718.04 1135.18,-725.03"/>
+<text text-anchor="middle" x="1063.65" y="-814.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="778.32,-754 778.32,-776 973.32,-776 973.32,-754 778.32,-754"/>
+<polygon fill="none" stroke="black" points="778.32,-754 778.32,-776 973.32,-776 973.32,-754 778.32,-754"/>
+<text text-anchor="start" x="827.22" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<text text-anchor="start" x="836.75" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<text text-anchor="start" x="818.47" y="-717.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-688 778.32,-710 973.32,-710 973.32,-688 778.32,-688"/>
+<text text-anchor="start" x="820.81" y="-695.4" font-family="Times,serif" font-size="14.00">followed_at: </text>
+<text text-anchor="start" x="895.07" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="778.32,-666 778.32,-688 973.32,-688 973.32,-666 778.32,-666"/>
+<text text-anchor="start" x="811.09" y="-673.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="904.79" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="778.32,-644 778.32,-666 973.32,-666 973.32,-644 778.32,-644"/>
+<polygon fill="none" stroke="black" points="778.32,-644 778.32,-666 973.32,-666 973.32,-644 778.32,-644"/>
+<text text-anchor="start" x="855.61" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="778.32,-622 778.32,-644 973.32,-644 973.32,-622 778.32,-622"/>
+<text text-anchor="start" x="780.95" y="-628.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M974.32,-721C1046.61,-721 1067.23,-721 1134.68,-721"/>
+<polygon fill="black" stroke="black" points="1134.98,-724.5 1144.98,-721 1134.98,-717.5 1134.98,-724.5"/>
+<text text-anchor="middle" x="1063.65" y="-726.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<polygon fill="none" stroke="black" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<text text-anchor="start" x="854.44" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="780.32,-542 780.32,-564 971.32,-564 971.32,-542 780.32,-542"/>
+<text text-anchor="start" x="836.75" y="-549.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-549.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-520 780.32,-542 971.32,-542 971.32,-520 780.32,-520"/>
+<text text-anchor="start" x="818.47" y="-527.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-498 780.32,-520 971.32,-520 971.32,-498 780.32,-498"/>
+<text text-anchor="start" x="820.42" y="-505.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="871.36" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-476 780.32,-498 971.32,-498 971.32,-476 780.32,-476"/>
+<text text-anchor="start" x="818.86" y="-483.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="872.92" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-454 780.32,-476 971.32,-476 971.32,-454 780.32,-454"/>
+<text text-anchor="start" x="843.36" y="-461.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="872.52" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-432 780.32,-454 971.32,-454 971.32,-432 780.32,-432"/>
+<text text-anchor="start" x="828.2" y="-439.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="887.68" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-410 780.32,-432 971.32,-432 971.32,-410 780.32,-410"/>
+<text text-anchor="start" x="820.81" y="-417.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="870.97" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-388 780.32,-410 971.32,-410 971.32,-388 780.32,-388"/>
+<text text-anchor="start" x="831.31" y="-395.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="884.57" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-366 780.32,-388 971.32,-388 971.32,-366 780.32,-366"/>
+<text text-anchor="start" x="816.53" y="-373.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="875.24" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-344 780.32,-366 971.32,-366 971.32,-344 780.32,-344"/>
+<text text-anchor="start" x="818.09" y="-351.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="873.68" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-322 780.32,-344 971.32,-344 971.32,-322 780.32,-322"/>
+<text text-anchor="start" x="821.2" y="-329.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="893.9" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="780.32,-300 780.32,-322 971.32,-322 971.32,-300 780.32,-300"/>
+<text text-anchor="start" x="811.09" y="-307.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="880.69" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-278 780.32,-300 971.32,-300 971.32,-278 780.32,-278"/>
+<text text-anchor="start" x="803.7" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="912.18" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-256 780.32,-278 971.32,-278 971.32,-256 780.32,-256"/>
+<text text-anchor="start" x="794.76" y="-263.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="921.12" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<polygon fill="none" stroke="black" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<text text-anchor="start" x="855.61" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="780.32,-212 780.32,-234 971.32,-234 971.32,-212 780.32,-212"/>
+<text text-anchor="start" x="783.28" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M972.32,-531C1026.03,-531 1081.07,-699.39 1134.94,-719.12"/>
+<polygon fill="black" stroke="black" points="1134.51,-722.6 1144.98,-721 1135.8,-715.72 1134.51,-722.6"/>
+<text text-anchor="middle" x="1063.65" y="-653.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<polygon fill="none" stroke="black" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<text text-anchor="start" x="479.56" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="401.66,-564 401.66,-586 605.66,-586 605.66,-564 401.66,-564"/>
+<text text-anchor="start" x="464.59" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="482.87" y="-571.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-542 401.66,-564 605.66,-564 605.66,-542 401.66,-542"/>
+<text text-anchor="start" x="442.43" y="-549.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="505.03" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-520 401.66,-542 605.66,-542 605.66,-520 401.66,-520"/>
+<text text-anchor="start" x="448.26" y="-527.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="499.2" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-498 401.66,-520 605.66,-520 605.66,-498 401.66,-498"/>
+<text text-anchor="start" x="446.7" y="-505.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="500.76" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-476 401.66,-498 605.66,-498 605.66,-476 401.66,-476"/>
+<text text-anchor="start" x="471.19" y="-483.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="500.36" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-454 401.66,-476 605.66,-476 605.66,-454 401.66,-454"/>
+<text text-anchor="start" x="456.04" y="-461.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="515.52" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-432 401.66,-454 605.66,-454 605.66,-432 401.66,-432"/>
+<text text-anchor="start" x="448.65" y="-439.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="498.8" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-410 401.66,-432 605.66,-432 605.66,-410 401.66,-410"/>
+<text text-anchor="start" x="453.32" y="-417.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="518.24" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-388 401.66,-410 605.66,-410 605.66,-388 401.66,-388"/>
+<text text-anchor="start" x="449.03" y="-395.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="521.74" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="401.66,-366 401.66,-388 605.66,-388 605.66,-366 401.66,-366"/>
+<text text-anchor="start" x="419.1" y="-373.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="528.35" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-344 401.66,-366 605.66,-366 605.66,-344 401.66,-344"/>
+<text text-anchor="start" x="422.59" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="548.96" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<polygon fill="none" stroke="black" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<text text-anchor="start" x="483.45" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<text text-anchor="start" x="404.52" y="-306.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M605.66,-553C679.38,-553 700.29,-553 769.26,-553"/>
+<polygon fill="black" stroke="black" points="769.32,-556.5 779.32,-553 769.32,-549.5 769.32,-556.5"/>
+<text text-anchor="middle" x="686.99" y="-557.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<polygon fill="none" stroke="black" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<text text-anchor="start" x="835.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="768.32,-132 768.32,-154 982.32,-154 982.32,-132 768.32,-132"/>
+<text text-anchor="start" x="836.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="854.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-110 768.32,-132 982.32,-132 982.32,-110 768.32,-110"/>
+<text text-anchor="start" x="817.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="872.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-88 768.32,-110 982.32,-110 982.32,-88 768.32,-88"/>
+<text text-anchor="start" x="800.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="890.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-66 768.32,-88 982.32,-88 982.32,-66 768.32,-66"/>
+<text text-anchor="start" x="807.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="882.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<polygon fill="none" stroke="black" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<text text-anchor="start" x="855.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="768.32,-22 768.32,-44 982.32,-44 982.32,-22 768.32,-22"/>
+<text text-anchor="start" x="789.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="768.32,0 768.32,-22 982.32,-22 982.32,0 768.32,0"/>
+<text text-anchor="start" x="771.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-99C1111.52,-99 1039.61,-250.38 1072.98,-375.2 1092.34,-447.62 1068.8,-697.14 1135.03,-719.41"/>
+<polygon fill="black" stroke="black" points="1134.55,-722.88 1144.98,-721 1135.66,-715.96 1134.55,-722.88"/>
+<text text-anchor="middle" x="1063.65" y="-380.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-121C1109.09,-121 1021.24,-274.62 1054.32,-397 1072.92,-465.79 1070.5,-697.79 1134.97,-719.38"/>
+<polygon fill="black" stroke="black" points="1134.55,-722.86 1144.98,-721 1135.67,-715.95 1134.55,-722.86"/>
+<text text-anchor="middle" x="1063.65" y="-538.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node10" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="56.25" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="80.93" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-593.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="56.04" y="-571.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="64.6" y="-549.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="66.55" y="-527.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="55.26" y="-505.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<polygon fill="none" stroke="black" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<text text-anchor="start" x="99.79" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-454 0.5,-476 239.5,-476 239.5,-454 0.5,-454"/>
+<text text-anchor="start" x="3.37" y="-460.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-432 0.5,-454 239.5,-454 239.5,-432 0.5,-432"/>
+<text text-anchor="start" x="11.92" y="-438.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-575C307.76,-575 327.47,-575 391.45,-575"/>
+<polygon fill="black" stroke="black" points="391.66,-578.5 401.66,-575 391.66,-571.5 391.66,-578.5"/>
+<text text-anchor="middle" x="320.33" y="-579.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node11" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1098 9.5,-1120 229.5,-1120 229.5,-1098 9.5,-1098"/>
+<polygon fill="none" stroke="black" points="9.5,-1098 9.5,-1120 229.5,-1120 229.5,-1098 9.5,-1098"/>
+<text text-anchor="start" x="83.34" y="-1105.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1076 9.5,-1098 229.5,-1098 229.5,-1076 9.5,-1076"/>
+<text text-anchor="start" x="80.43" y="-1083.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1083.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1054 9.5,-1076 229.5,-1076 229.5,-1054 9.5,-1054"/>
+<text text-anchor="start" x="77.71" y="-1061.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1061.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1032 9.5,-1054 229.5,-1054 229.5,-1032 9.5,-1032"/>
+<text text-anchor="start" x="60.98" y="-1039.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1039.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1010 9.5,-1032 229.5,-1032 229.5,-1010 9.5,-1010"/>
+<text text-anchor="start" x="56.71" y="-1017.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1017.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-988 9.5,-1010 229.5,-1010 229.5,-988 9.5,-988"/>
+<polygon fill="none" stroke="black" points="9.5,-988 9.5,-1010 229.5,-1010 229.5,-988 9.5,-988"/>
+<text text-anchor="start" x="99.29" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-966 9.5,-988 229.5,-988 229.5,-966 9.5,-966"/>
+<text text-anchor="start" x="12.19" y="-972.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/14.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/14.svg
@@ -1,0 +1,444 @@
+<svg width="1385px" height="1396px"
+ viewBox="0.00 0.00 1384.98 1396.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1360)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1360 1348.98,-1360 1348.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1144.98,-732 1144.98,-754 1312.98,-754 1312.98,-732 1144.98,-732"/>
+<polygon fill="none" stroke="black" points="1144.98,-732 1144.98,-754 1312.98,-754 1312.98,-732 1144.98,-732"/>
+<text text-anchor="start" x="1211.48" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1144.98,-710 1144.98,-732 1312.98,-732 1312.98,-710 1144.98,-710"/>
+<text text-anchor="start" x="1189.91" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1208.19" y="-717.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-688 1144.98,-710 1312.98,-710 1312.98,-688 1144.98,-688"/>
+<text text-anchor="start" x="1196.52" y="-695.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1225.68" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-666 1144.98,-688 1312.98,-688 1312.98,-666 1144.98,-666"/>
+<text text-anchor="start" x="1171.24" y="-673.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1250.96" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-644 1144.98,-666 1312.98,-666 1312.98,-644 1144.98,-644"/>
+<text text-anchor="start" x="1173.58" y="-651.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1224.52" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-622 1144.98,-644 1312.98,-644 1312.98,-622 1144.98,-622"/>
+<text text-anchor="start" x="1172.02" y="-629.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1226.08" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-600 1144.98,-622 1312.98,-622 1312.98,-600 1144.98,-600"/>
+<text text-anchor="start" x="1184.07" y="-607.4" font-family="Times,serif" font-size="14.00">imdb_id: </text>
+<text text-anchor="start" x="1238.13" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-578 1144.98,-600 1312.98,-600 1312.98,-578 1144.98,-578"/>
+<text text-anchor="start" x="1156.86" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1265.34" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-556 1144.98,-578 1312.98,-578 1312.98,-556 1144.98,-556"/>
+<text text-anchor="start" x="1147.92" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1274.28" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-534 1144.98,-556 1312.98,-556 1312.98,-534 1144.98,-534"/>
+<text text-anchor="start" x="1181.36" y="-541.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1240.84" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-512 1144.98,-534 1312.98,-534 1312.98,-512 1144.98,-512"/>
+<text text-anchor="start" x="1178.64" y="-519.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1243.56" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-490 1144.98,-512 1312.98,-512 1312.98,-490 1144.98,-490"/>
+<text text-anchor="start" x="1174.36" y="-497.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1247.06" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1144.98,-468 1144.98,-490 1312.98,-490 1312.98,-468 1144.98,-468"/>
+<text text-anchor="start" x="1173.59" y="-475.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1248.61" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-446 1144.98,-468 1312.98,-468 1312.98,-446 1144.98,-446"/>
+<text text-anchor="start" x="1178.64" y="-453.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1243.56" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-424 1144.98,-446 1312.98,-446 1312.98,-424 1144.98,-424"/>
+<text text-anchor="start" x="1186.02" y="-431.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1236.18" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-402 1144.98,-424 1312.98,-424 1312.98,-402 1144.98,-402"/>
+<text text-anchor="start" x="1184.47" y="-409.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1237.73" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-380 1144.98,-402 1312.98,-402 1312.98,-380 1144.98,-380"/>
+<text text-anchor="start" x="1173.58" y="-387.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1224.52" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<text text-anchor="start" x="1189.14" y="-365.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1233.06" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<polygon fill="none" stroke="black" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<text text-anchor="start" x="1208.77" y="-343.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1144.98,-314 1144.98,-336 1312.98,-336 1312.98,-314 1144.98,-314"/>
+<text text-anchor="start" x="1167.16" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1144.98,-292 1144.98,-314 1312.98,-314 1312.98,-292 1144.98,-292"/>
+<text text-anchor="start" x="1165.6" y="-298.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="782.32,-1302 782.32,-1324 969.32,-1324 969.32,-1302 782.32,-1302"/>
+<polygon fill="none" stroke="black" points="782.32,-1302 782.32,-1324 969.32,-1324 969.32,-1302 782.32,-1302"/>
+<text text-anchor="start" x="831.5" y="-1309.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<text text-anchor="start" x="836.75" y="-1287.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1287.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1258 782.32,-1280 969.32,-1280 969.32,-1258 782.32,-1258"/>
+<text text-anchor="start" x="818.47" y="-1265.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1236 782.32,-1258 969.32,-1258 969.32,-1236 782.32,-1236"/>
+<text text-anchor="start" x="828.98" y="-1243.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<text text-anchor="start" x="817.32" y="-1221.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="874.46" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="782.32,-1192 782.32,-1214 969.32,-1214 969.32,-1192 782.32,-1192"/>
+<polygon fill="none" stroke="black" points="782.32,-1192 782.32,-1214 969.32,-1214 969.32,-1192 782.32,-1192"/>
+<text text-anchor="start" x="855.61" y="-1199.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="782.32,-1170 782.32,-1192 969.32,-1192 969.32,-1170 782.32,-1170"/>
+<text text-anchor="start" x="785.22" y="-1176.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M970.32,-1269C1000.15,-1269 1098.67,-791.36 1137.62,-727.93"/>
+<polygon fill="black" stroke="black" points="1140.1,-730.4 1144.98,-721 1135.3,-725.3 1140.1,-730.4"/>
+<text text-anchor="middle" x="1063.65" y="-999.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="784.32,-1112 784.32,-1134 967.32,-1134 967.32,-1112 784.32,-1112"/>
+<polygon fill="none" stroke="black" points="784.32,-1112 784.32,-1134 967.32,-1134 967.32,-1112 784.32,-1112"/>
+<text text-anchor="start" x="833.44" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<text text-anchor="start" x="836.75" y="-1097.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1097.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1068 784.32,-1090 967.32,-1090 967.32,-1068 784.32,-1068"/>
+<text text-anchor="start" x="818.47" y="-1075.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1046 784.32,-1068 967.32,-1068 967.32,-1046 784.32,-1046"/>
+<text text-anchor="start" x="828.98" y="-1053.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<text text-anchor="start" x="810.71" y="-1031.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="881.06" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="784.32,-1002 784.32,-1024 967.32,-1024 967.32,-1002 784.32,-1002"/>
+<polygon fill="none" stroke="black" points="784.32,-1002 784.32,-1024 967.32,-1024 967.32,-1002 784.32,-1002"/>
+<text text-anchor="start" x="855.61" y="-1009.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="784.32,-980 784.32,-1002 967.32,-1002 967.32,-980 784.32,-980"/>
+<text text-anchor="start" x="787.17" y="-986.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M968.32,-1079C1053.57,-1079 1056.19,-748.42 1134.98,-722.6"/>
+<polygon fill="black" stroke="black" points="1135.66,-726.03 1144.98,-721 1134.56,-719.12 1135.66,-726.03"/>
+<text text-anchor="middle" x="1063.65" y="-904.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-908 53.5,-930 186.5,-930 186.5,-908 53.5,-908"/>
+<polygon fill="none" stroke="black" points="53.5,-908 53.5,-930 186.5,-930 186.5,-908 53.5,-908"/>
+<text text-anchor="start" x="105.62" y="-915.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-886 53.5,-908 186.5,-908 186.5,-886 53.5,-886"/>
+<text text-anchor="start" x="80.93" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-893.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-864 53.5,-886 186.5,-886 186.5,-864 53.5,-864"/>
+<text text-anchor="start" x="71.6" y="-871.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-871.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-842 53.5,-864 186.5,-864 186.5,-842 53.5,-842"/>
+<text text-anchor="start" x="83.26" y="-849.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-820 53.5,-842 186.5,-842 186.5,-820 53.5,-820"/>
+<text text-anchor="start" x="65.76" y="-827.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-798 53.5,-820 186.5,-820 186.5,-798 53.5,-798"/>
+<text text-anchor="start" x="75.87" y="-805.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-776 53.5,-798 186.5,-798 186.5,-776 53.5,-776"/>
+<text text-anchor="start" x="82.87" y="-783.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-754 53.5,-776 186.5,-776 186.5,-754 53.5,-754"/>
+<text text-anchor="start" x="70.05" y="-761.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-732 53.5,-754 186.5,-754 186.5,-732 53.5,-732"/>
+<text text-anchor="start" x="77.43" y="-739.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-710 53.5,-732 186.5,-732 186.5,-710 53.5,-710"/>
+<text text-anchor="start" x="69.65" y="-717.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-688 53.5,-710 186.5,-710 186.5,-688 53.5,-688"/>
+<polygon fill="none" stroke="black" points="53.5,-688 53.5,-710 186.5,-710 186.5,-688 53.5,-688"/>
+<text text-anchor="start" x="99.79" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-666 53.5,-688 186.5,-688 186.5,-666 53.5,-666"/>
+<text text-anchor="start" x="56.25" y="-672.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="781.32,-922 781.32,-944 970.32,-944 970.32,-922 781.32,-922"/>
+<polygon fill="none" stroke="black" points="781.32,-922 781.32,-944 970.32,-944 970.32,-922 781.32,-922"/>
+<text text-anchor="start" x="830.34" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<text text-anchor="start" x="836.75" y="-907.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-907.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-878 781.32,-900 970.32,-900 970.32,-878 781.32,-878"/>
+<text text-anchor="start" x="818.47" y="-885.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<text text-anchor="start" x="817.7" y="-863.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="898.17" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="781.32,-834 781.32,-856 970.32,-856 970.32,-834 781.32,-834"/>
+<polygon fill="none" stroke="black" points="781.32,-834 781.32,-856 970.32,-856 970.32,-834 781.32,-834"/>
+<text text-anchor="start" x="855.61" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="781.32,-812 781.32,-834 970.32,-834 970.32,-812 781.32,-812"/>
+<text text-anchor="start" x="784.07" y="-818.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M971.32,-889C1075.14,-889 1040.16,-731.97 1134.77,-721.54"/>
+<polygon fill="black" stroke="black" points="1135.18,-725.03 1144.98,-721 1134.81,-718.04 1135.18,-725.03"/>
+<text text-anchor="middle" x="1063.65" y="-814.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="778.32,-754 778.32,-776 973.32,-776 973.32,-754 778.32,-754"/>
+<polygon fill="none" stroke="black" points="778.32,-754 778.32,-776 973.32,-776 973.32,-754 778.32,-754"/>
+<text text-anchor="start" x="827.22" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<text text-anchor="start" x="836.75" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<text text-anchor="start" x="818.47" y="-717.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-688 778.32,-710 973.32,-710 973.32,-688 778.32,-688"/>
+<text text-anchor="start" x="820.81" y="-695.4" font-family="Times,serif" font-size="14.00">followed_at: </text>
+<text text-anchor="start" x="895.07" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="778.32,-666 778.32,-688 973.32,-688 973.32,-666 778.32,-666"/>
+<text text-anchor="start" x="811.09" y="-673.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="904.79" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="778.32,-644 778.32,-666 973.32,-666 973.32,-644 778.32,-644"/>
+<polygon fill="none" stroke="black" points="778.32,-644 778.32,-666 973.32,-666 973.32,-644 778.32,-644"/>
+<text text-anchor="start" x="855.61" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="778.32,-622 778.32,-644 973.32,-644 973.32,-622 778.32,-622"/>
+<text text-anchor="start" x="780.95" y="-628.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M974.32,-721C1046.61,-721 1067.23,-721 1134.68,-721"/>
+<polygon fill="black" stroke="black" points="1134.98,-724.5 1144.98,-721 1134.98,-717.5 1134.98,-724.5"/>
+<text text-anchor="middle" x="1063.65" y="-726.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<polygon fill="none" stroke="black" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<text text-anchor="start" x="854.44" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="780.32,-542 780.32,-564 971.32,-564 971.32,-542 780.32,-542"/>
+<text text-anchor="start" x="836.75" y="-549.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-549.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-520 780.32,-542 971.32,-542 971.32,-520 780.32,-520"/>
+<text text-anchor="start" x="818.47" y="-527.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-498 780.32,-520 971.32,-520 971.32,-498 780.32,-498"/>
+<text text-anchor="start" x="820.42" y="-505.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="871.36" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-476 780.32,-498 971.32,-498 971.32,-476 780.32,-476"/>
+<text text-anchor="start" x="818.86" y="-483.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="872.92" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-454 780.32,-476 971.32,-476 971.32,-454 780.32,-454"/>
+<text text-anchor="start" x="843.36" y="-461.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="872.52" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-432 780.32,-454 971.32,-454 971.32,-432 780.32,-432"/>
+<text text-anchor="start" x="828.2" y="-439.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="887.68" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-410 780.32,-432 971.32,-432 971.32,-410 780.32,-410"/>
+<text text-anchor="start" x="820.81" y="-417.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="870.97" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-388 780.32,-410 971.32,-410 971.32,-388 780.32,-388"/>
+<text text-anchor="start" x="831.31" y="-395.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="884.57" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-366 780.32,-388 971.32,-388 971.32,-366 780.32,-366"/>
+<text text-anchor="start" x="816.53" y="-373.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="875.24" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-344 780.32,-366 971.32,-366 971.32,-344 780.32,-344"/>
+<text text-anchor="start" x="818.09" y="-351.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="873.68" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-322 780.32,-344 971.32,-344 971.32,-322 780.32,-322"/>
+<text text-anchor="start" x="821.2" y="-329.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="893.9" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="780.32,-300 780.32,-322 971.32,-322 971.32,-300 780.32,-300"/>
+<text text-anchor="start" x="811.09" y="-307.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="880.69" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-278 780.32,-300 971.32,-300 971.32,-278 780.32,-278"/>
+<text text-anchor="start" x="803.7" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="912.18" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-256 780.32,-278 971.32,-278 971.32,-256 780.32,-256"/>
+<text text-anchor="start" x="794.76" y="-263.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="921.12" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<polygon fill="none" stroke="black" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<text text-anchor="start" x="855.61" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="780.32,-212 780.32,-234 971.32,-234 971.32,-212 780.32,-212"/>
+<text text-anchor="start" x="783.28" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M972.32,-531C1026.03,-531 1081.07,-699.39 1134.94,-719.12"/>
+<polygon fill="black" stroke="black" points="1134.51,-722.6 1144.98,-721 1135.8,-715.72 1134.51,-722.6"/>
+<text text-anchor="middle" x="1063.65" y="-653.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<polygon fill="none" stroke="black" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<text text-anchor="start" x="479.56" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="401.66,-564 401.66,-586 605.66,-586 605.66,-564 401.66,-564"/>
+<text text-anchor="start" x="464.59" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="482.87" y="-571.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-542 401.66,-564 605.66,-564 605.66,-542 401.66,-542"/>
+<text text-anchor="start" x="442.43" y="-549.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="505.03" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-520 401.66,-542 605.66,-542 605.66,-520 401.66,-520"/>
+<text text-anchor="start" x="448.26" y="-527.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="499.2" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-498 401.66,-520 605.66,-520 605.66,-498 401.66,-498"/>
+<text text-anchor="start" x="446.7" y="-505.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="500.76" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-476 401.66,-498 605.66,-498 605.66,-476 401.66,-476"/>
+<text text-anchor="start" x="471.19" y="-483.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="500.36" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-454 401.66,-476 605.66,-476 605.66,-454 401.66,-454"/>
+<text text-anchor="start" x="456.04" y="-461.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="515.52" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-432 401.66,-454 605.66,-454 605.66,-432 401.66,-432"/>
+<text text-anchor="start" x="448.65" y="-439.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="498.8" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-410 401.66,-432 605.66,-432 605.66,-410 401.66,-410"/>
+<text text-anchor="start" x="453.32" y="-417.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="518.24" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-388 401.66,-410 605.66,-410 605.66,-388 401.66,-388"/>
+<text text-anchor="start" x="449.03" y="-395.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="521.74" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="401.66,-366 401.66,-388 605.66,-388 605.66,-366 401.66,-366"/>
+<text text-anchor="start" x="419.1" y="-373.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="528.35" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-344 401.66,-366 605.66,-366 605.66,-344 401.66,-344"/>
+<text text-anchor="start" x="422.59" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="548.96" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<polygon fill="none" stroke="black" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<text text-anchor="start" x="483.45" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<text text-anchor="start" x="404.52" y="-306.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M605.66,-553C679.38,-553 700.29,-553 769.26,-553"/>
+<polygon fill="black" stroke="black" points="769.32,-556.5 779.32,-553 769.32,-549.5 769.32,-556.5"/>
+<text text-anchor="middle" x="686.99" y="-557.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<polygon fill="none" stroke="black" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<text text-anchor="start" x="835.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="768.32,-132 768.32,-154 982.32,-154 982.32,-132 768.32,-132"/>
+<text text-anchor="start" x="836.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="854.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-110 768.32,-132 982.32,-132 982.32,-110 768.32,-110"/>
+<text text-anchor="start" x="817.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="872.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-88 768.32,-110 982.32,-110 982.32,-88 768.32,-88"/>
+<text text-anchor="start" x="800.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="890.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-66 768.32,-88 982.32,-88 982.32,-66 768.32,-66"/>
+<text text-anchor="start" x="807.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="882.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<polygon fill="none" stroke="black" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<text text-anchor="start" x="855.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="768.32,-22 768.32,-44 982.32,-44 982.32,-22 768.32,-22"/>
+<text text-anchor="start" x="789.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="768.32,0 768.32,-22 982.32,-22 982.32,0 768.32,0"/>
+<text text-anchor="start" x="771.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-99C1111.52,-99 1039.61,-250.38 1072.98,-375.2 1092.34,-447.62 1068.8,-697.14 1135.03,-719.41"/>
+<polygon fill="black" stroke="black" points="1134.55,-722.88 1144.98,-721 1135.66,-715.96 1134.55,-722.88"/>
+<text text-anchor="middle" x="1063.65" y="-380.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-121C1109.09,-121 1021.24,-274.62 1054.32,-397 1072.92,-465.79 1070.5,-697.79 1134.97,-719.38"/>
+<polygon fill="black" stroke="black" points="1134.55,-722.86 1144.98,-721 1135.67,-715.95 1134.55,-722.86"/>
+<text text-anchor="middle" x="1063.65" y="-538.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node10" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="56.25" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="80.93" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-593.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="56.04" y="-571.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="64.6" y="-549.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="66.55" y="-527.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="55.26" y="-505.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<polygon fill="none" stroke="black" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<text text-anchor="start" x="99.79" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-454 0.5,-476 239.5,-476 239.5,-454 0.5,-454"/>
+<text text-anchor="start" x="3.37" y="-460.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-432 0.5,-454 239.5,-454 239.5,-432 0.5,-432"/>
+<text text-anchor="start" x="11.92" y="-438.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-575C307.76,-575 327.47,-575 391.45,-575"/>
+<polygon fill="black" stroke="black" points="391.66,-578.5 401.66,-575 391.66,-571.5 391.66,-578.5"/>
+<text text-anchor="middle" x="320.33" y="-579.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node11" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1098 9.5,-1120 229.5,-1120 229.5,-1098 9.5,-1098"/>
+<polygon fill="none" stroke="black" points="9.5,-1098 9.5,-1120 229.5,-1120 229.5,-1098 9.5,-1098"/>
+<text text-anchor="start" x="83.34" y="-1105.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1076 9.5,-1098 229.5,-1098 229.5,-1076 9.5,-1076"/>
+<text text-anchor="start" x="80.43" y="-1083.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1083.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1054 9.5,-1076 229.5,-1076 229.5,-1054 9.5,-1054"/>
+<text text-anchor="start" x="77.71" y="-1061.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1061.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1032 9.5,-1054 229.5,-1054 229.5,-1032 9.5,-1032"/>
+<text text-anchor="start" x="60.98" y="-1039.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1039.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1010 9.5,-1032 229.5,-1032 229.5,-1010 9.5,-1010"/>
+<text text-anchor="start" x="56.71" y="-1017.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1017.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-988 9.5,-1010 229.5,-1010 229.5,-988 9.5,-988"/>
+<polygon fill="none" stroke="black" points="9.5,-988 9.5,-1010 229.5,-1010 229.5,-988 9.5,-988"/>
+<text text-anchor="start" x="99.29" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-966 9.5,-988 229.5,-988 229.5,-966 9.5,-966"/>
+<text text-anchor="start" x="12.19" y="-972.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/15.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/15.svg
@@ -1,0 +1,448 @@
+<svg width="1356px" height="1418px"
+ viewBox="0.00 0.00 1355.98 1418.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1382)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1382 1319.98,-1382 1319.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1115.98,-754 1115.98,-776 1283.98,-776 1283.98,-754 1115.98,-754"/>
+<polygon fill="none" stroke="black" points="1115.98,-754 1115.98,-776 1283.98,-776 1283.98,-754 1115.98,-754"/>
+<text text-anchor="start" x="1182.48" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1115.98,-732 1115.98,-754 1283.98,-754 1283.98,-732 1115.98,-732"/>
+<text text-anchor="start" x="1160.91" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1179.19" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1115.98,-710 1115.98,-732 1283.98,-732 1283.98,-710 1115.98,-710"/>
+<text text-anchor="start" x="1167.52" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1196.68" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-688 1115.98,-710 1283.98,-710 1283.98,-688 1115.98,-688"/>
+<text text-anchor="start" x="1142.24" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1221.96" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-666 1115.98,-688 1283.98,-688 1283.98,-666 1115.98,-666"/>
+<text text-anchor="start" x="1144.58" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1195.52" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1115.98,-644 1115.98,-666 1283.98,-666 1283.98,-644 1115.98,-644"/>
+<text text-anchor="start" x="1143.02" y="-651.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1197.08" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1115.98,-622 1115.98,-644 1283.98,-644 1283.98,-622 1115.98,-622"/>
+<text text-anchor="start" x="1155.07" y="-629.4" font-family="Times,serif" font-size="14.00">imdb_id: </text>
+<text text-anchor="start" x="1209.13" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-600 1115.98,-622 1283.98,-622 1283.98,-600 1115.98,-600"/>
+<text text-anchor="start" x="1127.86" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1236.34" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-578 1115.98,-600 1283.98,-600 1283.98,-578 1115.98,-578"/>
+<text text-anchor="start" x="1118.92" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1245.28" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-556 1115.98,-578 1283.98,-578 1283.98,-556 1115.98,-556"/>
+<text text-anchor="start" x="1152.36" y="-563.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1211.84" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-534 1115.98,-556 1283.98,-556 1283.98,-534 1115.98,-534"/>
+<text text-anchor="start" x="1149.64" y="-541.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1214.56" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-512 1115.98,-534 1283.98,-534 1283.98,-512 1115.98,-512"/>
+<text text-anchor="start" x="1145.36" y="-519.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1218.06" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1115.98,-490 1115.98,-512 1283.98,-512 1283.98,-490 1115.98,-490"/>
+<text text-anchor="start" x="1144.59" y="-497.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1219.61" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-468 1115.98,-490 1283.98,-490 1283.98,-468 1115.98,-468"/>
+<text text-anchor="start" x="1149.64" y="-475.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1214.56" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-446 1115.98,-468 1283.98,-468 1283.98,-446 1115.98,-446"/>
+<text text-anchor="start" x="1157.02" y="-453.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1207.18" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-424 1115.98,-446 1283.98,-446 1283.98,-424 1115.98,-424"/>
+<text text-anchor="start" x="1155.47" y="-431.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1208.73" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-402 1115.98,-424 1283.98,-424 1283.98,-402 1115.98,-402"/>
+<text text-anchor="start" x="1144.58" y="-409.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1195.52" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1115.98,-380 1115.98,-402 1283.98,-402 1283.98,-380 1115.98,-380"/>
+<text text-anchor="start" x="1160.14" y="-387.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1204.06" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1115.98,-358 1115.98,-380 1283.98,-380 1283.98,-358 1115.98,-358"/>
+<polygon fill="none" stroke="black" points="1115.98,-358 1115.98,-380 1283.98,-380 1283.98,-358 1115.98,-358"/>
+<text text-anchor="start" x="1179.77" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1115.98,-336 1115.98,-358 1283.98,-358 1283.98,-336 1115.98,-336"/>
+<text text-anchor="start" x="1138.16" y="-342.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1115.98,-314 1115.98,-336 1283.98,-336 1283.98,-314 1115.98,-314"/>
+<text text-anchor="start" x="1136.6" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="753.32,-1324 753.32,-1346 940.32,-1346 940.32,-1324 753.32,-1324"/>
+<polygon fill="none" stroke="black" points="753.32,-1324 753.32,-1346 940.32,-1346 940.32,-1324 753.32,-1324"/>
+<text text-anchor="start" x="802.5" y="-1331.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="753.32,-1302 753.32,-1324 940.32,-1324 940.32,-1302 753.32,-1302"/>
+<text text-anchor="start" x="807.75" y="-1309.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1309.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1280 753.32,-1302 940.32,-1302 940.32,-1280 753.32,-1280"/>
+<text text-anchor="start" x="789.47" y="-1287.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1258 753.32,-1280 940.32,-1280 940.32,-1258 753.32,-1258"/>
+<text text-anchor="start" x="799.98" y="-1265.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1236 753.32,-1258 940.32,-1258 940.32,-1236 753.32,-1236"/>
+<text text-anchor="start" x="788.32" y="-1243.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="845.46" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="753.32,-1214 753.32,-1236 940.32,-1236 940.32,-1214 753.32,-1214"/>
+<polygon fill="none" stroke="black" points="753.32,-1214 753.32,-1236 940.32,-1236 940.32,-1214 753.32,-1214"/>
+<text text-anchor="start" x="826.61" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="753.32,-1192 753.32,-1214 940.32,-1214 940.32,-1192 753.32,-1192"/>
+<text text-anchor="start" x="756.22" y="-1198.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M941.32,-1291C971.15,-1291 1069.67,-813.36 1108.62,-749.93"/>
+<polygon fill="black" stroke="black" points="1111.1,-752.4 1115.98,-743 1106.3,-747.3 1111.1,-752.4"/>
+<text text-anchor="middle" x="1034.65" y="-1021.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="755.32,-1134 755.32,-1156 938.32,-1156 938.32,-1134 755.32,-1134"/>
+<polygon fill="none" stroke="black" points="755.32,-1134 755.32,-1156 938.32,-1156 938.32,-1134 755.32,-1134"/>
+<text text-anchor="start" x="804.44" y="-1141.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="755.32,-1112 755.32,-1134 938.32,-1134 938.32,-1112 755.32,-1112"/>
+<text text-anchor="start" x="807.75" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1119.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1090 755.32,-1112 938.32,-1112 938.32,-1090 755.32,-1090"/>
+<text text-anchor="start" x="789.47" y="-1097.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1068 755.32,-1090 938.32,-1090 938.32,-1068 755.32,-1068"/>
+<text text-anchor="start" x="799.98" y="-1075.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1046 755.32,-1068 938.32,-1068 938.32,-1046 755.32,-1046"/>
+<text text-anchor="start" x="781.71" y="-1053.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="852.06" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="755.32,-1024 755.32,-1046 938.32,-1046 938.32,-1024 755.32,-1024"/>
+<polygon fill="none" stroke="black" points="755.32,-1024 755.32,-1046 938.32,-1046 938.32,-1024 755.32,-1024"/>
+<text text-anchor="start" x="826.61" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="755.32,-1002 755.32,-1024 938.32,-1024 938.32,-1002 755.32,-1002"/>
+<text text-anchor="start" x="758.17" y="-1008.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M939.32,-1101C1024.57,-1101 1027.19,-770.42 1105.98,-744.6"/>
+<polygon fill="black" stroke="black" points="1106.66,-748.03 1115.98,-743 1105.56,-741.12 1106.66,-748.03"/>
+<text text-anchor="middle" x="1034.65" y="-926.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-930 53.5,-952 186.5,-952 186.5,-930 53.5,-930"/>
+<polygon fill="none" stroke="black" points="53.5,-930 53.5,-952 186.5,-952 186.5,-930 53.5,-930"/>
+<text text-anchor="start" x="105.62" y="-937.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-908 53.5,-930 186.5,-930 186.5,-908 53.5,-908"/>
+<text text-anchor="start" x="80.93" y="-915.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-915.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-886 53.5,-908 186.5,-908 186.5,-886 53.5,-886"/>
+<text text-anchor="start" x="71.6" y="-893.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-893.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-864 53.5,-886 186.5,-886 186.5,-864 53.5,-864"/>
+<text text-anchor="start" x="83.26" y="-871.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-871.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-842 53.5,-864 186.5,-864 186.5,-842 53.5,-842"/>
+<text text-anchor="start" x="65.76" y="-849.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-820 53.5,-842 186.5,-842 186.5,-820 53.5,-820"/>
+<text text-anchor="start" x="75.87" y="-827.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-798 53.5,-820 186.5,-820 186.5,-798 53.5,-798"/>
+<text text-anchor="start" x="82.87" y="-805.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-776 53.5,-798 186.5,-798 186.5,-776 53.5,-776"/>
+<text text-anchor="start" x="70.05" y="-783.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-754 53.5,-776 186.5,-776 186.5,-754 53.5,-754"/>
+<text text-anchor="start" x="77.43" y="-761.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-732 53.5,-754 186.5,-754 186.5,-732 53.5,-732"/>
+<text text-anchor="start" x="69.65" y="-739.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-710 53.5,-732 186.5,-732 186.5,-710 53.5,-710"/>
+<polygon fill="none" stroke="black" points="53.5,-710 53.5,-732 186.5,-732 186.5,-710 53.5,-710"/>
+<text text-anchor="start" x="99.79" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-688 53.5,-710 186.5,-710 186.5,-688 53.5,-688"/>
+<text text-anchor="start" x="56.25" y="-694.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="752.32,-944 752.32,-966 941.32,-966 941.32,-944 752.32,-944"/>
+<polygon fill="none" stroke="black" points="752.32,-944 752.32,-966 941.32,-966 941.32,-944 752.32,-944"/>
+<text text-anchor="start" x="801.34" y="-951.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="752.32,-922 752.32,-944 941.32,-944 941.32,-922 752.32,-922"/>
+<text text-anchor="start" x="807.75" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-929.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-900 752.32,-922 941.32,-922 941.32,-900 752.32,-900"/>
+<text text-anchor="start" x="789.47" y="-907.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-878 752.32,-900 941.32,-900 941.32,-878 752.32,-878"/>
+<text text-anchor="start" x="788.7" y="-885.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="869.17" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="752.32,-856 752.32,-878 941.32,-878 941.32,-856 752.32,-856"/>
+<polygon fill="none" stroke="black" points="752.32,-856 752.32,-878 941.32,-878 941.32,-856 752.32,-856"/>
+<text text-anchor="start" x="826.61" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="752.32,-834 752.32,-856 941.32,-856 941.32,-834 752.32,-834"/>
+<text text-anchor="start" x="755.07" y="-840.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M942.32,-911C1046.14,-911 1011.16,-753.97 1105.77,-743.54"/>
+<polygon fill="black" stroke="black" points="1106.18,-747.03 1115.98,-743 1105.81,-740.04 1106.18,-747.03"/>
+<text text-anchor="middle" x="1034.65" y="-836.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="749.32,-776 749.32,-798 944.32,-798 944.32,-776 749.32,-776"/>
+<polygon fill="none" stroke="black" points="749.32,-776 749.32,-798 944.32,-798 944.32,-776 749.32,-776"/>
+<text text-anchor="start" x="798.22" y="-783.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="749.32,-754 749.32,-776 944.32,-776 944.32,-754 749.32,-754"/>
+<text text-anchor="start" x="807.75" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-761.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-732 749.32,-754 944.32,-754 944.32,-732 749.32,-732"/>
+<text text-anchor="start" x="789.47" y="-739.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-710 749.32,-732 944.32,-732 944.32,-710 749.32,-710"/>
+<text text-anchor="start" x="791.81" y="-717.4" font-family="Times,serif" font-size="14.00">followed_at: </text>
+<text text-anchor="start" x="866.07" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="749.32,-688 749.32,-710 944.32,-710 944.32,-688 749.32,-688"/>
+<text text-anchor="start" x="782.09" y="-695.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="875.79" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="749.32,-666 749.32,-688 944.32,-688 944.32,-666 749.32,-666"/>
+<polygon fill="none" stroke="black" points="749.32,-666 749.32,-688 944.32,-688 944.32,-666 749.32,-666"/>
+<text text-anchor="start" x="826.61" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="749.32,-644 749.32,-666 944.32,-666 944.32,-644 749.32,-644"/>
+<text text-anchor="start" x="751.95" y="-650.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M945.32,-743C1017.61,-743 1038.23,-743 1105.68,-743"/>
+<polygon fill="black" stroke="black" points="1105.98,-746.5 1115.98,-743 1105.98,-739.5 1105.98,-746.5"/>
+<text text-anchor="middle" x="1034.65" y="-748.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="762.32,-586 762.32,-608 930.32,-608 930.32,-586 762.32,-586"/>
+<polygon fill="none" stroke="black" points="762.32,-586 762.32,-608 930.32,-608 930.32,-586 762.32,-586"/>
+<text text-anchor="start" x="824.94" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="762.32,-564 762.32,-586 930.32,-586 930.32,-564 762.32,-564"/>
+<text text-anchor="start" x="807.25" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-571.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-542 762.32,-564 930.32,-564 930.32,-542 762.32,-542"/>
+<text text-anchor="start" x="788.97" y="-549.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-520 762.32,-542 930.32,-542 930.32,-520 762.32,-520"/>
+<text text-anchor="start" x="790.92" y="-527.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="841.86" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-498 762.32,-520 930.32,-520 930.32,-498 762.32,-498"/>
+<text text-anchor="start" x="789.36" y="-505.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="843.42" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-476 762.32,-498 930.32,-498 930.32,-476 762.32,-476"/>
+<text text-anchor="start" x="813.86" y="-483.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="843.02" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-454 762.32,-476 930.32,-476 930.32,-454 762.32,-454"/>
+<text text-anchor="start" x="798.7" y="-461.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="858.18" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-432 762.32,-454 930.32,-454 930.32,-432 762.32,-432"/>
+<text text-anchor="start" x="791.31" y="-439.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="841.47" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-410 762.32,-432 930.32,-432 930.32,-410 762.32,-410"/>
+<text text-anchor="start" x="801.81" y="-417.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="855.07" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-388 762.32,-410 930.32,-410 930.32,-388 762.32,-388"/>
+<text text-anchor="start" x="787.03" y="-395.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="845.74" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-366 762.32,-388 930.32,-388 930.32,-366 762.32,-366"/>
+<text text-anchor="start" x="788.59" y="-373.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="844.18" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-344 762.32,-366 930.32,-366 930.32,-344 762.32,-344"/>
+<text text-anchor="start" x="791.7" y="-351.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="864.4" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="762.32,-322 762.32,-344 930.32,-344 930.32,-322 762.32,-322"/>
+<text text-anchor="start" x="781.59" y="-329.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="851.19" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-300 762.32,-322 930.32,-322 930.32,-300 762.32,-300"/>
+<text text-anchor="start" x="774.2" y="-307.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="882.68" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-278 762.32,-300 930.32,-300 930.32,-278 762.32,-278"/>
+<text text-anchor="start" x="765.26" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="891.62" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="762.32,-256 762.32,-278 930.32,-278 930.32,-256 762.32,-256"/>
+<polygon fill="none" stroke="black" points="762.32,-256 762.32,-278 930.32,-278 930.32,-256 762.32,-256"/>
+<text text-anchor="start" x="826.11" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="762.32,-234 762.32,-256 930.32,-256 930.32,-234 762.32,-234"/>
+<text text-anchor="start" x="780.61" y="-240.4" font-family="Times,serif" font-size="14.00">index_seasons_trakt_id</text>
+<polygon fill="none" stroke="black" points="762.32,-212 762.32,-234 930.32,-234 930.32,-212 762.32,-212"/>
+<text text-anchor="start" x="778.67" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M931.32,-553C986.86,-553 1049.55,-722.09 1105.9,-741.24"/>
+<polygon fill="black" stroke="black" points="1105.53,-744.73 1115.98,-743 1106.73,-737.83 1105.53,-744.73"/>
+<text text-anchor="middle" x="1034.65" y="-681.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="402.16,-608 402.16,-630 577.16,-630 577.16,-608 402.16,-608"/>
+<polygon fill="none" stroke="black" points="402.16,-608 402.16,-630 577.16,-630 577.16,-608 402.16,-608"/>
+<text text-anchor="start" x="465.56" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="402.16,-586 402.16,-608 577.16,-608 577.16,-586 402.16,-586"/>
+<text text-anchor="start" x="450.59" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="468.87" y="-593.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-564 402.16,-586 577.16,-586 577.16,-564 402.16,-564"/>
+<text text-anchor="start" x="428.43" y="-571.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="491.03" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-542 402.16,-564 577.16,-564 577.16,-542 402.16,-542"/>
+<text text-anchor="start" x="434.26" y="-549.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="485.2" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-520 402.16,-542 577.16,-542 577.16,-520 402.16,-520"/>
+<text text-anchor="start" x="432.7" y="-527.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="486.76" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-498 402.16,-520 577.16,-520 577.16,-498 402.16,-498"/>
+<text text-anchor="start" x="457.19" y="-505.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="486.36" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-476 402.16,-498 577.16,-498 577.16,-476 402.16,-476"/>
+<text text-anchor="start" x="442.04" y="-483.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="501.52" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-454 402.16,-476 577.16,-476 577.16,-454 402.16,-454"/>
+<text text-anchor="start" x="434.65" y="-461.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="484.8" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-432 402.16,-454 577.16,-454 577.16,-432 402.16,-432"/>
+<text text-anchor="start" x="439.32" y="-439.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="504.24" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-410 402.16,-432 577.16,-432 577.16,-410 402.16,-410"/>
+<text text-anchor="start" x="435.03" y="-417.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="507.74" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="402.16,-388 402.16,-410 577.16,-410 577.16,-388 402.16,-388"/>
+<text text-anchor="start" x="405.1" y="-395.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="514.35" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-366 402.16,-388 577.16,-388 577.16,-366 402.16,-366"/>
+<text text-anchor="start" x="408.59" y="-373.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="534.96" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="402.16,-344 402.16,-366 577.16,-366 577.16,-344 402.16,-344"/>
+<polygon fill="none" stroke="black" points="402.16,-344 402.16,-366 577.16,-366 577.16,-344 402.16,-344"/>
+<text text-anchor="start" x="469.45" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="402.16,-322 402.16,-344 577.16,-344 577.16,-322 402.16,-322"/>
+<text text-anchor="start" x="421.23" y="-328.4" font-family="Times,serif" font-size="14.00">index_episodes_trakt_id</text>
+<polygon fill="none" stroke="black" points="402.16,-300 402.16,-322 577.16,-322 577.16,-300 402.16,-300"/>
+<text text-anchor="start" x="415.4" y="-306.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M576.66,-575C655.21,-575 677.37,-575 751.07,-575"/>
+<polygon fill="black" stroke="black" points="751.32,-578.5 761.32,-575 751.32,-571.5 751.32,-578.5"/>
+<text text-anchor="middle" x="657.99" y="-579.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="739.32,-154 739.32,-176 953.32,-176 953.32,-154 739.32,-154"/>
+<polygon fill="none" stroke="black" points="739.32,-154 739.32,-176 953.32,-176 953.32,-154 739.32,-154"/>
+<text text-anchor="start" x="806.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="739.32,-132 739.32,-154 953.32,-154 953.32,-132 739.32,-132"/>
+<text text-anchor="start" x="807.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-110 739.32,-132 953.32,-132 953.32,-110 739.32,-110"/>
+<text text-anchor="start" x="788.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-88 739.32,-110 953.32,-110 953.32,-88 739.32,-88"/>
+<text text-anchor="start" x="771.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="861.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-66 739.32,-88 953.32,-88 953.32,-66 739.32,-66"/>
+<text text-anchor="start" x="778.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="853.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="739.32,-44 739.32,-66 953.32,-66 953.32,-44 739.32,-44"/>
+<polygon fill="none" stroke="black" points="739.32,-44 739.32,-66 953.32,-66 953.32,-44 739.32,-44"/>
+<text text-anchor="start" x="826.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="739.32,-22 739.32,-44 953.32,-44 953.32,-22 739.32,-22"/>
+<text text-anchor="start" x="760.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="739.32,0 739.32,-22 953.32,-22 953.32,0 739.32,0"/>
+<text text-anchor="start" x="742.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-99C1088.45,-99 1010.32,-258.34 1043.98,-389.2 1063.07,-463.41 1038.19,-718.59 1105.81,-741.37"/>
+<polygon fill="black" stroke="black" points="1105.55,-744.87 1115.98,-743 1106.66,-737.96 1105.55,-744.87"/>
+<text text-anchor="middle" x="1034.65" y="-394.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-121C1019.72,-121 1008.57,-346.75 1025.32,-411 1043.71,-481.54 1039.93,-719.22 1105.75,-741.34"/>
+<polygon fill="black" stroke="black" points="1105.55,-744.86 1115.98,-743 1106.67,-737.95 1105.55,-744.86"/>
+<text text-anchor="middle" x="1034.65" y="-564.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node10" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<polygon fill="none" stroke="black" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<text text-anchor="start" x="56.25" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="80.93" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-615.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="56.04" y="-593.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="64.6" y="-571.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="66.55" y="-549.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="55.26" y="-527.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="99.79" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<text text-anchor="start" x="3.37" y="-482.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-454 0.5,-476 239.5,-476 239.5,-454 0.5,-454"/>
+<text text-anchor="start" x="11.92" y="-460.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-597C307.76,-597 327.47,-597 391.45,-597"/>
+<polygon fill="black" stroke="black" points="391.66,-600.5 401.66,-597 391.66,-593.5 391.66,-600.5"/>
+<text text-anchor="middle" x="320.33" y="-601.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node11" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1120 9.5,-1142 229.5,-1142 229.5,-1120 9.5,-1120"/>
+<polygon fill="none" stroke="black" points="9.5,-1120 9.5,-1142 229.5,-1142 229.5,-1120 9.5,-1120"/>
+<text text-anchor="start" x="83.34" y="-1127.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1098 9.5,-1120 229.5,-1120 229.5,-1098 9.5,-1098"/>
+<text text-anchor="start" x="80.43" y="-1105.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1105.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1076 9.5,-1098 229.5,-1098 229.5,-1076 9.5,-1076"/>
+<text text-anchor="start" x="77.71" y="-1083.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1083.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1054 9.5,-1076 229.5,-1076 229.5,-1054 9.5,-1054"/>
+<text text-anchor="start" x="60.98" y="-1061.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1061.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1032 9.5,-1054 229.5,-1054 229.5,-1032 9.5,-1032"/>
+<text text-anchor="start" x="56.71" y="-1039.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1039.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-1010 9.5,-1032 229.5,-1032 229.5,-1010 9.5,-1010"/>
+<polygon fill="none" stroke="black" points="9.5,-1010 9.5,-1032 229.5,-1032 229.5,-1010 9.5,-1010"/>
+<text text-anchor="start" x="99.29" y="-1017.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-988 9.5,-1010 229.5,-1010 229.5,-988 9.5,-988"/>
+<text text-anchor="start" x="12.19" y="-994.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/16.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/16.svg
@@ -1,0 +1,461 @@
+<svg width="1356px" height="1418px"
+ viewBox="0.00 0.00 1355.98 1418.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1382)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1382 1319.98,-1382 1319.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1115.98,-754 1115.98,-776 1283.98,-776 1283.98,-754 1115.98,-754"/>
+<polygon fill="none" stroke="black" points="1115.98,-754 1115.98,-776 1283.98,-776 1283.98,-754 1115.98,-754"/>
+<text text-anchor="start" x="1182.48" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1115.98,-732 1115.98,-754 1283.98,-754 1283.98,-732 1115.98,-732"/>
+<text text-anchor="start" x="1160.91" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1179.19" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1115.98,-710 1115.98,-732 1283.98,-732 1283.98,-710 1115.98,-710"/>
+<text text-anchor="start" x="1167.52" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1196.68" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-688 1115.98,-710 1283.98,-710 1283.98,-688 1115.98,-688"/>
+<text text-anchor="start" x="1142.24" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1221.96" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-666 1115.98,-688 1283.98,-688 1283.98,-666 1115.98,-666"/>
+<text text-anchor="start" x="1144.58" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1195.52" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1115.98,-644 1115.98,-666 1283.98,-666 1283.98,-644 1115.98,-644"/>
+<text text-anchor="start" x="1143.02" y="-651.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1197.08" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1115.98,-622 1115.98,-644 1283.98,-644 1283.98,-622 1115.98,-622"/>
+<text text-anchor="start" x="1155.07" y="-629.4" font-family="Times,serif" font-size="14.00">imdb_id: </text>
+<text text-anchor="start" x="1209.13" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-600 1115.98,-622 1283.98,-622 1283.98,-600 1115.98,-600"/>
+<text text-anchor="start" x="1127.86" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1236.34" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-578 1115.98,-600 1283.98,-600 1283.98,-578 1115.98,-578"/>
+<text text-anchor="start" x="1118.92" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1245.28" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-556 1115.98,-578 1283.98,-578 1283.98,-556 1115.98,-556"/>
+<text text-anchor="start" x="1152.36" y="-563.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1211.84" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-534 1115.98,-556 1283.98,-556 1283.98,-534 1115.98,-534"/>
+<text text-anchor="start" x="1149.64" y="-541.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1214.56" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-512 1115.98,-534 1283.98,-534 1283.98,-512 1115.98,-512"/>
+<text text-anchor="start" x="1145.36" y="-519.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1218.06" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1115.98,-490 1115.98,-512 1283.98,-512 1283.98,-490 1115.98,-490"/>
+<text text-anchor="start" x="1144.59" y="-497.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1219.61" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-468 1115.98,-490 1283.98,-490 1283.98,-468 1115.98,-468"/>
+<text text-anchor="start" x="1149.64" y="-475.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1214.56" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-446 1115.98,-468 1283.98,-468 1283.98,-446 1115.98,-446"/>
+<text text-anchor="start" x="1157.02" y="-453.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1207.18" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-424 1115.98,-446 1283.98,-446 1283.98,-424 1115.98,-424"/>
+<text text-anchor="start" x="1155.47" y="-431.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1208.73" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-402 1115.98,-424 1283.98,-424 1283.98,-402 1115.98,-402"/>
+<text text-anchor="start" x="1144.58" y="-409.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1195.52" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1115.98,-380 1115.98,-402 1283.98,-402 1283.98,-380 1115.98,-380"/>
+<text text-anchor="start" x="1160.14" y="-387.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1204.06" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1115.98,-358 1115.98,-380 1283.98,-380 1283.98,-358 1115.98,-358"/>
+<polygon fill="none" stroke="black" points="1115.98,-358 1115.98,-380 1283.98,-380 1283.98,-358 1115.98,-358"/>
+<text text-anchor="start" x="1179.77" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1115.98,-336 1115.98,-358 1283.98,-358 1283.98,-336 1115.98,-336"/>
+<text text-anchor="start" x="1138.16" y="-342.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1115.98,-314 1115.98,-336 1283.98,-336 1283.98,-314 1115.98,-314"/>
+<text text-anchor="start" x="1136.6" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- shows_fts -->
+<g id="node2" class="node">
+<title>shows_fts</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-732 59.5,-754 180.5,-754 180.5,-732 59.5,-732"/>
+<polygon fill="none" stroke="black" points="59.5,-732 59.5,-754 180.5,-754 180.5,-732 59.5,-732"/>
+<text text-anchor="start" x="92" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows_fts</text>
+<polygon fill="none" stroke="black" points="59.5,-710 59.5,-732 180.5,-732 180.5,-710 59.5,-710"/>
+<text text-anchor="start" x="87.53" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="116.7" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-688 59.5,-710 180.5,-710 180.5,-688 59.5,-688"/>
+<text text-anchor="start" x="62.26" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="141.98" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- trending_shows -->
+<g id="node3" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="753.32,-1324 753.32,-1346 940.32,-1346 940.32,-1324 753.32,-1324"/>
+<polygon fill="none" stroke="black" points="753.32,-1324 753.32,-1346 940.32,-1346 940.32,-1324 753.32,-1324"/>
+<text text-anchor="start" x="802.5" y="-1331.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="753.32,-1302 753.32,-1324 940.32,-1324 940.32,-1302 753.32,-1302"/>
+<text text-anchor="start" x="807.75" y="-1309.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1309.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1280 753.32,-1302 940.32,-1302 940.32,-1280 753.32,-1280"/>
+<text text-anchor="start" x="789.47" y="-1287.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1258 753.32,-1280 940.32,-1280 940.32,-1258 753.32,-1258"/>
+<text text-anchor="start" x="799.98" y="-1265.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1236 753.32,-1258 940.32,-1258 940.32,-1236 753.32,-1236"/>
+<text text-anchor="start" x="788.32" y="-1243.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="845.46" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="753.32,-1214 753.32,-1236 940.32,-1236 940.32,-1214 753.32,-1214"/>
+<polygon fill="none" stroke="black" points="753.32,-1214 753.32,-1236 940.32,-1236 940.32,-1214 753.32,-1214"/>
+<text text-anchor="start" x="826.61" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="753.32,-1192 753.32,-1214 940.32,-1214 940.32,-1192 753.32,-1192"/>
+<text text-anchor="start" x="756.22" y="-1198.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M941.32,-1291C971.15,-1291 1069.67,-813.36 1108.62,-749.93"/>
+<polygon fill="black" stroke="black" points="1111.1,-752.4 1115.98,-743 1106.3,-747.3 1111.1,-752.4"/>
+<text text-anchor="middle" x="1034.65" y="-1021.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node4" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="755.32,-1134 755.32,-1156 938.32,-1156 938.32,-1134 755.32,-1134"/>
+<polygon fill="none" stroke="black" points="755.32,-1134 755.32,-1156 938.32,-1156 938.32,-1134 755.32,-1134"/>
+<text text-anchor="start" x="804.44" y="-1141.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="755.32,-1112 755.32,-1134 938.32,-1134 938.32,-1112 755.32,-1112"/>
+<text text-anchor="start" x="807.75" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1119.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1090 755.32,-1112 938.32,-1112 938.32,-1090 755.32,-1090"/>
+<text text-anchor="start" x="789.47" y="-1097.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1068 755.32,-1090 938.32,-1090 938.32,-1068 755.32,-1068"/>
+<text text-anchor="start" x="799.98" y="-1075.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1046 755.32,-1068 938.32,-1068 938.32,-1046 755.32,-1046"/>
+<text text-anchor="start" x="781.71" y="-1053.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="852.06" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="755.32,-1024 755.32,-1046 938.32,-1046 938.32,-1024 755.32,-1024"/>
+<polygon fill="none" stroke="black" points="755.32,-1024 755.32,-1046 938.32,-1046 938.32,-1024 755.32,-1024"/>
+<text text-anchor="start" x="826.61" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="755.32,-1002 755.32,-1024 938.32,-1024 938.32,-1002 755.32,-1002"/>
+<text text-anchor="start" x="758.17" y="-1008.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M939.32,-1101C1024.57,-1101 1027.19,-770.42 1105.98,-744.6"/>
+<polygon fill="black" stroke="black" points="1106.66,-748.03 1115.98,-743 1105.56,-741.12 1106.66,-748.03"/>
+<text text-anchor="middle" x="1034.65" y="-926.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node5" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-1032 53.5,-1054 186.5,-1054 186.5,-1032 53.5,-1032"/>
+<polygon fill="none" stroke="black" points="53.5,-1032 53.5,-1054 186.5,-1054 186.5,-1032 53.5,-1032"/>
+<text text-anchor="start" x="105.62" y="-1039.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-1010 53.5,-1032 186.5,-1032 186.5,-1010 53.5,-1010"/>
+<text text-anchor="start" x="80.93" y="-1017.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-1017.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-988 53.5,-1010 186.5,-1010 186.5,-988 53.5,-988"/>
+<text text-anchor="start" x="71.6" y="-995.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-966 53.5,-988 186.5,-988 186.5,-966 53.5,-966"/>
+<text text-anchor="start" x="83.26" y="-973.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-944 53.5,-966 186.5,-966 186.5,-944 53.5,-944"/>
+<text text-anchor="start" x="65.76" y="-951.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-922 53.5,-944 186.5,-944 186.5,-922 53.5,-922"/>
+<text text-anchor="start" x="75.87" y="-929.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-900 53.5,-922 186.5,-922 186.5,-900 53.5,-900"/>
+<text text-anchor="start" x="82.87" y="-907.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-878 53.5,-900 186.5,-900 186.5,-878 53.5,-878"/>
+<text text-anchor="start" x="70.05" y="-885.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-856 53.5,-878 186.5,-878 186.5,-856 53.5,-856"/>
+<text text-anchor="start" x="77.43" y="-863.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-834 53.5,-856 186.5,-856 186.5,-834 53.5,-834"/>
+<text text-anchor="start" x="69.65" y="-841.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-812 53.5,-834 186.5,-834 186.5,-812 53.5,-812"/>
+<polygon fill="none" stroke="black" points="53.5,-812 53.5,-834 186.5,-834 186.5,-812 53.5,-812"/>
+<text text-anchor="start" x="99.79" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-790 53.5,-812 186.5,-812 186.5,-790 53.5,-790"/>
+<text text-anchor="start" x="56.25" y="-796.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node6" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="752.32,-944 752.32,-966 941.32,-966 941.32,-944 752.32,-944"/>
+<polygon fill="none" stroke="black" points="752.32,-944 752.32,-966 941.32,-966 941.32,-944 752.32,-944"/>
+<text text-anchor="start" x="801.34" y="-951.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="752.32,-922 752.32,-944 941.32,-944 941.32,-922 752.32,-922"/>
+<text text-anchor="start" x="807.75" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-929.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-900 752.32,-922 941.32,-922 941.32,-900 752.32,-900"/>
+<text text-anchor="start" x="789.47" y="-907.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-878 752.32,-900 941.32,-900 941.32,-878 752.32,-878"/>
+<text text-anchor="start" x="788.7" y="-885.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="869.17" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="752.32,-856 752.32,-878 941.32,-878 941.32,-856 752.32,-856"/>
+<polygon fill="none" stroke="black" points="752.32,-856 752.32,-878 941.32,-878 941.32,-856 752.32,-856"/>
+<text text-anchor="start" x="826.61" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="752.32,-834 752.32,-856 941.32,-856 941.32,-834 752.32,-834"/>
+<text text-anchor="start" x="755.07" y="-840.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M942.32,-911C1046.14,-911 1011.16,-753.97 1105.77,-743.54"/>
+<polygon fill="black" stroke="black" points="1106.18,-747.03 1115.98,-743 1105.81,-740.04 1106.18,-747.03"/>
+<text text-anchor="middle" x="1034.65" y="-836.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node7" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="749.32,-776 749.32,-798 944.32,-798 944.32,-776 749.32,-776"/>
+<polygon fill="none" stroke="black" points="749.32,-776 749.32,-798 944.32,-798 944.32,-776 749.32,-776"/>
+<text text-anchor="start" x="798.22" y="-783.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="749.32,-754 749.32,-776 944.32,-776 944.32,-754 749.32,-754"/>
+<text text-anchor="start" x="807.75" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-761.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-732 749.32,-754 944.32,-754 944.32,-732 749.32,-732"/>
+<text text-anchor="start" x="789.47" y="-739.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-710 749.32,-732 944.32,-732 944.32,-710 749.32,-710"/>
+<text text-anchor="start" x="791.81" y="-717.4" font-family="Times,serif" font-size="14.00">followed_at: </text>
+<text text-anchor="start" x="866.07" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="749.32,-688 749.32,-710 944.32,-710 944.32,-688 749.32,-688"/>
+<text text-anchor="start" x="782.09" y="-695.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="875.79" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="749.32,-666 749.32,-688 944.32,-688 944.32,-666 749.32,-666"/>
+<polygon fill="none" stroke="black" points="749.32,-666 749.32,-688 944.32,-688 944.32,-666 749.32,-666"/>
+<text text-anchor="start" x="826.61" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="749.32,-644 749.32,-666 944.32,-666 944.32,-644 749.32,-644"/>
+<text text-anchor="start" x="751.95" y="-650.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M945.32,-743C1017.61,-743 1038.23,-743 1105.68,-743"/>
+<polygon fill="black" stroke="black" points="1105.98,-746.5 1115.98,-743 1105.98,-739.5 1105.98,-746.5"/>
+<text text-anchor="middle" x="1034.65" y="-748.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node8" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="762.32,-586 762.32,-608 930.32,-608 930.32,-586 762.32,-586"/>
+<polygon fill="none" stroke="black" points="762.32,-586 762.32,-608 930.32,-608 930.32,-586 762.32,-586"/>
+<text text-anchor="start" x="824.94" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="762.32,-564 762.32,-586 930.32,-586 930.32,-564 762.32,-564"/>
+<text text-anchor="start" x="807.25" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-571.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-542 762.32,-564 930.32,-564 930.32,-542 762.32,-542"/>
+<text text-anchor="start" x="788.97" y="-549.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-520 762.32,-542 930.32,-542 930.32,-520 762.32,-520"/>
+<text text-anchor="start" x="790.92" y="-527.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="841.86" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-498 762.32,-520 930.32,-520 930.32,-498 762.32,-498"/>
+<text text-anchor="start" x="789.36" y="-505.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="843.42" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-476 762.32,-498 930.32,-498 930.32,-476 762.32,-476"/>
+<text text-anchor="start" x="813.86" y="-483.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="843.02" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-454 762.32,-476 930.32,-476 930.32,-454 762.32,-454"/>
+<text text-anchor="start" x="798.7" y="-461.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="858.18" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-432 762.32,-454 930.32,-454 930.32,-432 762.32,-432"/>
+<text text-anchor="start" x="791.31" y="-439.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="841.47" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-410 762.32,-432 930.32,-432 930.32,-410 762.32,-410"/>
+<text text-anchor="start" x="801.81" y="-417.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="855.07" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-388 762.32,-410 930.32,-410 930.32,-388 762.32,-388"/>
+<text text-anchor="start" x="787.03" y="-395.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="845.74" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-366 762.32,-388 930.32,-388 930.32,-366 762.32,-366"/>
+<text text-anchor="start" x="788.59" y="-373.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="844.18" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-344 762.32,-366 930.32,-366 930.32,-344 762.32,-344"/>
+<text text-anchor="start" x="791.7" y="-351.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="864.4" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="762.32,-322 762.32,-344 930.32,-344 930.32,-322 762.32,-322"/>
+<text text-anchor="start" x="781.59" y="-329.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="851.19" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-300 762.32,-322 930.32,-322 930.32,-300 762.32,-300"/>
+<text text-anchor="start" x="774.2" y="-307.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="882.68" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-278 762.32,-300 930.32,-300 930.32,-278 762.32,-278"/>
+<text text-anchor="start" x="765.26" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="891.62" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="762.32,-256 762.32,-278 930.32,-278 930.32,-256 762.32,-256"/>
+<polygon fill="none" stroke="black" points="762.32,-256 762.32,-278 930.32,-278 930.32,-256 762.32,-256"/>
+<text text-anchor="start" x="826.11" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="762.32,-234 762.32,-256 930.32,-256 930.32,-234 762.32,-234"/>
+<text text-anchor="start" x="780.61" y="-240.4" font-family="Times,serif" font-size="14.00">index_seasons_trakt_id</text>
+<polygon fill="none" stroke="black" points="762.32,-212 762.32,-234 930.32,-234 930.32,-212 762.32,-212"/>
+<text text-anchor="start" x="778.67" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M931.32,-553C986.86,-553 1049.55,-722.09 1105.9,-741.24"/>
+<polygon fill="black" stroke="black" points="1105.53,-744.73 1115.98,-743 1106.73,-737.83 1105.53,-744.73"/>
+<text text-anchor="middle" x="1034.65" y="-681.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node9" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="402.16,-608 402.16,-630 577.16,-630 577.16,-608 402.16,-608"/>
+<polygon fill="none" stroke="black" points="402.16,-608 402.16,-630 577.16,-630 577.16,-608 402.16,-608"/>
+<text text-anchor="start" x="465.56" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="402.16,-586 402.16,-608 577.16,-608 577.16,-586 402.16,-586"/>
+<text text-anchor="start" x="450.59" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="468.87" y="-593.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-564 402.16,-586 577.16,-586 577.16,-564 402.16,-564"/>
+<text text-anchor="start" x="428.43" y="-571.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="491.03" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-542 402.16,-564 577.16,-564 577.16,-542 402.16,-542"/>
+<text text-anchor="start" x="434.26" y="-549.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="485.2" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-520 402.16,-542 577.16,-542 577.16,-520 402.16,-520"/>
+<text text-anchor="start" x="432.7" y="-527.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="486.76" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-498 402.16,-520 577.16,-520 577.16,-498 402.16,-498"/>
+<text text-anchor="start" x="457.19" y="-505.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="486.36" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-476 402.16,-498 577.16,-498 577.16,-476 402.16,-476"/>
+<text text-anchor="start" x="442.04" y="-483.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="501.52" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-454 402.16,-476 577.16,-476 577.16,-454 402.16,-454"/>
+<text text-anchor="start" x="434.65" y="-461.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="484.8" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-432 402.16,-454 577.16,-454 577.16,-432 402.16,-432"/>
+<text text-anchor="start" x="439.32" y="-439.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="504.24" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-410 402.16,-432 577.16,-432 577.16,-410 402.16,-410"/>
+<text text-anchor="start" x="435.03" y="-417.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="507.74" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="402.16,-388 402.16,-410 577.16,-410 577.16,-388 402.16,-388"/>
+<text text-anchor="start" x="405.1" y="-395.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="514.35" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-366 402.16,-388 577.16,-388 577.16,-366 402.16,-366"/>
+<text text-anchor="start" x="408.59" y="-373.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="534.96" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="402.16,-344 402.16,-366 577.16,-366 577.16,-344 402.16,-344"/>
+<polygon fill="none" stroke="black" points="402.16,-344 402.16,-366 577.16,-366 577.16,-344 402.16,-344"/>
+<text text-anchor="start" x="469.45" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="402.16,-322 402.16,-344 577.16,-344 577.16,-322 402.16,-322"/>
+<text text-anchor="start" x="421.23" y="-328.4" font-family="Times,serif" font-size="14.00">index_episodes_trakt_id</text>
+<polygon fill="none" stroke="black" points="402.16,-300 402.16,-322 577.16,-322 577.16,-300 402.16,-300"/>
+<text text-anchor="start" x="415.4" y="-306.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M576.66,-575C655.21,-575 677.37,-575 751.07,-575"/>
+<polygon fill="black" stroke="black" points="751.32,-578.5 761.32,-575 751.32,-571.5 751.32,-578.5"/>
+<text text-anchor="middle" x="657.99" y="-579.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node10" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="739.32,-154 739.32,-176 953.32,-176 953.32,-154 739.32,-154"/>
+<polygon fill="none" stroke="black" points="739.32,-154 739.32,-176 953.32,-176 953.32,-154 739.32,-154"/>
+<text text-anchor="start" x="806.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="739.32,-132 739.32,-154 953.32,-154 953.32,-132 739.32,-132"/>
+<text text-anchor="start" x="807.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-110 739.32,-132 953.32,-132 953.32,-110 739.32,-110"/>
+<text text-anchor="start" x="788.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-88 739.32,-110 953.32,-110 953.32,-88 739.32,-88"/>
+<text text-anchor="start" x="771.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="861.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-66 739.32,-88 953.32,-88 953.32,-66 739.32,-66"/>
+<text text-anchor="start" x="778.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="853.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="739.32,-44 739.32,-66 953.32,-66 953.32,-44 739.32,-44"/>
+<polygon fill="none" stroke="black" points="739.32,-44 739.32,-66 953.32,-66 953.32,-44 739.32,-44"/>
+<text text-anchor="start" x="826.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="739.32,-22 739.32,-44 953.32,-44 953.32,-22 739.32,-22"/>
+<text text-anchor="start" x="760.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="739.32,0 739.32,-22 953.32,-22 953.32,0 739.32,0"/>
+<text text-anchor="start" x="742.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-99C1088.45,-99 1010.32,-258.34 1043.98,-389.2 1063.07,-463.41 1038.19,-718.59 1105.81,-741.37"/>
+<polygon fill="black" stroke="black" points="1105.55,-744.87 1115.98,-743 1106.66,-737.96 1105.55,-744.87"/>
+<text text-anchor="middle" x="1034.65" y="-394.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-121C1019.72,-121 1008.57,-346.75 1025.32,-411 1043.71,-481.54 1039.93,-719.22 1105.75,-741.34"/>
+<polygon fill="black" stroke="black" points="1105.55,-744.86 1115.98,-743 1106.67,-737.95 1105.55,-744.86"/>
+<text text-anchor="middle" x="1034.65" y="-564.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node11" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<polygon fill="none" stroke="black" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<text text-anchor="start" x="56.25" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="80.93" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-615.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="56.04" y="-593.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="64.6" y="-571.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="66.55" y="-549.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="55.26" y="-527.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="99.79" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<text text-anchor="start" x="3.37" y="-482.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-454 0.5,-476 239.5,-476 239.5,-454 0.5,-454"/>
+<text text-anchor="start" x="11.92" y="-460.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-597C307.76,-597 327.47,-597 391.45,-597"/>
+<polygon fill="black" stroke="black" points="391.66,-600.5 401.66,-597 391.66,-593.5 391.66,-600.5"/>
+<text text-anchor="middle" x="320.33" y="-601.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node12" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1222 9.5,-1244 229.5,-1244 229.5,-1222 9.5,-1222"/>
+<polygon fill="none" stroke="black" points="9.5,-1222 9.5,-1244 229.5,-1244 229.5,-1222 9.5,-1222"/>
+<text text-anchor="start" x="83.34" y="-1229.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1200 9.5,-1222 229.5,-1222 229.5,-1200 9.5,-1200"/>
+<text text-anchor="start" x="80.43" y="-1207.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1207.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1178 9.5,-1200 229.5,-1200 229.5,-1178 9.5,-1178"/>
+<text text-anchor="start" x="77.71" y="-1185.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1185.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1156 9.5,-1178 229.5,-1178 229.5,-1156 9.5,-1156"/>
+<text text-anchor="start" x="60.98" y="-1163.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1134 9.5,-1156 229.5,-1156 229.5,-1134 9.5,-1134"/>
+<text text-anchor="start" x="56.71" y="-1141.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-1112 9.5,-1134 229.5,-1134 229.5,-1112 9.5,-1112"/>
+<polygon fill="none" stroke="black" points="9.5,-1112 9.5,-1134 229.5,-1134 229.5,-1112 9.5,-1112"/>
+<text text-anchor="start" x="99.29" y="-1119.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-1090 9.5,-1112 229.5,-1112 229.5,-1090 9.5,-1090"/>
+<text text-anchor="start" x="12.19" y="-1096.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/17.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/17.svg
@@ -1,0 +1,461 @@
+<svg width="1356px" height="1418px"
+ viewBox="0.00 0.00 1355.98 1418.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1382)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1382 1319.98,-1382 1319.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1115.98,-754 1115.98,-776 1283.98,-776 1283.98,-754 1115.98,-754"/>
+<polygon fill="none" stroke="black" points="1115.98,-754 1115.98,-776 1283.98,-776 1283.98,-754 1115.98,-754"/>
+<text text-anchor="start" x="1182.48" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1115.98,-732 1115.98,-754 1283.98,-754 1283.98,-732 1115.98,-732"/>
+<text text-anchor="start" x="1160.91" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1179.19" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1115.98,-710 1115.98,-732 1283.98,-732 1283.98,-710 1115.98,-710"/>
+<text text-anchor="start" x="1167.52" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1196.68" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-688 1115.98,-710 1283.98,-710 1283.98,-688 1115.98,-688"/>
+<text text-anchor="start" x="1142.24" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1221.96" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-666 1115.98,-688 1283.98,-688 1283.98,-666 1115.98,-666"/>
+<text text-anchor="start" x="1144.58" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1195.52" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1115.98,-644 1115.98,-666 1283.98,-666 1283.98,-644 1115.98,-644"/>
+<text text-anchor="start" x="1143.02" y="-651.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1197.08" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1115.98,-622 1115.98,-644 1283.98,-644 1283.98,-622 1115.98,-622"/>
+<text text-anchor="start" x="1155.07" y="-629.4" font-family="Times,serif" font-size="14.00">imdb_id: </text>
+<text text-anchor="start" x="1209.13" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-600 1115.98,-622 1283.98,-622 1283.98,-600 1115.98,-600"/>
+<text text-anchor="start" x="1127.86" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1236.34" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-578 1115.98,-600 1283.98,-600 1283.98,-578 1115.98,-578"/>
+<text text-anchor="start" x="1118.92" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1245.28" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-556 1115.98,-578 1283.98,-578 1283.98,-556 1115.98,-556"/>
+<text text-anchor="start" x="1152.36" y="-563.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1211.84" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-534 1115.98,-556 1283.98,-556 1283.98,-534 1115.98,-534"/>
+<text text-anchor="start" x="1149.64" y="-541.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1214.56" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-512 1115.98,-534 1283.98,-534 1283.98,-512 1115.98,-512"/>
+<text text-anchor="start" x="1145.36" y="-519.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1218.06" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1115.98,-490 1115.98,-512 1283.98,-512 1283.98,-490 1115.98,-490"/>
+<text text-anchor="start" x="1144.59" y="-497.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1219.61" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-468 1115.98,-490 1283.98,-490 1283.98,-468 1115.98,-468"/>
+<text text-anchor="start" x="1149.64" y="-475.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1214.56" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-446 1115.98,-468 1283.98,-468 1283.98,-446 1115.98,-446"/>
+<text text-anchor="start" x="1157.02" y="-453.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1207.18" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-424 1115.98,-446 1283.98,-446 1283.98,-424 1115.98,-424"/>
+<text text-anchor="start" x="1155.47" y="-431.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1208.73" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-402 1115.98,-424 1283.98,-424 1283.98,-402 1115.98,-402"/>
+<text text-anchor="start" x="1144.58" y="-409.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1195.52" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1115.98,-380 1115.98,-402 1283.98,-402 1283.98,-380 1115.98,-380"/>
+<text text-anchor="start" x="1160.14" y="-387.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1204.06" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1115.98,-358 1115.98,-380 1283.98,-380 1283.98,-358 1115.98,-358"/>
+<polygon fill="none" stroke="black" points="1115.98,-358 1115.98,-380 1283.98,-380 1283.98,-358 1115.98,-358"/>
+<text text-anchor="start" x="1179.77" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1115.98,-336 1115.98,-358 1283.98,-358 1283.98,-336 1115.98,-336"/>
+<text text-anchor="start" x="1138.16" y="-342.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1115.98,-314 1115.98,-336 1283.98,-336 1283.98,-314 1115.98,-314"/>
+<text text-anchor="start" x="1136.6" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- shows_fts -->
+<g id="node2" class="node">
+<title>shows_fts</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-732 59.5,-754 180.5,-754 180.5,-732 59.5,-732"/>
+<polygon fill="none" stroke="black" points="59.5,-732 59.5,-754 180.5,-754 180.5,-732 59.5,-732"/>
+<text text-anchor="start" x="92" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows_fts</text>
+<polygon fill="none" stroke="black" points="59.5,-710 59.5,-732 180.5,-732 180.5,-710 59.5,-710"/>
+<text text-anchor="start" x="87.53" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="116.7" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-688 59.5,-710 180.5,-710 180.5,-688 59.5,-688"/>
+<text text-anchor="start" x="62.26" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="141.98" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- trending_shows -->
+<g id="node3" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="753.32,-1324 753.32,-1346 940.32,-1346 940.32,-1324 753.32,-1324"/>
+<polygon fill="none" stroke="black" points="753.32,-1324 753.32,-1346 940.32,-1346 940.32,-1324 753.32,-1324"/>
+<text text-anchor="start" x="802.5" y="-1331.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="753.32,-1302 753.32,-1324 940.32,-1324 940.32,-1302 753.32,-1302"/>
+<text text-anchor="start" x="807.75" y="-1309.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1309.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1280 753.32,-1302 940.32,-1302 940.32,-1280 753.32,-1280"/>
+<text text-anchor="start" x="789.47" y="-1287.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1258 753.32,-1280 940.32,-1280 940.32,-1258 753.32,-1258"/>
+<text text-anchor="start" x="799.98" y="-1265.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1236 753.32,-1258 940.32,-1258 940.32,-1236 753.32,-1236"/>
+<text text-anchor="start" x="788.32" y="-1243.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="845.46" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="753.32,-1214 753.32,-1236 940.32,-1236 940.32,-1214 753.32,-1214"/>
+<polygon fill="none" stroke="black" points="753.32,-1214 753.32,-1236 940.32,-1236 940.32,-1214 753.32,-1214"/>
+<text text-anchor="start" x="826.61" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="753.32,-1192 753.32,-1214 940.32,-1214 940.32,-1192 753.32,-1192"/>
+<text text-anchor="start" x="756.22" y="-1198.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M941.32,-1291C971.15,-1291 1069.67,-813.36 1108.62,-749.93"/>
+<polygon fill="black" stroke="black" points="1111.1,-752.4 1115.98,-743 1106.3,-747.3 1111.1,-752.4"/>
+<text text-anchor="middle" x="1034.65" y="-1021.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node4" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="755.32,-1134 755.32,-1156 938.32,-1156 938.32,-1134 755.32,-1134"/>
+<polygon fill="none" stroke="black" points="755.32,-1134 755.32,-1156 938.32,-1156 938.32,-1134 755.32,-1134"/>
+<text text-anchor="start" x="804.44" y="-1141.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="755.32,-1112 755.32,-1134 938.32,-1134 938.32,-1112 755.32,-1112"/>
+<text text-anchor="start" x="807.75" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1119.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1090 755.32,-1112 938.32,-1112 938.32,-1090 755.32,-1090"/>
+<text text-anchor="start" x="789.47" y="-1097.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1068 755.32,-1090 938.32,-1090 938.32,-1068 755.32,-1068"/>
+<text text-anchor="start" x="799.98" y="-1075.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1046 755.32,-1068 938.32,-1068 938.32,-1046 755.32,-1046"/>
+<text text-anchor="start" x="781.71" y="-1053.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="852.06" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="755.32,-1024 755.32,-1046 938.32,-1046 938.32,-1024 755.32,-1024"/>
+<polygon fill="none" stroke="black" points="755.32,-1024 755.32,-1046 938.32,-1046 938.32,-1024 755.32,-1024"/>
+<text text-anchor="start" x="826.61" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="755.32,-1002 755.32,-1024 938.32,-1024 938.32,-1002 755.32,-1002"/>
+<text text-anchor="start" x="758.17" y="-1008.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M939.32,-1101C1024.57,-1101 1027.19,-770.42 1105.98,-744.6"/>
+<polygon fill="black" stroke="black" points="1106.66,-748.03 1115.98,-743 1105.56,-741.12 1106.66,-748.03"/>
+<text text-anchor="middle" x="1034.65" y="-926.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node5" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-1032 53.5,-1054 186.5,-1054 186.5,-1032 53.5,-1032"/>
+<polygon fill="none" stroke="black" points="53.5,-1032 53.5,-1054 186.5,-1054 186.5,-1032 53.5,-1032"/>
+<text text-anchor="start" x="105.62" y="-1039.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-1010 53.5,-1032 186.5,-1032 186.5,-1010 53.5,-1010"/>
+<text text-anchor="start" x="80.93" y="-1017.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-1017.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-988 53.5,-1010 186.5,-1010 186.5,-988 53.5,-988"/>
+<text text-anchor="start" x="71.6" y="-995.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-966 53.5,-988 186.5,-988 186.5,-966 53.5,-966"/>
+<text text-anchor="start" x="83.26" y="-973.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-944 53.5,-966 186.5,-966 186.5,-944 53.5,-944"/>
+<text text-anchor="start" x="65.76" y="-951.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-922 53.5,-944 186.5,-944 186.5,-922 53.5,-922"/>
+<text text-anchor="start" x="75.87" y="-929.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-900 53.5,-922 186.5,-922 186.5,-900 53.5,-900"/>
+<text text-anchor="start" x="82.87" y="-907.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-878 53.5,-900 186.5,-900 186.5,-878 53.5,-878"/>
+<text text-anchor="start" x="70.05" y="-885.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-856 53.5,-878 186.5,-878 186.5,-856 53.5,-856"/>
+<text text-anchor="start" x="77.43" y="-863.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-834 53.5,-856 186.5,-856 186.5,-834 53.5,-834"/>
+<text text-anchor="start" x="69.65" y="-841.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-812 53.5,-834 186.5,-834 186.5,-812 53.5,-812"/>
+<polygon fill="none" stroke="black" points="53.5,-812 53.5,-834 186.5,-834 186.5,-812 53.5,-812"/>
+<text text-anchor="start" x="99.79" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-790 53.5,-812 186.5,-812 186.5,-790 53.5,-790"/>
+<text text-anchor="start" x="56.25" y="-796.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node6" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="752.32,-944 752.32,-966 941.32,-966 941.32,-944 752.32,-944"/>
+<polygon fill="none" stroke="black" points="752.32,-944 752.32,-966 941.32,-966 941.32,-944 752.32,-944"/>
+<text text-anchor="start" x="801.34" y="-951.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="752.32,-922 752.32,-944 941.32,-944 941.32,-922 752.32,-922"/>
+<text text-anchor="start" x="807.75" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-929.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-900 752.32,-922 941.32,-922 941.32,-900 752.32,-900"/>
+<text text-anchor="start" x="789.47" y="-907.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-878 752.32,-900 941.32,-900 941.32,-878 752.32,-878"/>
+<text text-anchor="start" x="788.7" y="-885.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="869.17" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="752.32,-856 752.32,-878 941.32,-878 941.32,-856 752.32,-856"/>
+<polygon fill="none" stroke="black" points="752.32,-856 752.32,-878 941.32,-878 941.32,-856 752.32,-856"/>
+<text text-anchor="start" x="826.61" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="752.32,-834 752.32,-856 941.32,-856 941.32,-834 752.32,-834"/>
+<text text-anchor="start" x="755.07" y="-840.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M942.32,-911C1046.14,-911 1011.16,-753.97 1105.77,-743.54"/>
+<polygon fill="black" stroke="black" points="1106.18,-747.03 1115.98,-743 1105.81,-740.04 1106.18,-747.03"/>
+<text text-anchor="middle" x="1034.65" y="-836.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node7" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="749.32,-776 749.32,-798 944.32,-798 944.32,-776 749.32,-776"/>
+<polygon fill="none" stroke="black" points="749.32,-776 749.32,-798 944.32,-798 944.32,-776 749.32,-776"/>
+<text text-anchor="start" x="798.22" y="-783.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="749.32,-754 749.32,-776 944.32,-776 944.32,-754 749.32,-754"/>
+<text text-anchor="start" x="807.75" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-761.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-732 749.32,-754 944.32,-754 944.32,-732 749.32,-732"/>
+<text text-anchor="start" x="789.47" y="-739.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-710 749.32,-732 944.32,-732 944.32,-710 749.32,-710"/>
+<text text-anchor="start" x="791.81" y="-717.4" font-family="Times,serif" font-size="14.00">followed_at: </text>
+<text text-anchor="start" x="866.07" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="749.32,-688 749.32,-710 944.32,-710 944.32,-688 749.32,-688"/>
+<text text-anchor="start" x="782.09" y="-695.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="875.79" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="749.32,-666 749.32,-688 944.32,-688 944.32,-666 749.32,-666"/>
+<polygon fill="none" stroke="black" points="749.32,-666 749.32,-688 944.32,-688 944.32,-666 749.32,-666"/>
+<text text-anchor="start" x="826.61" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="749.32,-644 749.32,-666 944.32,-666 944.32,-644 749.32,-644"/>
+<text text-anchor="start" x="751.95" y="-650.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M945.32,-743C1017.61,-743 1038.23,-743 1105.68,-743"/>
+<polygon fill="black" stroke="black" points="1105.98,-746.5 1115.98,-743 1105.98,-739.5 1105.98,-746.5"/>
+<text text-anchor="middle" x="1034.65" y="-748.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node8" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="762.32,-586 762.32,-608 930.32,-608 930.32,-586 762.32,-586"/>
+<polygon fill="none" stroke="black" points="762.32,-586 762.32,-608 930.32,-608 930.32,-586 762.32,-586"/>
+<text text-anchor="start" x="824.94" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="762.32,-564 762.32,-586 930.32,-586 930.32,-564 762.32,-564"/>
+<text text-anchor="start" x="807.25" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-571.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-542 762.32,-564 930.32,-564 930.32,-542 762.32,-542"/>
+<text text-anchor="start" x="788.97" y="-549.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-520 762.32,-542 930.32,-542 930.32,-520 762.32,-520"/>
+<text text-anchor="start" x="790.92" y="-527.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="841.86" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-498 762.32,-520 930.32,-520 930.32,-498 762.32,-498"/>
+<text text-anchor="start" x="789.36" y="-505.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="843.42" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-476 762.32,-498 930.32,-498 930.32,-476 762.32,-476"/>
+<text text-anchor="start" x="813.86" y="-483.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="843.02" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-454 762.32,-476 930.32,-476 930.32,-454 762.32,-454"/>
+<text text-anchor="start" x="798.7" y="-461.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="858.18" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-432 762.32,-454 930.32,-454 930.32,-432 762.32,-432"/>
+<text text-anchor="start" x="791.31" y="-439.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="841.47" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-410 762.32,-432 930.32,-432 930.32,-410 762.32,-410"/>
+<text text-anchor="start" x="801.81" y="-417.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="855.07" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-388 762.32,-410 930.32,-410 930.32,-388 762.32,-388"/>
+<text text-anchor="start" x="787.03" y="-395.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="845.74" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-366 762.32,-388 930.32,-388 930.32,-366 762.32,-366"/>
+<text text-anchor="start" x="788.59" y="-373.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="844.18" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-344 762.32,-366 930.32,-366 930.32,-344 762.32,-344"/>
+<text text-anchor="start" x="791.7" y="-351.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="864.4" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="762.32,-322 762.32,-344 930.32,-344 930.32,-322 762.32,-322"/>
+<text text-anchor="start" x="781.59" y="-329.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="851.19" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-300 762.32,-322 930.32,-322 930.32,-300 762.32,-300"/>
+<text text-anchor="start" x="774.2" y="-307.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="882.68" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-278 762.32,-300 930.32,-300 930.32,-278 762.32,-278"/>
+<text text-anchor="start" x="765.26" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="891.62" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="762.32,-256 762.32,-278 930.32,-278 930.32,-256 762.32,-256"/>
+<polygon fill="none" stroke="black" points="762.32,-256 762.32,-278 930.32,-278 930.32,-256 762.32,-256"/>
+<text text-anchor="start" x="826.11" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="762.32,-234 762.32,-256 930.32,-256 930.32,-234 762.32,-234"/>
+<text text-anchor="start" x="780.61" y="-240.4" font-family="Times,serif" font-size="14.00">index_seasons_trakt_id</text>
+<polygon fill="none" stroke="black" points="762.32,-212 762.32,-234 930.32,-234 930.32,-212 762.32,-212"/>
+<text text-anchor="start" x="778.67" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M931.32,-553C986.86,-553 1049.55,-722.09 1105.9,-741.24"/>
+<polygon fill="black" stroke="black" points="1105.53,-744.73 1115.98,-743 1106.73,-737.83 1105.53,-744.73"/>
+<text text-anchor="middle" x="1034.65" y="-681.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node9" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="402.16,-608 402.16,-630 577.16,-630 577.16,-608 402.16,-608"/>
+<polygon fill="none" stroke="black" points="402.16,-608 402.16,-630 577.16,-630 577.16,-608 402.16,-608"/>
+<text text-anchor="start" x="465.56" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="402.16,-586 402.16,-608 577.16,-608 577.16,-586 402.16,-586"/>
+<text text-anchor="start" x="450.59" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="468.87" y="-593.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-564 402.16,-586 577.16,-586 577.16,-564 402.16,-564"/>
+<text text-anchor="start" x="428.43" y="-571.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="491.03" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-542 402.16,-564 577.16,-564 577.16,-542 402.16,-542"/>
+<text text-anchor="start" x="434.26" y="-549.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="485.2" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-520 402.16,-542 577.16,-542 577.16,-520 402.16,-520"/>
+<text text-anchor="start" x="432.7" y="-527.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="486.76" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-498 402.16,-520 577.16,-520 577.16,-498 402.16,-498"/>
+<text text-anchor="start" x="457.19" y="-505.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="486.36" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-476 402.16,-498 577.16,-498 577.16,-476 402.16,-476"/>
+<text text-anchor="start" x="442.04" y="-483.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="501.52" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-454 402.16,-476 577.16,-476 577.16,-454 402.16,-454"/>
+<text text-anchor="start" x="434.65" y="-461.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="484.8" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-432 402.16,-454 577.16,-454 577.16,-432 402.16,-432"/>
+<text text-anchor="start" x="439.32" y="-439.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="504.24" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-410 402.16,-432 577.16,-432 577.16,-410 402.16,-410"/>
+<text text-anchor="start" x="435.03" y="-417.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="507.74" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="402.16,-388 402.16,-410 577.16,-410 577.16,-388 402.16,-388"/>
+<text text-anchor="start" x="405.1" y="-395.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="514.35" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-366 402.16,-388 577.16,-388 577.16,-366 402.16,-366"/>
+<text text-anchor="start" x="408.59" y="-373.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="534.96" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="402.16,-344 402.16,-366 577.16,-366 577.16,-344 402.16,-344"/>
+<polygon fill="none" stroke="black" points="402.16,-344 402.16,-366 577.16,-366 577.16,-344 402.16,-344"/>
+<text text-anchor="start" x="469.45" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="402.16,-322 402.16,-344 577.16,-344 577.16,-322 402.16,-322"/>
+<text text-anchor="start" x="421.23" y="-328.4" font-family="Times,serif" font-size="14.00">index_episodes_trakt_id</text>
+<polygon fill="none" stroke="black" points="402.16,-300 402.16,-322 577.16,-322 577.16,-300 402.16,-300"/>
+<text text-anchor="start" x="415.4" y="-306.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M576.66,-575C655.21,-575 677.37,-575 751.07,-575"/>
+<polygon fill="black" stroke="black" points="751.32,-578.5 761.32,-575 751.32,-571.5 751.32,-578.5"/>
+<text text-anchor="middle" x="657.99" y="-579.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node10" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="739.32,-154 739.32,-176 953.32,-176 953.32,-154 739.32,-154"/>
+<polygon fill="none" stroke="black" points="739.32,-154 739.32,-176 953.32,-176 953.32,-154 739.32,-154"/>
+<text text-anchor="start" x="806.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="739.32,-132 739.32,-154 953.32,-154 953.32,-132 739.32,-132"/>
+<text text-anchor="start" x="807.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-110 739.32,-132 953.32,-132 953.32,-110 739.32,-110"/>
+<text text-anchor="start" x="788.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-88 739.32,-110 953.32,-110 953.32,-88 739.32,-88"/>
+<text text-anchor="start" x="771.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="861.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-66 739.32,-88 953.32,-88 953.32,-66 739.32,-66"/>
+<text text-anchor="start" x="778.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="853.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="739.32,-44 739.32,-66 953.32,-66 953.32,-44 739.32,-44"/>
+<polygon fill="none" stroke="black" points="739.32,-44 739.32,-66 953.32,-66 953.32,-44 739.32,-44"/>
+<text text-anchor="start" x="826.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="739.32,-22 739.32,-44 953.32,-44 953.32,-22 739.32,-22"/>
+<text text-anchor="start" x="760.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="739.32,0 739.32,-22 953.32,-22 953.32,0 739.32,0"/>
+<text text-anchor="start" x="742.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-99C1088.45,-99 1010.32,-258.34 1043.98,-389.2 1063.07,-463.41 1038.19,-718.59 1105.81,-741.37"/>
+<polygon fill="black" stroke="black" points="1105.55,-744.87 1115.98,-743 1106.66,-737.96 1105.55,-744.87"/>
+<text text-anchor="middle" x="1034.65" y="-394.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-121C1019.72,-121 1008.57,-346.75 1025.32,-411 1043.71,-481.54 1039.93,-719.22 1105.75,-741.34"/>
+<polygon fill="black" stroke="black" points="1105.55,-744.86 1115.98,-743 1106.67,-737.95 1105.55,-744.86"/>
+<text text-anchor="middle" x="1034.65" y="-564.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node11" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<polygon fill="none" stroke="black" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<text text-anchor="start" x="56.25" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="80.93" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-615.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="56.04" y="-593.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="64.6" y="-571.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="66.55" y="-549.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="55.26" y="-527.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="99.79" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<text text-anchor="start" x="3.37" y="-482.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-454 0.5,-476 239.5,-476 239.5,-454 0.5,-454"/>
+<text text-anchor="start" x="11.92" y="-460.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-597C307.76,-597 327.47,-597 391.45,-597"/>
+<polygon fill="black" stroke="black" points="391.66,-600.5 401.66,-597 391.66,-593.5 391.66,-600.5"/>
+<text text-anchor="middle" x="320.33" y="-601.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node12" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1222 9.5,-1244 229.5,-1244 229.5,-1222 9.5,-1222"/>
+<polygon fill="none" stroke="black" points="9.5,-1222 9.5,-1244 229.5,-1244 229.5,-1222 9.5,-1222"/>
+<text text-anchor="start" x="83.34" y="-1229.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1200 9.5,-1222 229.5,-1222 229.5,-1200 9.5,-1200"/>
+<text text-anchor="start" x="80.43" y="-1207.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1207.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1178 9.5,-1200 229.5,-1200 229.5,-1178 9.5,-1178"/>
+<text text-anchor="start" x="77.71" y="-1185.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1185.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1156 9.5,-1178 229.5,-1178 229.5,-1156 9.5,-1156"/>
+<text text-anchor="start" x="60.98" y="-1163.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1134 9.5,-1156 229.5,-1156 229.5,-1134 9.5,-1134"/>
+<text text-anchor="start" x="56.71" y="-1141.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-1112 9.5,-1134 229.5,-1134 229.5,-1112 9.5,-1112"/>
+<polygon fill="none" stroke="black" points="9.5,-1112 9.5,-1134 229.5,-1134 229.5,-1112 9.5,-1112"/>
+<text text-anchor="start" x="99.29" y="-1119.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-1090 9.5,-1112 229.5,-1112 229.5,-1090 9.5,-1090"/>
+<text text-anchor="start" x="12.19" y="-1096.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/18.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/18.svg
@@ -1,0 +1,461 @@
+<svg width="1356px" height="1418px"
+ viewBox="0.00 0.00 1355.98 1418.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1382)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1382 1319.98,-1382 1319.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1115.98,-754 1115.98,-776 1283.98,-776 1283.98,-754 1115.98,-754"/>
+<polygon fill="none" stroke="black" points="1115.98,-754 1115.98,-776 1283.98,-776 1283.98,-754 1115.98,-754"/>
+<text text-anchor="start" x="1182.48" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1115.98,-732 1115.98,-754 1283.98,-754 1283.98,-732 1115.98,-732"/>
+<text text-anchor="start" x="1160.91" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1179.19" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1115.98,-710 1115.98,-732 1283.98,-732 1283.98,-710 1115.98,-710"/>
+<text text-anchor="start" x="1167.52" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1196.68" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-688 1115.98,-710 1283.98,-710 1283.98,-688 1115.98,-688"/>
+<text text-anchor="start" x="1142.24" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1221.96" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-666 1115.98,-688 1283.98,-688 1283.98,-666 1115.98,-666"/>
+<text text-anchor="start" x="1144.58" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1195.52" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1115.98,-644 1115.98,-666 1283.98,-666 1283.98,-644 1115.98,-644"/>
+<text text-anchor="start" x="1143.02" y="-651.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1197.08" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1115.98,-622 1115.98,-644 1283.98,-644 1283.98,-622 1115.98,-622"/>
+<text text-anchor="start" x="1155.07" y="-629.4" font-family="Times,serif" font-size="14.00">imdb_id: </text>
+<text text-anchor="start" x="1209.13" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-600 1115.98,-622 1283.98,-622 1283.98,-600 1115.98,-600"/>
+<text text-anchor="start" x="1127.86" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1236.34" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-578 1115.98,-600 1283.98,-600 1283.98,-578 1115.98,-578"/>
+<text text-anchor="start" x="1118.92" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1245.28" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-556 1115.98,-578 1283.98,-578 1283.98,-556 1115.98,-556"/>
+<text text-anchor="start" x="1152.36" y="-563.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1211.84" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-534 1115.98,-556 1283.98,-556 1283.98,-534 1115.98,-534"/>
+<text text-anchor="start" x="1149.64" y="-541.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1214.56" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-512 1115.98,-534 1283.98,-534 1283.98,-512 1115.98,-512"/>
+<text text-anchor="start" x="1145.36" y="-519.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1218.06" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1115.98,-490 1115.98,-512 1283.98,-512 1283.98,-490 1115.98,-490"/>
+<text text-anchor="start" x="1144.59" y="-497.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1219.61" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-468 1115.98,-490 1283.98,-490 1283.98,-468 1115.98,-468"/>
+<text text-anchor="start" x="1149.64" y="-475.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1214.56" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-446 1115.98,-468 1283.98,-468 1283.98,-446 1115.98,-446"/>
+<text text-anchor="start" x="1157.02" y="-453.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1207.18" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-424 1115.98,-446 1283.98,-446 1283.98,-424 1115.98,-424"/>
+<text text-anchor="start" x="1155.47" y="-431.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1208.73" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1115.98,-402 1115.98,-424 1283.98,-424 1283.98,-402 1115.98,-402"/>
+<text text-anchor="start" x="1144.58" y="-409.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1195.52" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1115.98,-380 1115.98,-402 1283.98,-402 1283.98,-380 1115.98,-380"/>
+<text text-anchor="start" x="1160.14" y="-387.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1204.06" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1115.98,-358 1115.98,-380 1283.98,-380 1283.98,-358 1115.98,-358"/>
+<polygon fill="none" stroke="black" points="1115.98,-358 1115.98,-380 1283.98,-380 1283.98,-358 1115.98,-358"/>
+<text text-anchor="start" x="1179.77" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1115.98,-336 1115.98,-358 1283.98,-358 1283.98,-336 1115.98,-336"/>
+<text text-anchor="start" x="1138.16" y="-342.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1115.98,-314 1115.98,-336 1283.98,-336 1283.98,-314 1115.98,-314"/>
+<text text-anchor="start" x="1136.6" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- shows_fts -->
+<g id="node2" class="node">
+<title>shows_fts</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-732 59.5,-754 180.5,-754 180.5,-732 59.5,-732"/>
+<polygon fill="none" stroke="black" points="59.5,-732 59.5,-754 180.5,-754 180.5,-732 59.5,-732"/>
+<text text-anchor="start" x="92" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows_fts</text>
+<polygon fill="none" stroke="black" points="59.5,-710 59.5,-732 180.5,-732 180.5,-710 59.5,-710"/>
+<text text-anchor="start" x="87.53" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="116.7" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-688 59.5,-710 180.5,-710 180.5,-688 59.5,-688"/>
+<text text-anchor="start" x="62.26" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="141.98" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- trending_shows -->
+<g id="node3" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="753.32,-1324 753.32,-1346 940.32,-1346 940.32,-1324 753.32,-1324"/>
+<polygon fill="none" stroke="black" points="753.32,-1324 753.32,-1346 940.32,-1346 940.32,-1324 753.32,-1324"/>
+<text text-anchor="start" x="802.5" y="-1331.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="753.32,-1302 753.32,-1324 940.32,-1324 940.32,-1302 753.32,-1302"/>
+<text text-anchor="start" x="807.75" y="-1309.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1309.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1280 753.32,-1302 940.32,-1302 940.32,-1280 753.32,-1280"/>
+<text text-anchor="start" x="789.47" y="-1287.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1258 753.32,-1280 940.32,-1280 940.32,-1258 753.32,-1258"/>
+<text text-anchor="start" x="799.98" y="-1265.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1236 753.32,-1258 940.32,-1258 940.32,-1236 753.32,-1236"/>
+<text text-anchor="start" x="788.32" y="-1243.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="845.46" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="753.32,-1214 753.32,-1236 940.32,-1236 940.32,-1214 753.32,-1214"/>
+<polygon fill="none" stroke="black" points="753.32,-1214 753.32,-1236 940.32,-1236 940.32,-1214 753.32,-1214"/>
+<text text-anchor="start" x="826.61" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="753.32,-1192 753.32,-1214 940.32,-1214 940.32,-1192 753.32,-1192"/>
+<text text-anchor="start" x="756.22" y="-1198.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M941.32,-1291C971.15,-1291 1069.67,-813.36 1108.62,-749.93"/>
+<polygon fill="black" stroke="black" points="1111.1,-752.4 1115.98,-743 1106.3,-747.3 1111.1,-752.4"/>
+<text text-anchor="middle" x="1034.65" y="-1021.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node4" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="755.32,-1134 755.32,-1156 938.32,-1156 938.32,-1134 755.32,-1134"/>
+<polygon fill="none" stroke="black" points="755.32,-1134 755.32,-1156 938.32,-1156 938.32,-1134 755.32,-1134"/>
+<text text-anchor="start" x="804.44" y="-1141.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="755.32,-1112 755.32,-1134 938.32,-1134 938.32,-1112 755.32,-1112"/>
+<text text-anchor="start" x="807.75" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1119.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1090 755.32,-1112 938.32,-1112 938.32,-1090 755.32,-1090"/>
+<text text-anchor="start" x="789.47" y="-1097.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1068 755.32,-1090 938.32,-1090 938.32,-1068 755.32,-1068"/>
+<text text-anchor="start" x="799.98" y="-1075.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1046 755.32,-1068 938.32,-1068 938.32,-1046 755.32,-1046"/>
+<text text-anchor="start" x="781.71" y="-1053.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="852.06" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="755.32,-1024 755.32,-1046 938.32,-1046 938.32,-1024 755.32,-1024"/>
+<polygon fill="none" stroke="black" points="755.32,-1024 755.32,-1046 938.32,-1046 938.32,-1024 755.32,-1024"/>
+<text text-anchor="start" x="826.61" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="755.32,-1002 755.32,-1024 938.32,-1024 938.32,-1002 755.32,-1002"/>
+<text text-anchor="start" x="758.17" y="-1008.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M939.32,-1101C1024.57,-1101 1027.19,-770.42 1105.98,-744.6"/>
+<polygon fill="black" stroke="black" points="1106.66,-748.03 1115.98,-743 1105.56,-741.12 1106.66,-748.03"/>
+<text text-anchor="middle" x="1034.65" y="-926.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node5" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-1032 53.5,-1054 186.5,-1054 186.5,-1032 53.5,-1032"/>
+<polygon fill="none" stroke="black" points="53.5,-1032 53.5,-1054 186.5,-1054 186.5,-1032 53.5,-1032"/>
+<text text-anchor="start" x="105.62" y="-1039.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-1010 53.5,-1032 186.5,-1032 186.5,-1010 53.5,-1010"/>
+<text text-anchor="start" x="80.93" y="-1017.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-1017.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-988 53.5,-1010 186.5,-1010 186.5,-988 53.5,-988"/>
+<text text-anchor="start" x="71.6" y="-995.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-966 53.5,-988 186.5,-988 186.5,-966 53.5,-966"/>
+<text text-anchor="start" x="83.26" y="-973.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-944 53.5,-966 186.5,-966 186.5,-944 53.5,-944"/>
+<text text-anchor="start" x="65.76" y="-951.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-922 53.5,-944 186.5,-944 186.5,-922 53.5,-922"/>
+<text text-anchor="start" x="75.87" y="-929.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-900 53.5,-922 186.5,-922 186.5,-900 53.5,-900"/>
+<text text-anchor="start" x="82.87" y="-907.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-878 53.5,-900 186.5,-900 186.5,-878 53.5,-878"/>
+<text text-anchor="start" x="70.05" y="-885.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-856 53.5,-878 186.5,-878 186.5,-856 53.5,-856"/>
+<text text-anchor="start" x="77.43" y="-863.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-834 53.5,-856 186.5,-856 186.5,-834 53.5,-834"/>
+<text text-anchor="start" x="69.65" y="-841.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-812 53.5,-834 186.5,-834 186.5,-812 53.5,-812"/>
+<polygon fill="none" stroke="black" points="53.5,-812 53.5,-834 186.5,-834 186.5,-812 53.5,-812"/>
+<text text-anchor="start" x="99.79" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-790 53.5,-812 186.5,-812 186.5,-790 53.5,-790"/>
+<text text-anchor="start" x="56.25" y="-796.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node6" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="752.32,-944 752.32,-966 941.32,-966 941.32,-944 752.32,-944"/>
+<polygon fill="none" stroke="black" points="752.32,-944 752.32,-966 941.32,-966 941.32,-944 752.32,-944"/>
+<text text-anchor="start" x="801.34" y="-951.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="752.32,-922 752.32,-944 941.32,-944 941.32,-922 752.32,-922"/>
+<text text-anchor="start" x="807.75" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-929.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-900 752.32,-922 941.32,-922 941.32,-900 752.32,-900"/>
+<text text-anchor="start" x="789.47" y="-907.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-878 752.32,-900 941.32,-900 941.32,-878 752.32,-878"/>
+<text text-anchor="start" x="788.7" y="-885.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="869.17" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="752.32,-856 752.32,-878 941.32,-878 941.32,-856 752.32,-856"/>
+<polygon fill="none" stroke="black" points="752.32,-856 752.32,-878 941.32,-878 941.32,-856 752.32,-856"/>
+<text text-anchor="start" x="826.61" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="752.32,-834 752.32,-856 941.32,-856 941.32,-834 752.32,-834"/>
+<text text-anchor="start" x="755.07" y="-840.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M942.32,-911C1046.14,-911 1011.16,-753.97 1105.77,-743.54"/>
+<polygon fill="black" stroke="black" points="1106.18,-747.03 1115.98,-743 1105.81,-740.04 1106.18,-747.03"/>
+<text text-anchor="middle" x="1034.65" y="-836.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node7" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="749.32,-776 749.32,-798 944.32,-798 944.32,-776 749.32,-776"/>
+<polygon fill="none" stroke="black" points="749.32,-776 749.32,-798 944.32,-798 944.32,-776 749.32,-776"/>
+<text text-anchor="start" x="798.22" y="-783.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="749.32,-754 749.32,-776 944.32,-776 944.32,-754 749.32,-754"/>
+<text text-anchor="start" x="807.75" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-761.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-732 749.32,-754 944.32,-754 944.32,-732 749.32,-732"/>
+<text text-anchor="start" x="789.47" y="-739.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-710 749.32,-732 944.32,-732 944.32,-710 749.32,-710"/>
+<text text-anchor="start" x="791.81" y="-717.4" font-family="Times,serif" font-size="14.00">followed_at: </text>
+<text text-anchor="start" x="866.07" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="749.32,-688 749.32,-710 944.32,-710 944.32,-688 749.32,-688"/>
+<text text-anchor="start" x="782.09" y="-695.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="875.79" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="749.32,-666 749.32,-688 944.32,-688 944.32,-666 749.32,-666"/>
+<polygon fill="none" stroke="black" points="749.32,-666 749.32,-688 944.32,-688 944.32,-666 749.32,-666"/>
+<text text-anchor="start" x="826.61" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="749.32,-644 749.32,-666 944.32,-666 944.32,-644 749.32,-644"/>
+<text text-anchor="start" x="751.95" y="-650.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M945.32,-743C1017.61,-743 1038.23,-743 1105.68,-743"/>
+<polygon fill="black" stroke="black" points="1105.98,-746.5 1115.98,-743 1105.98,-739.5 1105.98,-746.5"/>
+<text text-anchor="middle" x="1034.65" y="-748.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node8" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="762.32,-586 762.32,-608 930.32,-608 930.32,-586 762.32,-586"/>
+<polygon fill="none" stroke="black" points="762.32,-586 762.32,-608 930.32,-608 930.32,-586 762.32,-586"/>
+<text text-anchor="start" x="824.94" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="762.32,-564 762.32,-586 930.32,-586 930.32,-564 762.32,-564"/>
+<text text-anchor="start" x="807.25" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-571.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-542 762.32,-564 930.32,-564 930.32,-542 762.32,-542"/>
+<text text-anchor="start" x="788.97" y="-549.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-520 762.32,-542 930.32,-542 930.32,-520 762.32,-520"/>
+<text text-anchor="start" x="790.92" y="-527.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="841.86" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-498 762.32,-520 930.32,-520 930.32,-498 762.32,-498"/>
+<text text-anchor="start" x="789.36" y="-505.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="843.42" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-476 762.32,-498 930.32,-498 930.32,-476 762.32,-476"/>
+<text text-anchor="start" x="813.86" y="-483.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="843.02" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-454 762.32,-476 930.32,-476 930.32,-454 762.32,-454"/>
+<text text-anchor="start" x="798.7" y="-461.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="858.18" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-432 762.32,-454 930.32,-454 930.32,-432 762.32,-432"/>
+<text text-anchor="start" x="791.31" y="-439.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="841.47" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-410 762.32,-432 930.32,-432 930.32,-410 762.32,-410"/>
+<text text-anchor="start" x="801.81" y="-417.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="855.07" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-388 762.32,-410 930.32,-410 930.32,-388 762.32,-388"/>
+<text text-anchor="start" x="787.03" y="-395.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="845.74" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-366 762.32,-388 930.32,-388 930.32,-366 762.32,-366"/>
+<text text-anchor="start" x="788.59" y="-373.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="844.18" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-344 762.32,-366 930.32,-366 930.32,-344 762.32,-344"/>
+<text text-anchor="start" x="791.7" y="-351.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="864.4" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="762.32,-322 762.32,-344 930.32,-344 930.32,-322 762.32,-322"/>
+<text text-anchor="start" x="781.59" y="-329.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="851.19" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-300 762.32,-322 930.32,-322 930.32,-300 762.32,-300"/>
+<text text-anchor="start" x="774.2" y="-307.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="882.68" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-278 762.32,-300 930.32,-300 930.32,-278 762.32,-278"/>
+<text text-anchor="start" x="765.26" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="891.62" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="762.32,-256 762.32,-278 930.32,-278 930.32,-256 762.32,-256"/>
+<polygon fill="none" stroke="black" points="762.32,-256 762.32,-278 930.32,-278 930.32,-256 762.32,-256"/>
+<text text-anchor="start" x="826.11" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="762.32,-234 762.32,-256 930.32,-256 930.32,-234 762.32,-234"/>
+<text text-anchor="start" x="780.61" y="-240.4" font-family="Times,serif" font-size="14.00">index_seasons_trakt_id</text>
+<polygon fill="none" stroke="black" points="762.32,-212 762.32,-234 930.32,-234 930.32,-212 762.32,-212"/>
+<text text-anchor="start" x="778.67" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M931.32,-553C986.86,-553 1049.55,-722.09 1105.9,-741.24"/>
+<polygon fill="black" stroke="black" points="1105.53,-744.73 1115.98,-743 1106.73,-737.83 1105.53,-744.73"/>
+<text text-anchor="middle" x="1034.65" y="-681.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node9" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="402.16,-608 402.16,-630 577.16,-630 577.16,-608 402.16,-608"/>
+<polygon fill="none" stroke="black" points="402.16,-608 402.16,-630 577.16,-630 577.16,-608 402.16,-608"/>
+<text text-anchor="start" x="465.56" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="402.16,-586 402.16,-608 577.16,-608 577.16,-586 402.16,-586"/>
+<text text-anchor="start" x="450.59" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="468.87" y="-593.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-564 402.16,-586 577.16,-586 577.16,-564 402.16,-564"/>
+<text text-anchor="start" x="428.43" y="-571.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="491.03" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-542 402.16,-564 577.16,-564 577.16,-542 402.16,-542"/>
+<text text-anchor="start" x="434.26" y="-549.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="485.2" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-520 402.16,-542 577.16,-542 577.16,-520 402.16,-520"/>
+<text text-anchor="start" x="432.7" y="-527.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="486.76" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-498 402.16,-520 577.16,-520 577.16,-498 402.16,-498"/>
+<text text-anchor="start" x="457.19" y="-505.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="486.36" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-476 402.16,-498 577.16,-498 577.16,-476 402.16,-476"/>
+<text text-anchor="start" x="442.04" y="-483.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="501.52" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-454 402.16,-476 577.16,-476 577.16,-454 402.16,-454"/>
+<text text-anchor="start" x="434.65" y="-461.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="484.8" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-432 402.16,-454 577.16,-454 577.16,-432 402.16,-432"/>
+<text text-anchor="start" x="439.32" y="-439.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="504.24" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-410 402.16,-432 577.16,-432 577.16,-410 402.16,-410"/>
+<text text-anchor="start" x="435.03" y="-417.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="507.74" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="402.16,-388 402.16,-410 577.16,-410 577.16,-388 402.16,-388"/>
+<text text-anchor="start" x="405.1" y="-395.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="514.35" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-366 402.16,-388 577.16,-388 577.16,-366 402.16,-366"/>
+<text text-anchor="start" x="408.59" y="-373.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="534.96" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="402.16,-344 402.16,-366 577.16,-366 577.16,-344 402.16,-344"/>
+<polygon fill="none" stroke="black" points="402.16,-344 402.16,-366 577.16,-366 577.16,-344 402.16,-344"/>
+<text text-anchor="start" x="469.45" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="402.16,-322 402.16,-344 577.16,-344 577.16,-322 402.16,-322"/>
+<text text-anchor="start" x="421.23" y="-328.4" font-family="Times,serif" font-size="14.00">index_episodes_trakt_id</text>
+<polygon fill="none" stroke="black" points="402.16,-300 402.16,-322 577.16,-322 577.16,-300 402.16,-300"/>
+<text text-anchor="start" x="415.4" y="-306.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M576.66,-575C655.21,-575 677.37,-575 751.07,-575"/>
+<polygon fill="black" stroke="black" points="751.32,-578.5 761.32,-575 751.32,-571.5 751.32,-578.5"/>
+<text text-anchor="middle" x="657.99" y="-579.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node10" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="739.32,-154 739.32,-176 953.32,-176 953.32,-154 739.32,-154"/>
+<polygon fill="none" stroke="black" points="739.32,-154 739.32,-176 953.32,-176 953.32,-154 739.32,-154"/>
+<text text-anchor="start" x="806.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="739.32,-132 739.32,-154 953.32,-154 953.32,-132 739.32,-132"/>
+<text text-anchor="start" x="807.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-110 739.32,-132 953.32,-132 953.32,-110 739.32,-110"/>
+<text text-anchor="start" x="788.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-88 739.32,-110 953.32,-110 953.32,-88 739.32,-88"/>
+<text text-anchor="start" x="771.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="861.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-66 739.32,-88 953.32,-88 953.32,-66 739.32,-66"/>
+<text text-anchor="start" x="778.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="853.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="739.32,-44 739.32,-66 953.32,-66 953.32,-44 739.32,-44"/>
+<polygon fill="none" stroke="black" points="739.32,-44 739.32,-66 953.32,-66 953.32,-44 739.32,-44"/>
+<text text-anchor="start" x="826.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="739.32,-22 739.32,-44 953.32,-44 953.32,-22 739.32,-22"/>
+<text text-anchor="start" x="760.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="739.32,0 739.32,-22 953.32,-22 953.32,0 739.32,0"/>
+<text text-anchor="start" x="742.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-99C1088.45,-99 1010.32,-258.34 1043.98,-389.2 1063.07,-463.41 1038.19,-718.59 1105.81,-741.37"/>
+<polygon fill="black" stroke="black" points="1105.55,-744.87 1115.98,-743 1106.66,-737.96 1105.55,-744.87"/>
+<text text-anchor="middle" x="1034.65" y="-394.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-121C1019.72,-121 1008.57,-346.75 1025.32,-411 1043.71,-481.54 1039.93,-719.22 1105.75,-741.34"/>
+<polygon fill="black" stroke="black" points="1105.55,-744.86 1115.98,-743 1106.67,-737.95 1105.55,-744.86"/>
+<text text-anchor="middle" x="1034.65" y="-564.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node11" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<polygon fill="none" stroke="black" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<text text-anchor="start" x="56.25" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="80.93" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-615.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="56.04" y="-593.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="64.6" y="-571.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="66.55" y="-549.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="55.26" y="-527.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="99.79" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<text text-anchor="start" x="3.37" y="-482.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-454 0.5,-476 239.5,-476 239.5,-454 0.5,-454"/>
+<text text-anchor="start" x="11.92" y="-460.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-597C307.76,-597 327.47,-597 391.45,-597"/>
+<polygon fill="black" stroke="black" points="391.66,-600.5 401.66,-597 391.66,-593.5 391.66,-600.5"/>
+<text text-anchor="middle" x="320.33" y="-601.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node12" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1222 9.5,-1244 229.5,-1244 229.5,-1222 9.5,-1222"/>
+<polygon fill="none" stroke="black" points="9.5,-1222 9.5,-1244 229.5,-1244 229.5,-1222 9.5,-1222"/>
+<text text-anchor="start" x="83.34" y="-1229.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1200 9.5,-1222 229.5,-1222 229.5,-1200 9.5,-1200"/>
+<text text-anchor="start" x="80.43" y="-1207.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1207.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1178 9.5,-1200 229.5,-1200 229.5,-1178 9.5,-1178"/>
+<text text-anchor="start" x="77.71" y="-1185.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1185.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1156 9.5,-1178 229.5,-1178 229.5,-1156 9.5,-1156"/>
+<text text-anchor="start" x="60.98" y="-1163.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1134 9.5,-1156 229.5,-1156 229.5,-1134 9.5,-1134"/>
+<text text-anchor="start" x="56.71" y="-1141.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-1112 9.5,-1134 229.5,-1134 229.5,-1112 9.5,-1112"/>
+<polygon fill="none" stroke="black" points="9.5,-1112 9.5,-1134 229.5,-1134 229.5,-1112 9.5,-1112"/>
+<text text-anchor="start" x="99.29" y="-1119.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-1090 9.5,-1112 229.5,-1112 229.5,-1090 9.5,-1090"/>
+<text text-anchor="start" x="12.19" y="-1096.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/19.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/19.svg
@@ -1,0 +1,464 @@
+<svg width="1363px" height="1418px"
+ viewBox="0.00 0.00 1362.98 1418.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1382)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1382 1326.98,-1382 1326.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1116.48,-754 1116.48,-776 1291.48,-776 1291.48,-754 1116.48,-754"/>
+<polygon fill="none" stroke="black" points="1116.48,-754 1116.48,-776 1291.48,-776 1291.48,-754 1116.48,-754"/>
+<text text-anchor="start" x="1186.48" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1116.48,-732 1116.48,-754 1291.48,-754 1291.48,-732 1116.48,-732"/>
+<text text-anchor="start" x="1164.91" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1183.19" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-710 1116.48,-732 1291.48,-732 1291.48,-710 1116.48,-710"/>
+<text text-anchor="start" x="1171.52" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1200.68" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-688 1116.48,-710 1291.48,-710 1291.48,-688 1116.48,-688"/>
+<text text-anchor="start" x="1146.24" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1225.96" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-666 1116.48,-688 1291.48,-688 1291.48,-666 1116.48,-666"/>
+<text text-anchor="start" x="1148.58" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1199.52" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-644 1116.48,-666 1291.48,-666 1291.48,-644 1116.48,-644"/>
+<text text-anchor="start" x="1147.02" y="-651.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1201.08" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-622 1116.48,-644 1291.48,-644 1291.48,-622 1116.48,-622"/>
+<text text-anchor="start" x="1159.07" y="-629.4" font-family="Times,serif" font-size="14.00">imdb_id: </text>
+<text text-anchor="start" x="1213.13" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-600 1116.48,-622 1291.48,-622 1291.48,-600 1116.48,-600"/>
+<text text-anchor="start" x="1131.86" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1240.34" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-578 1116.48,-600 1291.48,-600 1291.48,-578 1116.48,-578"/>
+<text text-anchor="start" x="1122.92" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1249.28" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-556 1116.48,-578 1291.48,-578 1291.48,-556 1116.48,-556"/>
+<text text-anchor="start" x="1156.36" y="-563.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1215.84" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-534 1116.48,-556 1291.48,-556 1291.48,-534 1116.48,-534"/>
+<text text-anchor="start" x="1153.64" y="-541.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1218.56" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-512 1116.48,-534 1291.48,-534 1291.48,-512 1116.48,-512"/>
+<text text-anchor="start" x="1149.36" y="-519.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1222.06" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1116.48,-490 1116.48,-512 1291.48,-512 1291.48,-490 1116.48,-490"/>
+<text text-anchor="start" x="1148.59" y="-497.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1223.61" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-468 1116.48,-490 1291.48,-490 1291.48,-468 1116.48,-468"/>
+<text text-anchor="start" x="1153.64" y="-475.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1218.56" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-446 1116.48,-468 1291.48,-468 1291.48,-446 1116.48,-446"/>
+<text text-anchor="start" x="1161.02" y="-453.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1211.18" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-424 1116.48,-446 1291.48,-446 1291.48,-424 1116.48,-424"/>
+<text text-anchor="start" x="1159.47" y="-431.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1212.73" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-402 1116.48,-424 1291.48,-424 1291.48,-402 1116.48,-402"/>
+<text text-anchor="start" x="1148.58" y="-409.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1199.52" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-380 1116.48,-402 1291.48,-402 1291.48,-380 1116.48,-380"/>
+<text text-anchor="start" x="1164.14" y="-387.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1208.06" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-358 1116.48,-380 1291.48,-380 1291.48,-358 1116.48,-358"/>
+<text text-anchor="start" x="1119.04" y="-365.4" font-family="Times,serif" font-size="14.00">last_trakt_data_update: </text>
+<text text-anchor="start" x="1253.16" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1116.48,-336 1116.48,-358 1291.48,-358 1291.48,-336 1116.48,-336"/>
+<polygon fill="none" stroke="black" points="1116.48,-336 1116.48,-358 1291.48,-358 1291.48,-336 1116.48,-336"/>
+<text text-anchor="start" x="1183.77" y="-343.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1116.48,-314 1116.48,-336 1291.48,-336 1291.48,-314 1116.48,-314"/>
+<text text-anchor="start" x="1142.16" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1116.48,-292 1116.48,-314 1291.48,-314 1291.48,-292 1116.48,-292"/>
+<text text-anchor="start" x="1140.6" y="-298.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- shows_fts -->
+<g id="node2" class="node">
+<title>shows_fts</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-732 59.5,-754 180.5,-754 180.5,-732 59.5,-732"/>
+<polygon fill="none" stroke="black" points="59.5,-732 59.5,-754 180.5,-754 180.5,-732 59.5,-732"/>
+<text text-anchor="start" x="92" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows_fts</text>
+<polygon fill="none" stroke="black" points="59.5,-710 59.5,-732 180.5,-732 180.5,-710 59.5,-710"/>
+<text text-anchor="start" x="87.53" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="116.7" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-688 59.5,-710 180.5,-710 180.5,-688 59.5,-688"/>
+<text text-anchor="start" x="62.26" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="141.98" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- trending_shows -->
+<g id="node3" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="753.32,-1324 753.32,-1346 940.32,-1346 940.32,-1324 753.32,-1324"/>
+<polygon fill="none" stroke="black" points="753.32,-1324 753.32,-1346 940.32,-1346 940.32,-1324 753.32,-1324"/>
+<text text-anchor="start" x="802.5" y="-1331.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="753.32,-1302 753.32,-1324 940.32,-1324 940.32,-1302 753.32,-1302"/>
+<text text-anchor="start" x="807.75" y="-1309.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1309.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1280 753.32,-1302 940.32,-1302 940.32,-1280 753.32,-1280"/>
+<text text-anchor="start" x="789.47" y="-1287.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1258 753.32,-1280 940.32,-1280 940.32,-1258 753.32,-1258"/>
+<text text-anchor="start" x="799.98" y="-1265.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1236 753.32,-1258 940.32,-1258 940.32,-1236 753.32,-1236"/>
+<text text-anchor="start" x="788.32" y="-1243.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="845.46" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="753.32,-1214 753.32,-1236 940.32,-1236 940.32,-1214 753.32,-1214"/>
+<polygon fill="none" stroke="black" points="753.32,-1214 753.32,-1236 940.32,-1236 940.32,-1214 753.32,-1214"/>
+<text text-anchor="start" x="826.61" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="753.32,-1192 753.32,-1214 940.32,-1214 940.32,-1192 753.32,-1192"/>
+<text text-anchor="start" x="756.22" y="-1198.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M941.32,-1291C971.15,-1291 1069.67,-813.36 1108.62,-749.93"/>
+<polygon fill="black" stroke="black" points="1111.1,-752.4 1115.98,-743 1106.3,-747.3 1111.1,-752.4"/>
+<text text-anchor="middle" x="1034.65" y="-1021.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node4" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="755.32,-1134 755.32,-1156 938.32,-1156 938.32,-1134 755.32,-1134"/>
+<polygon fill="none" stroke="black" points="755.32,-1134 755.32,-1156 938.32,-1156 938.32,-1134 755.32,-1134"/>
+<text text-anchor="start" x="804.44" y="-1141.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="755.32,-1112 755.32,-1134 938.32,-1134 938.32,-1112 755.32,-1112"/>
+<text text-anchor="start" x="807.75" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1119.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1090 755.32,-1112 938.32,-1112 938.32,-1090 755.32,-1090"/>
+<text text-anchor="start" x="789.47" y="-1097.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1068 755.32,-1090 938.32,-1090 938.32,-1068 755.32,-1068"/>
+<text text-anchor="start" x="799.98" y="-1075.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1046 755.32,-1068 938.32,-1068 938.32,-1046 755.32,-1046"/>
+<text text-anchor="start" x="781.71" y="-1053.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="852.06" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="755.32,-1024 755.32,-1046 938.32,-1046 938.32,-1024 755.32,-1024"/>
+<polygon fill="none" stroke="black" points="755.32,-1024 755.32,-1046 938.32,-1046 938.32,-1024 755.32,-1024"/>
+<text text-anchor="start" x="826.61" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="755.32,-1002 755.32,-1024 938.32,-1024 938.32,-1002 755.32,-1002"/>
+<text text-anchor="start" x="758.17" y="-1008.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M939.32,-1101C1024.57,-1101 1027.19,-770.42 1105.98,-744.6"/>
+<polygon fill="black" stroke="black" points="1106.66,-748.03 1115.98,-743 1105.56,-741.12 1106.66,-748.03"/>
+<text text-anchor="middle" x="1034.65" y="-926.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node5" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-1032 53.5,-1054 186.5,-1054 186.5,-1032 53.5,-1032"/>
+<polygon fill="none" stroke="black" points="53.5,-1032 53.5,-1054 186.5,-1054 186.5,-1032 53.5,-1032"/>
+<text text-anchor="start" x="105.62" y="-1039.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-1010 53.5,-1032 186.5,-1032 186.5,-1010 53.5,-1010"/>
+<text text-anchor="start" x="80.93" y="-1017.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-1017.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-988 53.5,-1010 186.5,-1010 186.5,-988 53.5,-988"/>
+<text text-anchor="start" x="71.6" y="-995.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-966 53.5,-988 186.5,-988 186.5,-966 53.5,-966"/>
+<text text-anchor="start" x="83.26" y="-973.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-944 53.5,-966 186.5,-966 186.5,-944 53.5,-944"/>
+<text text-anchor="start" x="65.76" y="-951.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-922 53.5,-944 186.5,-944 186.5,-922 53.5,-922"/>
+<text text-anchor="start" x="75.87" y="-929.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-900 53.5,-922 186.5,-922 186.5,-900 53.5,-900"/>
+<text text-anchor="start" x="82.87" y="-907.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-878 53.5,-900 186.5,-900 186.5,-878 53.5,-878"/>
+<text text-anchor="start" x="70.05" y="-885.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-856 53.5,-878 186.5,-878 186.5,-856 53.5,-856"/>
+<text text-anchor="start" x="77.43" y="-863.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-834 53.5,-856 186.5,-856 186.5,-834 53.5,-834"/>
+<text text-anchor="start" x="69.65" y="-841.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-812 53.5,-834 186.5,-834 186.5,-812 53.5,-812"/>
+<polygon fill="none" stroke="black" points="53.5,-812 53.5,-834 186.5,-834 186.5,-812 53.5,-812"/>
+<text text-anchor="start" x="99.79" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-790 53.5,-812 186.5,-812 186.5,-790 53.5,-790"/>
+<text text-anchor="start" x="56.25" y="-796.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node6" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="752.32,-944 752.32,-966 941.32,-966 941.32,-944 752.32,-944"/>
+<polygon fill="none" stroke="black" points="752.32,-944 752.32,-966 941.32,-966 941.32,-944 752.32,-944"/>
+<text text-anchor="start" x="801.34" y="-951.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="752.32,-922 752.32,-944 941.32,-944 941.32,-922 752.32,-922"/>
+<text text-anchor="start" x="807.75" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-929.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-900 752.32,-922 941.32,-922 941.32,-900 752.32,-900"/>
+<text text-anchor="start" x="789.47" y="-907.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-878 752.32,-900 941.32,-900 941.32,-878 752.32,-878"/>
+<text text-anchor="start" x="788.7" y="-885.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="869.17" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="752.32,-856 752.32,-878 941.32,-878 941.32,-856 752.32,-856"/>
+<polygon fill="none" stroke="black" points="752.32,-856 752.32,-878 941.32,-878 941.32,-856 752.32,-856"/>
+<text text-anchor="start" x="826.61" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="752.32,-834 752.32,-856 941.32,-856 941.32,-834 752.32,-834"/>
+<text text-anchor="start" x="755.07" y="-840.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M942.32,-911C1046.14,-911 1011.16,-753.97 1105.77,-743.54"/>
+<polygon fill="black" stroke="black" points="1106.18,-747.03 1115.98,-743 1105.81,-740.04 1106.18,-747.03"/>
+<text text-anchor="middle" x="1034.65" y="-836.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node7" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="749.32,-776 749.32,-798 944.32,-798 944.32,-776 749.32,-776"/>
+<polygon fill="none" stroke="black" points="749.32,-776 749.32,-798 944.32,-798 944.32,-776 749.32,-776"/>
+<text text-anchor="start" x="798.22" y="-783.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="749.32,-754 749.32,-776 944.32,-776 944.32,-754 749.32,-754"/>
+<text text-anchor="start" x="807.75" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-761.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-732 749.32,-754 944.32,-754 944.32,-732 749.32,-732"/>
+<text text-anchor="start" x="789.47" y="-739.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-710 749.32,-732 944.32,-732 944.32,-710 749.32,-710"/>
+<text text-anchor="start" x="791.81" y="-717.4" font-family="Times,serif" font-size="14.00">followed_at: </text>
+<text text-anchor="start" x="866.07" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="749.32,-688 749.32,-710 944.32,-710 944.32,-688 749.32,-688"/>
+<text text-anchor="start" x="782.09" y="-695.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="875.79" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="749.32,-666 749.32,-688 944.32,-688 944.32,-666 749.32,-666"/>
+<polygon fill="none" stroke="black" points="749.32,-666 749.32,-688 944.32,-688 944.32,-666 749.32,-666"/>
+<text text-anchor="start" x="826.61" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="749.32,-644 749.32,-666 944.32,-666 944.32,-644 749.32,-644"/>
+<text text-anchor="start" x="751.95" y="-650.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M945.32,-743C1017.61,-743 1038.23,-743 1105.68,-743"/>
+<polygon fill="black" stroke="black" points="1105.98,-746.5 1115.98,-743 1105.98,-739.5 1105.98,-746.5"/>
+<text text-anchor="middle" x="1034.65" y="-748.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node8" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="762.32,-586 762.32,-608 930.32,-608 930.32,-586 762.32,-586"/>
+<polygon fill="none" stroke="black" points="762.32,-586 762.32,-608 930.32,-608 930.32,-586 762.32,-586"/>
+<text text-anchor="start" x="824.94" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="762.32,-564 762.32,-586 930.32,-586 930.32,-564 762.32,-564"/>
+<text text-anchor="start" x="807.25" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-571.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-542 762.32,-564 930.32,-564 930.32,-542 762.32,-542"/>
+<text text-anchor="start" x="788.97" y="-549.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-520 762.32,-542 930.32,-542 930.32,-520 762.32,-520"/>
+<text text-anchor="start" x="790.92" y="-527.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="841.86" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-498 762.32,-520 930.32,-520 930.32,-498 762.32,-498"/>
+<text text-anchor="start" x="789.36" y="-505.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="843.42" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-476 762.32,-498 930.32,-498 930.32,-476 762.32,-476"/>
+<text text-anchor="start" x="813.86" y="-483.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="843.02" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-454 762.32,-476 930.32,-476 930.32,-454 762.32,-454"/>
+<text text-anchor="start" x="798.7" y="-461.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="858.18" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-432 762.32,-454 930.32,-454 930.32,-432 762.32,-432"/>
+<text text-anchor="start" x="791.31" y="-439.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="841.47" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-410 762.32,-432 930.32,-432 930.32,-410 762.32,-410"/>
+<text text-anchor="start" x="801.81" y="-417.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="855.07" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-388 762.32,-410 930.32,-410 930.32,-388 762.32,-388"/>
+<text text-anchor="start" x="787.03" y="-395.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="845.74" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-366 762.32,-388 930.32,-388 930.32,-366 762.32,-366"/>
+<text text-anchor="start" x="788.59" y="-373.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="844.18" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-344 762.32,-366 930.32,-366 930.32,-344 762.32,-344"/>
+<text text-anchor="start" x="791.7" y="-351.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="864.4" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="762.32,-322 762.32,-344 930.32,-344 930.32,-322 762.32,-322"/>
+<text text-anchor="start" x="781.59" y="-329.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="851.19" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-300 762.32,-322 930.32,-322 930.32,-300 762.32,-300"/>
+<text text-anchor="start" x="774.2" y="-307.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="882.68" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-278 762.32,-300 930.32,-300 930.32,-278 762.32,-278"/>
+<text text-anchor="start" x="765.26" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="891.62" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="762.32,-256 762.32,-278 930.32,-278 930.32,-256 762.32,-256"/>
+<polygon fill="none" stroke="black" points="762.32,-256 762.32,-278 930.32,-278 930.32,-256 762.32,-256"/>
+<text text-anchor="start" x="826.11" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="762.32,-234 762.32,-256 930.32,-256 930.32,-234 762.32,-234"/>
+<text text-anchor="start" x="780.61" y="-240.4" font-family="Times,serif" font-size="14.00">index_seasons_trakt_id</text>
+<polygon fill="none" stroke="black" points="762.32,-212 762.32,-234 930.32,-234 930.32,-212 762.32,-212"/>
+<text text-anchor="start" x="778.67" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M931.32,-553C986.86,-553 1049.55,-722.09 1105.9,-741.24"/>
+<polygon fill="black" stroke="black" points="1105.53,-744.73 1115.98,-743 1106.73,-737.83 1105.53,-744.73"/>
+<text text-anchor="middle" x="1034.65" y="-681.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node9" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="402.16,-608 402.16,-630 577.16,-630 577.16,-608 402.16,-608"/>
+<polygon fill="none" stroke="black" points="402.16,-608 402.16,-630 577.16,-630 577.16,-608 402.16,-608"/>
+<text text-anchor="start" x="465.56" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="402.16,-586 402.16,-608 577.16,-608 577.16,-586 402.16,-586"/>
+<text text-anchor="start" x="450.59" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="468.87" y="-593.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-564 402.16,-586 577.16,-586 577.16,-564 402.16,-564"/>
+<text text-anchor="start" x="428.43" y="-571.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="491.03" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-542 402.16,-564 577.16,-564 577.16,-542 402.16,-542"/>
+<text text-anchor="start" x="434.26" y="-549.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="485.2" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-520 402.16,-542 577.16,-542 577.16,-520 402.16,-520"/>
+<text text-anchor="start" x="432.7" y="-527.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="486.76" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-498 402.16,-520 577.16,-520 577.16,-498 402.16,-498"/>
+<text text-anchor="start" x="457.19" y="-505.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="486.36" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-476 402.16,-498 577.16,-498 577.16,-476 402.16,-476"/>
+<text text-anchor="start" x="442.04" y="-483.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="501.52" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-454 402.16,-476 577.16,-476 577.16,-454 402.16,-454"/>
+<text text-anchor="start" x="434.65" y="-461.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="484.8" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-432 402.16,-454 577.16,-454 577.16,-432 402.16,-432"/>
+<text text-anchor="start" x="439.32" y="-439.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="504.24" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-410 402.16,-432 577.16,-432 577.16,-410 402.16,-410"/>
+<text text-anchor="start" x="435.03" y="-417.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="507.74" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="402.16,-388 402.16,-410 577.16,-410 577.16,-388 402.16,-388"/>
+<text text-anchor="start" x="405.1" y="-395.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="514.35" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-366 402.16,-388 577.16,-388 577.16,-366 402.16,-366"/>
+<text text-anchor="start" x="408.59" y="-373.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="534.96" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="402.16,-344 402.16,-366 577.16,-366 577.16,-344 402.16,-344"/>
+<polygon fill="none" stroke="black" points="402.16,-344 402.16,-366 577.16,-366 577.16,-344 402.16,-344"/>
+<text text-anchor="start" x="469.45" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="402.16,-322 402.16,-344 577.16,-344 577.16,-322 402.16,-322"/>
+<text text-anchor="start" x="421.23" y="-328.4" font-family="Times,serif" font-size="14.00">index_episodes_trakt_id</text>
+<polygon fill="none" stroke="black" points="402.16,-300 402.16,-322 577.16,-322 577.16,-300 402.16,-300"/>
+<text text-anchor="start" x="415.4" y="-306.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M576.66,-575C655.21,-575 677.37,-575 751.07,-575"/>
+<polygon fill="black" stroke="black" points="751.32,-578.5 761.32,-575 751.32,-571.5 751.32,-578.5"/>
+<text text-anchor="middle" x="657.99" y="-579.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node10" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="739.32,-154 739.32,-176 953.32,-176 953.32,-154 739.32,-154"/>
+<polygon fill="none" stroke="black" points="739.32,-154 739.32,-176 953.32,-176 953.32,-154 739.32,-154"/>
+<text text-anchor="start" x="806.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="739.32,-132 739.32,-154 953.32,-154 953.32,-132 739.32,-132"/>
+<text text-anchor="start" x="807.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-110 739.32,-132 953.32,-132 953.32,-110 739.32,-110"/>
+<text text-anchor="start" x="788.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-88 739.32,-110 953.32,-110 953.32,-88 739.32,-88"/>
+<text text-anchor="start" x="771.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="861.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-66 739.32,-88 953.32,-88 953.32,-66 739.32,-66"/>
+<text text-anchor="start" x="778.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="853.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="739.32,-44 739.32,-66 953.32,-66 953.32,-44 739.32,-44"/>
+<polygon fill="none" stroke="black" points="739.32,-44 739.32,-66 953.32,-66 953.32,-44 739.32,-44"/>
+<text text-anchor="start" x="826.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="739.32,-22 739.32,-44 953.32,-44 953.32,-22 739.32,-22"/>
+<text text-anchor="start" x="760.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="739.32,0 739.32,-22 953.32,-22 953.32,0 739.32,0"/>
+<text text-anchor="start" x="742.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-99C1088.45,-99 1010.32,-258.34 1043.98,-389.2 1063.07,-463.41 1038.19,-718.59 1105.81,-741.37"/>
+<polygon fill="black" stroke="black" points="1105.55,-744.87 1115.98,-743 1106.66,-737.96 1105.55,-744.87"/>
+<text text-anchor="middle" x="1034.65" y="-394.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-121C1019.72,-121 1008.57,-346.75 1025.32,-411 1043.71,-481.54 1039.93,-719.22 1105.75,-741.34"/>
+<polygon fill="black" stroke="black" points="1105.55,-744.86 1115.98,-743 1106.67,-737.95 1105.55,-744.86"/>
+<text text-anchor="middle" x="1034.65" y="-564.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node11" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<polygon fill="none" stroke="black" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<text text-anchor="start" x="56.25" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="80.93" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-615.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="56.04" y="-593.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="64.6" y="-571.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="66.55" y="-549.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="55.26" y="-527.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="99.79" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<text text-anchor="start" x="3.37" y="-482.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-454 0.5,-476 239.5,-476 239.5,-454 0.5,-454"/>
+<text text-anchor="start" x="11.92" y="-460.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-597C307.76,-597 327.47,-597 391.45,-597"/>
+<polygon fill="black" stroke="black" points="391.66,-600.5 401.66,-597 391.66,-593.5 391.66,-600.5"/>
+<text text-anchor="middle" x="320.33" y="-601.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node12" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1222 9.5,-1244 229.5,-1244 229.5,-1222 9.5,-1222"/>
+<polygon fill="none" stroke="black" points="9.5,-1222 9.5,-1244 229.5,-1244 229.5,-1222 9.5,-1222"/>
+<text text-anchor="start" x="83.34" y="-1229.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1200 9.5,-1222 229.5,-1222 229.5,-1200 9.5,-1200"/>
+<text text-anchor="start" x="80.43" y="-1207.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1207.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1178 9.5,-1200 229.5,-1200 229.5,-1178 9.5,-1178"/>
+<text text-anchor="start" x="77.71" y="-1185.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1185.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1156 9.5,-1178 229.5,-1178 229.5,-1156 9.5,-1156"/>
+<text text-anchor="start" x="60.98" y="-1163.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1134 9.5,-1156 229.5,-1156 229.5,-1134 9.5,-1134"/>
+<text text-anchor="start" x="56.71" y="-1141.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-1112 9.5,-1134 229.5,-1134 229.5,-1112 9.5,-1112"/>
+<polygon fill="none" stroke="black" points="9.5,-1112 9.5,-1134 229.5,-1134 229.5,-1112 9.5,-1112"/>
+<text text-anchor="start" x="99.29" y="-1119.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-1090 9.5,-1112 229.5,-1112 229.5,-1090 9.5,-1090"/>
+<text text-anchor="start" x="12.19" y="-1096.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/2.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/2.svg
@@ -1,0 +1,424 @@
+<svg width="1385px" height="1418px"
+ viewBox="0.00 0.00 1384.98 1418.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1382)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1382 1348.98,-1382 1348.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1144.98,-754 1144.98,-776 1312.98,-776 1312.98,-754 1144.98,-754"/>
+<polygon fill="none" stroke="black" points="1144.98,-754 1144.98,-776 1312.98,-776 1312.98,-754 1144.98,-754"/>
+<text text-anchor="start" x="1211.48" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1144.98,-732 1144.98,-754 1312.98,-754 1312.98,-732 1144.98,-732"/>
+<text text-anchor="start" x="1189.91" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1208.19" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-710 1144.98,-732 1312.98,-732 1312.98,-710 1144.98,-710"/>
+<text text-anchor="start" x="1196.52" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1225.68" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-688 1144.98,-710 1312.98,-710 1312.98,-688 1144.98,-688"/>
+<text text-anchor="start" x="1171.24" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1250.96" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-666 1144.98,-688 1312.98,-688 1312.98,-666 1144.98,-666"/>
+<text text-anchor="start" x="1173.58" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1224.52" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-644 1144.98,-666 1312.98,-666 1312.98,-644 1144.98,-644"/>
+<text text-anchor="start" x="1172.02" y="-651.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1226.08" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-622 1144.98,-644 1312.98,-644 1312.98,-622 1144.98,-622"/>
+<text text-anchor="start" x="1156.86" y="-629.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1265.34" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-600 1144.98,-622 1312.98,-622 1312.98,-600 1144.98,-600"/>
+<text text-anchor="start" x="1147.92" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1274.28" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-578 1144.98,-600 1312.98,-600 1312.98,-578 1144.98,-578"/>
+<text text-anchor="start" x="1168.92" y="-585.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="1253.28" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-556 1144.98,-578 1312.98,-578 1312.98,-556 1144.98,-556"/>
+<text text-anchor="start" x="1167.35" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="1254.85" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-534 1144.98,-556 1312.98,-556 1312.98,-534 1144.98,-534"/>
+<text text-anchor="start" x="1181.36" y="-541.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1240.84" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-512 1144.98,-534 1312.98,-534 1312.98,-512 1144.98,-512"/>
+<text text-anchor="start" x="1178.64" y="-519.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1243.56" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-490 1144.98,-512 1312.98,-512 1312.98,-490 1144.98,-490"/>
+<text text-anchor="start" x="1190.68" y="-497.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="1230.73" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1144.98,-468 1144.98,-490 1312.98,-490 1312.98,-468 1144.98,-468"/>
+<text text-anchor="start" x="1173.59" y="-475.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1248.61" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-446 1144.98,-468 1312.98,-468 1312.98,-446 1144.98,-446"/>
+<text text-anchor="start" x="1186.02" y="-453.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1236.18" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-424 1144.98,-446 1312.98,-446 1312.98,-424 1144.98,-424"/>
+<text text-anchor="start" x="1184.47" y="-431.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1237.73" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-402 1144.98,-424 1312.98,-424 1312.98,-402 1144.98,-402"/>
+<text text-anchor="start" x="1173.58" y="-409.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1224.52" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-380 1144.98,-402 1312.98,-402 1312.98,-380 1144.98,-380"/>
+<text text-anchor="start" x="1189.14" y="-387.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1233.06" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<polygon fill="none" stroke="black" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<text text-anchor="start" x="1208.77" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<text text-anchor="start" x="1167.16" y="-342.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1144.98,-314 1144.98,-336 1312.98,-336 1312.98,-314 1144.98,-314"/>
+<text text-anchor="start" x="1165.6" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="782.32,-1324 782.32,-1346 969.32,-1346 969.32,-1324 782.32,-1324"/>
+<polygon fill="none" stroke="black" points="782.32,-1324 782.32,-1346 969.32,-1346 969.32,-1324 782.32,-1324"/>
+<text text-anchor="start" x="831.5" y="-1331.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="782.32,-1302 782.32,-1324 969.32,-1324 969.32,-1302 782.32,-1302"/>
+<text text-anchor="start" x="836.75" y="-1309.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1309.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<text text-anchor="start" x="818.47" y="-1287.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1258 782.32,-1280 969.32,-1280 969.32,-1258 782.32,-1258"/>
+<text text-anchor="start" x="828.98" y="-1265.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1236 782.32,-1258 969.32,-1258 969.32,-1236 782.32,-1236"/>
+<text text-anchor="start" x="817.32" y="-1243.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="874.46" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<polygon fill="none" stroke="black" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<text text-anchor="start" x="855.61" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="782.32,-1192 782.32,-1214 969.32,-1214 969.32,-1192 782.32,-1192"/>
+<text text-anchor="start" x="785.22" y="-1198.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M970.32,-1291C1000.15,-1291 1098.67,-813.36 1137.62,-749.93"/>
+<polygon fill="black" stroke="black" points="1140.1,-752.4 1144.98,-743 1135.3,-747.3 1140.1,-752.4"/>
+<text text-anchor="middle" x="1063.65" y="-1021.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="784.32,-1134 784.32,-1156 967.32,-1156 967.32,-1134 784.32,-1134"/>
+<polygon fill="none" stroke="black" points="784.32,-1134 784.32,-1156 967.32,-1156 967.32,-1134 784.32,-1134"/>
+<text text-anchor="start" x="833.44" y="-1141.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="784.32,-1112 784.32,-1134 967.32,-1134 967.32,-1112 784.32,-1112"/>
+<text text-anchor="start" x="836.75" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1119.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<text text-anchor="start" x="818.47" y="-1097.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1068 784.32,-1090 967.32,-1090 967.32,-1068 784.32,-1068"/>
+<text text-anchor="start" x="828.98" y="-1075.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1046 784.32,-1068 967.32,-1068 967.32,-1046 784.32,-1046"/>
+<text text-anchor="start" x="810.71" y="-1053.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="881.06" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<polygon fill="none" stroke="black" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<text text-anchor="start" x="855.61" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="784.32,-1002 784.32,-1024 967.32,-1024 967.32,-1002 784.32,-1002"/>
+<text text-anchor="start" x="787.17" y="-1008.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M968.32,-1101C1053.57,-1101 1056.19,-770.42 1134.98,-744.6"/>
+<polygon fill="black" stroke="black" points="1135.66,-748.03 1144.98,-743 1134.56,-741.12 1135.66,-748.03"/>
+<text text-anchor="middle" x="1063.65" y="-926.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="62.5,-886 62.5,-908 176.5,-908 176.5,-886 62.5,-886"/>
+<polygon fill="none" stroke="black" points="62.5,-886 62.5,-908 176.5,-908 176.5,-886 62.5,-886"/>
+<text text-anchor="start" x="105.12" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="62.5,-864 62.5,-886 176.5,-886 176.5,-864 62.5,-864"/>
+<text text-anchor="start" x="80.43" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-871.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="62.5,-842 62.5,-864 176.5,-864 176.5,-842 62.5,-842"/>
+<text text-anchor="start" x="71.1" y="-849.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.13" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-820 62.5,-842 176.5,-842 176.5,-820 62.5,-820"/>
+<text text-anchor="start" x="82.76" y="-827.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.47" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-798 62.5,-820 176.5,-820 176.5,-798 62.5,-798"/>
+<text text-anchor="start" x="65.26" y="-805.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="137.97" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-776 62.5,-798 176.5,-798 176.5,-776 62.5,-776"/>
+<text text-anchor="start" x="75.37" y="-783.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="127.86" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-754 62.5,-776 176.5,-776 176.5,-754 62.5,-754"/>
+<text text-anchor="start" x="82.37" y="-761.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="120.87" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-732 62.5,-754 176.5,-754 176.5,-732 62.5,-732"/>
+<text text-anchor="start" x="69.55" y="-739.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="133.69" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="781.32,-944 781.32,-966 970.32,-966 970.32,-944 781.32,-944"/>
+<polygon fill="none" stroke="black" points="781.32,-944 781.32,-966 970.32,-966 970.32,-944 781.32,-944"/>
+<text text-anchor="start" x="830.34" y="-951.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="781.32,-922 781.32,-944 970.32,-944 970.32,-922 781.32,-922"/>
+<text text-anchor="start" x="836.75" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-929.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<text text-anchor="start" x="818.47" y="-907.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-878 781.32,-900 970.32,-900 970.32,-878 781.32,-878"/>
+<text text-anchor="start" x="817.7" y="-885.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="898.17" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<polygon fill="none" stroke="black" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<text text-anchor="start" x="855.61" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="781.32,-834 781.32,-856 970.32,-856 970.32,-834 781.32,-834"/>
+<text text-anchor="start" x="784.07" y="-840.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M971.32,-911C1075.14,-911 1040.16,-753.97 1134.77,-743.54"/>
+<polygon fill="black" stroke="black" points="1135.18,-747.03 1144.98,-743 1134.81,-740.04 1135.18,-747.03"/>
+<text text-anchor="middle" x="1063.65" y="-836.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="778.32,-776 778.32,-798 973.32,-798 973.32,-776 778.32,-776"/>
+<polygon fill="none" stroke="black" points="778.32,-776 778.32,-798 973.32,-798 973.32,-776 778.32,-776"/>
+<text text-anchor="start" x="827.22" y="-783.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="778.32,-754 778.32,-776 973.32,-776 973.32,-754 778.32,-754"/>
+<text text-anchor="start" x="836.75" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-761.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<text text-anchor="start" x="818.47" y="-739.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<polygon fill="none" stroke="black" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<text text-anchor="start" x="855.61" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="778.32,-688 778.32,-710 973.32,-710 973.32,-688 778.32,-688"/>
+<text text-anchor="start" x="780.95" y="-694.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M974.32,-743C1046.61,-743 1067.23,-743 1134.68,-743"/>
+<polygon fill="black" stroke="black" points="1134.98,-746.5 1144.98,-743 1134.98,-739.5 1134.98,-746.5"/>
+<text text-anchor="middle" x="1063.65" y="-748.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="780.32,-630 780.32,-652 971.32,-652 971.32,-630 780.32,-630"/>
+<polygon fill="none" stroke="black" points="780.32,-630 780.32,-652 971.32,-652 971.32,-630 780.32,-630"/>
+<text text-anchor="start" x="854.44" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="780.32,-608 780.32,-630 971.32,-630 971.32,-608 780.32,-608"/>
+<text text-anchor="start" x="836.75" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-615.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-586 780.32,-608 971.32,-608 971.32,-586 780.32,-586"/>
+<text text-anchor="start" x="818.47" y="-593.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<text text-anchor="start" x="820.42" y="-571.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="871.36" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-542 780.32,-564 971.32,-564 971.32,-542 780.32,-542"/>
+<text text-anchor="start" x="818.86" y="-549.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="872.92" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-520 780.32,-542 971.32,-542 971.32,-520 780.32,-520"/>
+<text text-anchor="start" x="843.36" y="-527.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="872.52" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-498 780.32,-520 971.32,-520 971.32,-498 780.32,-498"/>
+<text text-anchor="start" x="828.2" y="-505.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="887.68" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-476 780.32,-498 971.32,-498 971.32,-476 780.32,-476"/>
+<text text-anchor="start" x="820.81" y="-483.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="870.97" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-454 780.32,-476 971.32,-476 971.32,-454 780.32,-454"/>
+<text text-anchor="start" x="816.53" y="-461.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="875.24" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-432 780.32,-454 971.32,-454 971.32,-432 780.32,-432"/>
+<text text-anchor="start" x="818.09" y="-439.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="873.68" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-410 780.32,-432 971.32,-432 971.32,-410 780.32,-410"/>
+<text text-anchor="start" x="837.52" y="-417.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="877.57" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="780.32,-388 780.32,-410 971.32,-410 971.32,-388 780.32,-388"/>
+<text text-anchor="start" x="831.31" y="-395.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="884.57" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-366 780.32,-388 971.32,-388 971.32,-366 780.32,-366"/>
+<text text-anchor="start" x="827.42" y="-373.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="864.36" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-344 780.32,-366 971.32,-366 971.32,-344 780.32,-344"/>
+<text text-anchor="start" x="803.7" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="912.18" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-322 780.32,-344 971.32,-344 971.32,-322 780.32,-322"/>
+<text text-anchor="start" x="794.76" y="-329.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="921.12" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-300 780.32,-322 971.32,-322 971.32,-300 780.32,-300"/>
+<text text-anchor="start" x="815.76" y="-307.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="900.12" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-278 780.32,-300 971.32,-300 971.32,-278 780.32,-278"/>
+<text text-anchor="start" x="814.19" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="901.68" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-256 780.32,-278 971.32,-278 971.32,-256 780.32,-256"/>
+<text text-anchor="start" x="804.48" y="-263.4" font-family="Times,serif" font-size="14.00">episodes_updated: </text>
+<text text-anchor="start" x="911.4" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<polygon fill="none" stroke="black" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<text text-anchor="start" x="855.61" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="780.32,-212 780.32,-234 971.32,-234 971.32,-212 780.32,-212"/>
+<text text-anchor="start" x="783.28" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M972.32,-597C1030.65,-597 1028.48,-643.49 1072.98,-681.2 1102.27,-706.01 1102.95,-736.85 1134.64,-742.19"/>
+<polygon fill="black" stroke="black" points="1134.74,-745.71 1144.98,-743 1135.28,-738.73 1134.74,-745.71"/>
+<text text-anchor="middle" x="1063.65" y="-686.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="401.66,-652 401.66,-674 605.66,-674 605.66,-652 401.66,-652"/>
+<polygon fill="none" stroke="black" points="401.66,-652 401.66,-674 605.66,-674 605.66,-652 401.66,-652"/>
+<text text-anchor="start" x="479.56" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="401.66,-630 401.66,-652 605.66,-652 605.66,-630 401.66,-630"/>
+<text text-anchor="start" x="464.59" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="482.87" y="-637.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-608 401.66,-630 605.66,-630 605.66,-608 401.66,-608"/>
+<text text-anchor="start" x="442.43" y="-615.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="505.03" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<text text-anchor="start" x="448.26" y="-593.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="499.2" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-564 401.66,-586 605.66,-586 605.66,-564 401.66,-564"/>
+<text text-anchor="start" x="446.7" y="-571.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="500.76" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-542 401.66,-564 605.66,-564 605.66,-542 401.66,-542"/>
+<text text-anchor="start" x="471.19" y="-549.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="500.36" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-520 401.66,-542 605.66,-542 605.66,-520 401.66,-520"/>
+<text text-anchor="start" x="456.04" y="-527.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="515.52" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-498 401.66,-520 605.66,-520 605.66,-498 401.66,-498"/>
+<text text-anchor="start" x="448.65" y="-505.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="498.8" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-476 401.66,-498 605.66,-498 605.66,-476 401.66,-476"/>
+<text text-anchor="start" x="453.32" y="-483.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="518.24" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-454 401.66,-476 605.66,-476 605.66,-454 401.66,-454"/>
+<text text-anchor="start" x="465.36" y="-461.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="505.41" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="401.66,-432 401.66,-454 605.66,-454 605.66,-432 401.66,-432"/>
+<text text-anchor="start" x="455.26" y="-439.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="492.2" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-410 401.66,-432 605.66,-432 605.66,-410 401.66,-410"/>
+<text text-anchor="start" x="431.53" y="-417.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="540.02" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-388 401.66,-410 605.66,-410 605.66,-388 401.66,-388"/>
+<text text-anchor="start" x="422.59" y="-395.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="548.96" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-366 401.66,-388 605.66,-388 605.66,-366 401.66,-366"/>
+<text text-anchor="start" x="443.59" y="-373.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="527.96" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-344 401.66,-366 605.66,-366 605.66,-344 401.66,-344"/>
+<text text-anchor="start" x="442.03" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="529.52" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<text text-anchor="start" x="436.99" y="-329.4" font-family="Times,serif" font-size="14.00">last_watched_at: </text>
+<text text-anchor="start" x="534.57" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<polygon fill="none" stroke="black" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<text text-anchor="start" x="483.45" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="401.66,-278 401.66,-300 605.66,-300 605.66,-278 401.66,-278"/>
+<text text-anchor="start" x="404.52" y="-284.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M605.66,-619C679.38,-619 700.29,-619 769.26,-619"/>
+<polygon fill="black" stroke="black" points="769.32,-622.5 779.32,-619 769.32,-615.5 769.32,-622.5"/>
+<text text-anchor="middle" x="686.99" y="-623.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<polygon fill="none" stroke="black" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<text text-anchor="start" x="835.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="768.32,-132 768.32,-154 982.32,-154 982.32,-132 768.32,-132"/>
+<text text-anchor="start" x="836.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="854.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-110 768.32,-132 982.32,-132 982.32,-110 768.32,-110"/>
+<text text-anchor="start" x="817.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="872.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-88 768.32,-110 982.32,-110 982.32,-88 768.32,-88"/>
+<text text-anchor="start" x="800.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="890.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-66 768.32,-88 982.32,-88 982.32,-66 768.32,-66"/>
+<text text-anchor="start" x="807.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="882.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<polygon fill="none" stroke="black" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<text text-anchor="start" x="855.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="768.32,-22 768.32,-44 982.32,-44 982.32,-22 768.32,-22"/>
+<text text-anchor="start" x="789.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="768.32,0 768.32,-22 982.32,-22 982.32,0 768.32,0"/>
+<text text-anchor="start" x="771.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-99C1123.82,-99 1038.1,-267.06 1072.98,-404.2 1091.07,-475.3 1070.16,-718.65 1134.81,-741.31"/>
+<polygon fill="black" stroke="black" points="1134.54,-744.81 1144.98,-743 1135.69,-737.9 1134.54,-744.81"/>
+<text text-anchor="middle" x="1063.65" y="-409.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-121C1051.96,-121 1036.74,-358.61 1054.32,-426 1071.91,-493.43 1071.77,-719.38 1134.77,-741.29"/>
+<polygon fill="black" stroke="black" points="1134.54,-744.8 1144.98,-743 1135.7,-737.9 1134.54,-744.8"/>
+<text text-anchor="middle" x="1063.65" y="-564.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node10" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-674 0.5,-696 239.5,-696 239.5,-674 0.5,-674"/>
+<polygon fill="none" stroke="black" points="0.5,-674 0.5,-696 239.5,-696 239.5,-674 0.5,-674"/>
+<text text-anchor="start" x="56.25" y="-681.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-652 0.5,-674 239.5,-674 239.5,-652 0.5,-652"/>
+<text text-anchor="start" x="80.93" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-659.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<text text-anchor="start" x="56.04" y="-637.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-637.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="64.6" y="-615.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="66.55" y="-593.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="43.21" y="-571.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="136.92" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="99.79" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="3.37" y="-526.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="11.92" y="-504.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-641C307.76,-641 327.47,-641 391.45,-641"/>
+<polygon fill="black" stroke="black" points="391.66,-644.5 401.66,-641 391.66,-637.5 391.66,-644.5"/>
+<text text-anchor="middle" x="320.33" y="-645.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/20.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/20.svg
@@ -1,0 +1,498 @@
+<svg width="1363px" height="1630px"
+ viewBox="0.00 0.00 1362.98 1630.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1594)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1594 1326.98,-1594 1326.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1116.48,-918 1116.48,-940 1291.48,-940 1291.48,-918 1116.48,-918"/>
+<polygon fill="none" stroke="black" points="1116.48,-918 1116.48,-940 1291.48,-940 1291.48,-918 1116.48,-918"/>
+<text text-anchor="start" x="1186.48" y="-925.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1116.48,-896 1116.48,-918 1291.48,-918 1291.48,-896 1116.48,-896"/>
+<text text-anchor="start" x="1164.91" y="-903.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1183.19" y="-903.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-874 1116.48,-896 1291.48,-896 1291.48,-874 1116.48,-874"/>
+<text text-anchor="start" x="1171.52" y="-881.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1200.68" y="-881.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-852 1116.48,-874 1291.48,-874 1291.48,-852 1116.48,-852"/>
+<text text-anchor="start" x="1146.24" y="-859.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1225.96" y="-859.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-830 1116.48,-852 1291.48,-852 1291.48,-830 1116.48,-830"/>
+<text text-anchor="start" x="1148.58" y="-837.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1199.52" y="-837.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-808 1116.48,-830 1291.48,-830 1291.48,-808 1116.48,-808"/>
+<text text-anchor="start" x="1147.02" y="-815.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1201.08" y="-815.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-786 1116.48,-808 1291.48,-808 1291.48,-786 1116.48,-786"/>
+<text text-anchor="start" x="1159.07" y="-793.4" font-family="Times,serif" font-size="14.00">imdb_id: </text>
+<text text-anchor="start" x="1213.13" y="-793.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-764 1116.48,-786 1291.48,-786 1291.48,-764 1116.48,-764"/>
+<text text-anchor="start" x="1131.86" y="-771.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1240.34" y="-771.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-742 1116.48,-764 1291.48,-764 1291.48,-742 1116.48,-742"/>
+<text text-anchor="start" x="1122.92" y="-749.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1249.28" y="-749.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-720 1116.48,-742 1291.48,-742 1291.48,-720 1116.48,-720"/>
+<text text-anchor="start" x="1156.36" y="-727.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1215.84" y="-727.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-698 1116.48,-720 1291.48,-720 1291.48,-698 1116.48,-698"/>
+<text text-anchor="start" x="1153.64" y="-705.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1218.56" y="-705.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-676 1116.48,-698 1291.48,-698 1291.48,-676 1116.48,-676"/>
+<text text-anchor="start" x="1149.36" y="-683.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1222.06" y="-683.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1116.48,-654 1116.48,-676 1291.48,-676 1291.48,-654 1116.48,-654"/>
+<text text-anchor="start" x="1148.59" y="-661.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1223.61" y="-661.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-632 1116.48,-654 1291.48,-654 1291.48,-632 1116.48,-632"/>
+<text text-anchor="start" x="1153.64" y="-639.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1218.56" y="-639.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-610 1116.48,-632 1291.48,-632 1291.48,-610 1116.48,-610"/>
+<text text-anchor="start" x="1161.02" y="-617.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1211.18" y="-617.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-588 1116.48,-610 1291.48,-610 1291.48,-588 1116.48,-588"/>
+<text text-anchor="start" x="1159.47" y="-595.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1212.73" y="-595.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-566 1116.48,-588 1291.48,-588 1291.48,-566 1116.48,-566"/>
+<text text-anchor="start" x="1148.58" y="-573.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1199.52" y="-573.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-544 1116.48,-566 1291.48,-566 1291.48,-544 1116.48,-544"/>
+<text text-anchor="start" x="1164.14" y="-551.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1208.06" y="-551.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-522 1116.48,-544 1291.48,-544 1291.48,-522 1116.48,-522"/>
+<text text-anchor="start" x="1119.04" y="-529.4" font-family="Times,serif" font-size="14.00">last_trakt_data_update: </text>
+<text text-anchor="start" x="1253.16" y="-529.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1116.48,-500 1116.48,-522 1291.48,-522 1291.48,-500 1116.48,-500"/>
+<polygon fill="none" stroke="black" points="1116.48,-500 1116.48,-522 1291.48,-522 1291.48,-500 1116.48,-500"/>
+<text text-anchor="start" x="1183.77" y="-507.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1116.48,-478 1116.48,-500 1291.48,-500 1291.48,-478 1116.48,-478"/>
+<text text-anchor="start" x="1142.16" y="-484.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1116.48,-456 1116.48,-478 1291.48,-478 1291.48,-456 1116.48,-456"/>
+<text text-anchor="start" x="1140.6" y="-462.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- shows_fts -->
+<g id="node2" class="node">
+<title>shows_fts</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-944 59.5,-966 180.5,-966 180.5,-944 59.5,-944"/>
+<polygon fill="none" stroke="black" points="59.5,-944 59.5,-966 180.5,-966 180.5,-944 59.5,-944"/>
+<text text-anchor="start" x="92" y="-951.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows_fts</text>
+<polygon fill="none" stroke="black" points="59.5,-922 59.5,-944 180.5,-944 180.5,-922 59.5,-922"/>
+<text text-anchor="start" x="87.53" y="-929.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="116.7" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-900 59.5,-922 180.5,-922 180.5,-900 59.5,-900"/>
+<text text-anchor="start" x="62.26" y="-907.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="141.98" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- trending_shows -->
+<g id="node3" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="753.32,-1536 753.32,-1558 940.32,-1558 940.32,-1536 753.32,-1536"/>
+<polygon fill="none" stroke="black" points="753.32,-1536 753.32,-1558 940.32,-1558 940.32,-1536 753.32,-1536"/>
+<text text-anchor="start" x="802.5" y="-1543.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="753.32,-1514 753.32,-1536 940.32,-1536 940.32,-1514 753.32,-1514"/>
+<text text-anchor="start" x="807.75" y="-1521.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1521.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1492 753.32,-1514 940.32,-1514 940.32,-1492 753.32,-1492"/>
+<text text-anchor="start" x="789.47" y="-1499.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1499.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1470 753.32,-1492 940.32,-1492 940.32,-1470 753.32,-1470"/>
+<text text-anchor="start" x="799.98" y="-1477.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1477.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1448 753.32,-1470 940.32,-1470 940.32,-1448 753.32,-1448"/>
+<text text-anchor="start" x="788.32" y="-1455.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="845.46" y="-1455.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="753.32,-1426 753.32,-1448 940.32,-1448 940.32,-1426 753.32,-1426"/>
+<polygon fill="none" stroke="black" points="753.32,-1426 753.32,-1448 940.32,-1448 940.32,-1426 753.32,-1426"/>
+<text text-anchor="start" x="826.61" y="-1433.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="753.32,-1404 753.32,-1426 940.32,-1426 940.32,-1404 753.32,-1404"/>
+<text text-anchor="start" x="756.22" y="-1410.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M941.32,-1503C973.6,-1503 1068.15,-981.35 1108.46,-914.11"/>
+<polygon fill="black" stroke="black" points="1111.12,-916.41 1115.98,-907 1106.31,-911.33 1111.12,-916.41"/>
+<text text-anchor="middle" x="1034.65" y="-1209.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node4" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="755.32,-1346 755.32,-1368 938.32,-1368 938.32,-1346 755.32,-1346"/>
+<polygon fill="none" stroke="black" points="755.32,-1346 755.32,-1368 938.32,-1368 938.32,-1346 755.32,-1346"/>
+<text text-anchor="start" x="804.44" y="-1353.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="755.32,-1324 755.32,-1346 938.32,-1346 938.32,-1324 755.32,-1324"/>
+<text text-anchor="start" x="807.75" y="-1331.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1331.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1302 755.32,-1324 938.32,-1324 938.32,-1302 755.32,-1302"/>
+<text text-anchor="start" x="789.47" y="-1309.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1309.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1280 755.32,-1302 938.32,-1302 938.32,-1280 755.32,-1280"/>
+<text text-anchor="start" x="799.98" y="-1287.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1258 755.32,-1280 938.32,-1280 938.32,-1258 755.32,-1258"/>
+<text text-anchor="start" x="781.71" y="-1265.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="852.06" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="755.32,-1236 755.32,-1258 938.32,-1258 938.32,-1236 755.32,-1236"/>
+<polygon fill="none" stroke="black" points="755.32,-1236 755.32,-1258 938.32,-1258 938.32,-1236 755.32,-1236"/>
+<text text-anchor="start" x="826.61" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="755.32,-1214 755.32,-1236 938.32,-1236 938.32,-1214 755.32,-1214"/>
+<text text-anchor="start" x="758.17" y="-1220.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M939.32,-1313C985.54,-1313 1057.41,-954.68 1106.74,-911.28"/>
+<polygon fill="black" stroke="black" points="1108.38,-914.38 1115.98,-907 1105.44,-908.03 1108.38,-914.38"/>
+<text text-anchor="middle" x="1034.65" y="-1114.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node5" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-1244 53.5,-1266 186.5,-1266 186.5,-1244 53.5,-1244"/>
+<polygon fill="none" stroke="black" points="53.5,-1244 53.5,-1266 186.5,-1266 186.5,-1244 53.5,-1244"/>
+<text text-anchor="start" x="105.62" y="-1251.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-1222 53.5,-1244 186.5,-1244 186.5,-1222 53.5,-1222"/>
+<text text-anchor="start" x="80.93" y="-1229.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-1229.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-1200 53.5,-1222 186.5,-1222 186.5,-1200 53.5,-1200"/>
+<text text-anchor="start" x="71.6" y="-1207.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-1207.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1178 53.5,-1200 186.5,-1200 186.5,-1178 53.5,-1178"/>
+<text text-anchor="start" x="83.26" y="-1185.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-1185.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1156 53.5,-1178 186.5,-1178 186.5,-1156 53.5,-1156"/>
+<text text-anchor="start" x="65.76" y="-1163.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1134 53.5,-1156 186.5,-1156 186.5,-1134 53.5,-1134"/>
+<text text-anchor="start" x="75.87" y="-1141.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1112 53.5,-1134 186.5,-1134 186.5,-1112 53.5,-1112"/>
+<text text-anchor="start" x="82.87" y="-1119.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-1119.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1090 53.5,-1112 186.5,-1112 186.5,-1090 53.5,-1090"/>
+<text text-anchor="start" x="70.05" y="-1097.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1068 53.5,-1090 186.5,-1090 186.5,-1068 53.5,-1068"/>
+<text text-anchor="start" x="77.43" y="-1075.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-1046 53.5,-1068 186.5,-1068 186.5,-1046 53.5,-1046"/>
+<text text-anchor="start" x="69.65" y="-1053.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-1024 53.5,-1046 186.5,-1046 186.5,-1024 53.5,-1024"/>
+<polygon fill="none" stroke="black" points="53.5,-1024 53.5,-1046 186.5,-1046 186.5,-1024 53.5,-1024"/>
+<text text-anchor="start" x="99.79" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-1002 53.5,-1024 186.5,-1024 186.5,-1002 53.5,-1002"/>
+<text text-anchor="start" x="56.25" y="-1008.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node6" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="752.32,-1156 752.32,-1178 941.32,-1178 941.32,-1156 752.32,-1156"/>
+<polygon fill="none" stroke="black" points="752.32,-1156 752.32,-1178 941.32,-1178 941.32,-1156 752.32,-1156"/>
+<text text-anchor="start" x="801.34" y="-1163.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="752.32,-1134 752.32,-1156 941.32,-1156 941.32,-1134 752.32,-1134"/>
+<text text-anchor="start" x="807.75" y="-1141.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1141.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-1112 752.32,-1134 941.32,-1134 941.32,-1112 752.32,-1112"/>
+<text text-anchor="start" x="789.47" y="-1119.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1119.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-1090 752.32,-1112 941.32,-1112 941.32,-1090 752.32,-1090"/>
+<text text-anchor="start" x="788.7" y="-1097.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="869.17" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="752.32,-1068 752.32,-1090 941.32,-1090 941.32,-1068 752.32,-1068"/>
+<polygon fill="none" stroke="black" points="752.32,-1068 752.32,-1090 941.32,-1090 941.32,-1068 752.32,-1068"/>
+<text text-anchor="start" x="826.61" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="752.32,-1046 752.32,-1068 941.32,-1068 941.32,-1046 752.32,-1046"/>
+<text text-anchor="start" x="755.07" y="-1052.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M942.32,-1123C1062.01,-1123 996.76,-919.06 1105.98,-907.51"/>
+<polygon fill="black" stroke="black" points="1106.17,-911 1115.98,-907 1105.82,-904.01 1106.17,-911"/>
+<text text-anchor="middle" x="1034.65" y="-1031.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node7" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="749.32,-988 749.32,-1010 944.32,-1010 944.32,-988 749.32,-988"/>
+<polygon fill="none" stroke="black" points="749.32,-988 749.32,-1010 944.32,-1010 944.32,-988 749.32,-988"/>
+<text text-anchor="start" x="798.22" y="-995.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="749.32,-966 749.32,-988 944.32,-988 944.32,-966 749.32,-966"/>
+<text text-anchor="start" x="807.75" y="-973.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-973.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-944 749.32,-966 944.32,-966 944.32,-944 749.32,-944"/>
+<text text-anchor="start" x="789.47" y="-951.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-922 749.32,-944 944.32,-944 944.32,-922 749.32,-922"/>
+<text text-anchor="start" x="791.81" y="-929.4" font-family="Times,serif" font-size="14.00">followed_at: </text>
+<text text-anchor="start" x="866.07" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="749.32,-900 749.32,-922 944.32,-922 944.32,-900 749.32,-900"/>
+<text text-anchor="start" x="782.09" y="-907.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="875.79" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="749.32,-878 749.32,-900 944.32,-900 944.32,-878 749.32,-878"/>
+<polygon fill="none" stroke="black" points="749.32,-878 749.32,-900 944.32,-900 944.32,-878 749.32,-878"/>
+<text text-anchor="start" x="826.61" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="749.32,-856 749.32,-878 944.32,-878 944.32,-856 749.32,-856"/>
+<text text-anchor="start" x="751.95" y="-862.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M945.32,-955C1020.57,-955 1035.88,-911.22 1105.75,-907.28"/>
+<polygon fill="black" stroke="black" points="1106.08,-910.77 1115.98,-907 1105.89,-903.78 1106.08,-910.77"/>
+<text text-anchor="middle" x="1034.65" y="-936.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node8" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="762.32,-798 762.32,-820 930.32,-820 930.32,-798 762.32,-798"/>
+<polygon fill="none" stroke="black" points="762.32,-798 762.32,-820 930.32,-820 930.32,-798 762.32,-798"/>
+<text text-anchor="start" x="824.94" y="-805.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="762.32,-776 762.32,-798 930.32,-798 930.32,-776 762.32,-776"/>
+<text text-anchor="start" x="807.25" y="-783.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-783.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-754 762.32,-776 930.32,-776 930.32,-754 762.32,-754"/>
+<text text-anchor="start" x="788.97" y="-761.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-732 762.32,-754 930.32,-754 930.32,-732 762.32,-732"/>
+<text text-anchor="start" x="790.92" y="-739.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="841.86" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-710 762.32,-732 930.32,-732 930.32,-710 762.32,-710"/>
+<text text-anchor="start" x="789.36" y="-717.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="843.42" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-688 762.32,-710 930.32,-710 930.32,-688 762.32,-688"/>
+<text text-anchor="start" x="813.86" y="-695.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="843.02" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-666 762.32,-688 930.32,-688 930.32,-666 762.32,-666"/>
+<text text-anchor="start" x="798.7" y="-673.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="858.18" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-644 762.32,-666 930.32,-666 930.32,-644 762.32,-644"/>
+<text text-anchor="start" x="791.31" y="-651.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="841.47" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-622 762.32,-644 930.32,-644 930.32,-622 762.32,-622"/>
+<text text-anchor="start" x="801.81" y="-629.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="855.07" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-600 762.32,-622 930.32,-622 930.32,-600 762.32,-600"/>
+<text text-anchor="start" x="787.03" y="-607.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="845.74" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-578 762.32,-600 930.32,-600 930.32,-578 762.32,-578"/>
+<text text-anchor="start" x="788.59" y="-585.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="844.18" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-556 762.32,-578 930.32,-578 930.32,-556 762.32,-556"/>
+<text text-anchor="start" x="791.7" y="-563.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="864.4" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="762.32,-534 762.32,-556 930.32,-556 930.32,-534 762.32,-534"/>
+<text text-anchor="start" x="781.59" y="-541.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="851.19" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-512 762.32,-534 930.32,-534 930.32,-512 762.32,-512"/>
+<text text-anchor="start" x="774.2" y="-519.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="882.68" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-490 762.32,-512 930.32,-512 930.32,-490 762.32,-490"/>
+<text text-anchor="start" x="765.26" y="-497.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="891.62" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="762.32,-468 762.32,-490 930.32,-490 930.32,-468 762.32,-468"/>
+<polygon fill="none" stroke="black" points="762.32,-468 762.32,-490 930.32,-490 930.32,-468 762.32,-468"/>
+<text text-anchor="start" x="826.11" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="762.32,-446 762.32,-468 930.32,-468 930.32,-446 762.32,-446"/>
+<text text-anchor="start" x="780.61" y="-452.4" font-family="Times,serif" font-size="14.00">index_seasons_trakt_id</text>
+<polygon fill="none" stroke="black" points="762.32,-424 762.32,-446 930.32,-446 930.32,-424 762.32,-424"/>
+<text text-anchor="start" x="778.67" y="-430.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M931.32,-765C1031.31,-765 1013.83,-897.46 1105.8,-906.51"/>
+<polygon fill="black" stroke="black" points="1105.83,-910.02 1115.98,-907 1106.16,-903.03 1105.83,-910.02"/>
+<text text-anchor="middle" x="1034.65" y="-869.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node9" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="402.16,-820 402.16,-842 577.16,-842 577.16,-820 402.16,-820"/>
+<polygon fill="none" stroke="black" points="402.16,-820 402.16,-842 577.16,-842 577.16,-820 402.16,-820"/>
+<text text-anchor="start" x="465.56" y="-827.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="402.16,-798 402.16,-820 577.16,-820 577.16,-798 402.16,-798"/>
+<text text-anchor="start" x="450.59" y="-805.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="468.87" y="-805.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-776 402.16,-798 577.16,-798 577.16,-776 402.16,-776"/>
+<text text-anchor="start" x="428.43" y="-783.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="491.03" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-754 402.16,-776 577.16,-776 577.16,-754 402.16,-754"/>
+<text text-anchor="start" x="434.26" y="-761.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="485.2" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-732 402.16,-754 577.16,-754 577.16,-732 402.16,-732"/>
+<text text-anchor="start" x="432.7" y="-739.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="486.76" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-710 402.16,-732 577.16,-732 577.16,-710 402.16,-710"/>
+<text text-anchor="start" x="457.19" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="486.36" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-688 402.16,-710 577.16,-710 577.16,-688 402.16,-688"/>
+<text text-anchor="start" x="442.04" y="-695.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="501.52" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-666 402.16,-688 577.16,-688 577.16,-666 402.16,-666"/>
+<text text-anchor="start" x="434.65" y="-673.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="484.8" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-644 402.16,-666 577.16,-666 577.16,-644 402.16,-644"/>
+<text text-anchor="start" x="439.32" y="-651.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="504.24" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-622 402.16,-644 577.16,-644 577.16,-622 402.16,-622"/>
+<text text-anchor="start" x="435.03" y="-629.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="507.74" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="402.16,-600 402.16,-622 577.16,-622 577.16,-600 402.16,-600"/>
+<text text-anchor="start" x="405.1" y="-607.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="514.35" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-578 402.16,-600 577.16,-600 577.16,-578 402.16,-578"/>
+<text text-anchor="start" x="408.59" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="534.96" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="402.16,-556 402.16,-578 577.16,-578 577.16,-556 402.16,-556"/>
+<polygon fill="none" stroke="black" points="402.16,-556 402.16,-578 577.16,-578 577.16,-556 402.16,-556"/>
+<text text-anchor="start" x="469.45" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="402.16,-534 402.16,-556 577.16,-556 577.16,-534 402.16,-534"/>
+<text text-anchor="start" x="421.23" y="-540.4" font-family="Times,serif" font-size="14.00">index_episodes_trakt_id</text>
+<polygon fill="none" stroke="black" points="402.16,-512 402.16,-534 577.16,-534 577.16,-512 402.16,-512"/>
+<text text-anchor="start" x="415.4" y="-518.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M576.66,-787C655.21,-787 677.37,-787 751.07,-787"/>
+<polygon fill="black" stroke="black" points="751.32,-790.5 761.32,-787 751.32,-783.5 751.32,-790.5"/>
+<text text-anchor="middle" x="657.99" y="-791.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node10" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="739.32,-366 739.32,-388 953.32,-388 953.32,-366 739.32,-366"/>
+<polygon fill="none" stroke="black" points="739.32,-366 739.32,-388 953.32,-388 953.32,-366 739.32,-366"/>
+<text text-anchor="start" x="806.28" y="-373.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="739.32,-344 739.32,-366 953.32,-366 953.32,-344 739.32,-344"/>
+<text text-anchor="start" x="807.25" y="-351.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-351.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-322 739.32,-344 953.32,-344 953.32,-322 739.32,-322"/>
+<text text-anchor="start" x="788.97" y="-329.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-300 739.32,-322 953.32,-322 953.32,-300 739.32,-300"/>
+<text text-anchor="start" x="771.09" y="-307.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="861.69" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-278 739.32,-300 953.32,-300 953.32,-278 739.32,-278"/>
+<text text-anchor="start" x="778.87" y="-285.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="853.9" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="739.32,-256 739.32,-278 953.32,-278 953.32,-256 739.32,-256"/>
+<polygon fill="none" stroke="black" points="739.32,-256 739.32,-278 953.32,-278 953.32,-256 739.32,-256"/>
+<text text-anchor="start" x="826.11" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="739.32,-234 739.32,-256 953.32,-256 953.32,-234 739.32,-234"/>
+<text text-anchor="start" x="760.01" y="-240.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="739.32,-212 739.32,-234 953.32,-234 953.32,-212 739.32,-212"/>
+<text text-anchor="start" x="742.12" y="-218.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-311C1091.42,-311 1007.64,-474.97 1043.98,-608.2 1061.01,-670.62 1049.1,-882.9 1105.85,-905.12"/>
+<polygon fill="black" stroke="black" points="1105.51,-908.61 1115.98,-907 1106.79,-901.73 1105.51,-908.61"/>
+<text text-anchor="middle" x="1034.65" y="-612.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-333C1021.23,-333 1006.74,-564.68 1025.32,-630 1042.07,-688.89 1050.29,-883.97 1105.85,-905.13"/>
+<polygon fill="black" stroke="black" points="1105.51,-908.63 1115.98,-907 1106.78,-901.75 1105.51,-908.63"/>
+<text text-anchor="middle" x="1034.65" y="-743.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node11" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-842 0.5,-864 239.5,-864 239.5,-842 0.5,-842"/>
+<polygon fill="none" stroke="black" points="0.5,-842 0.5,-864 239.5,-864 239.5,-842 0.5,-842"/>
+<text text-anchor="start" x="56.25" y="-849.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-820 0.5,-842 239.5,-842 239.5,-820 0.5,-820"/>
+<text text-anchor="start" x="80.93" y="-827.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-827.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-798 0.5,-820 239.5,-820 239.5,-798 0.5,-798"/>
+<text text-anchor="start" x="56.04" y="-805.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-776 0.5,-798 239.5,-798 239.5,-776 0.5,-776"/>
+<text text-anchor="start" x="64.6" y="-783.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-754 0.5,-776 239.5,-776 239.5,-754 0.5,-754"/>
+<text text-anchor="start" x="66.55" y="-761.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-732 0.5,-754 239.5,-754 239.5,-732 0.5,-732"/>
+<text text-anchor="start" x="55.26" y="-739.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-710 0.5,-732 239.5,-732 239.5,-710 0.5,-710"/>
+<polygon fill="none" stroke="black" points="0.5,-710 0.5,-732 239.5,-732 239.5,-710 0.5,-710"/>
+<text text-anchor="start" x="99.79" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-688 0.5,-710 239.5,-710 239.5,-688 0.5,-688"/>
+<text text-anchor="start" x="3.37" y="-694.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-666 0.5,-688 239.5,-688 239.5,-666 0.5,-666"/>
+<text text-anchor="start" x="11.92" y="-672.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-809C307.76,-809 327.47,-809 391.45,-809"/>
+<polygon fill="black" stroke="black" points="391.66,-812.5 401.66,-809 391.66,-805.5 391.66,-812.5"/>
+<text text-anchor="middle" x="320.33" y="-813.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node12" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1434 9.5,-1456 229.5,-1456 229.5,-1434 9.5,-1434"/>
+<polygon fill="none" stroke="black" points="9.5,-1434 9.5,-1456 229.5,-1456 229.5,-1434 9.5,-1434"/>
+<text text-anchor="start" x="83.34" y="-1441.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1412 9.5,-1434 229.5,-1434 229.5,-1412 9.5,-1412"/>
+<text text-anchor="start" x="80.43" y="-1419.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1419.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1390 9.5,-1412 229.5,-1412 229.5,-1390 9.5,-1390"/>
+<text text-anchor="start" x="77.71" y="-1397.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1397.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1368 9.5,-1390 229.5,-1390 229.5,-1368 9.5,-1368"/>
+<text text-anchor="start" x="60.98" y="-1375.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1375.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1346 9.5,-1368 229.5,-1368 229.5,-1346 9.5,-1346"/>
+<text text-anchor="start" x="56.71" y="-1353.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1353.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-1324 9.5,-1346 229.5,-1346 229.5,-1324 9.5,-1324"/>
+<polygon fill="none" stroke="black" points="9.5,-1324 9.5,-1346 229.5,-1346 229.5,-1324 9.5,-1324"/>
+<text text-anchor="start" x="99.29" y="-1331.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-1302 9.5,-1324 229.5,-1324 229.5,-1302 9.5,-1302"/>
+<text text-anchor="start" x="12.19" y="-1308.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+<!-- show_images -->
+<g id="node13" class="node">
+<title>show_images</title>
+<polygon fill="#caff70" stroke="transparent" points="759.32,-154 759.32,-176 933.32,-176 933.32,-154 759.32,-154"/>
+<polygon fill="none" stroke="black" points="759.32,-154 759.32,-176 933.32,-176 933.32,-154 759.32,-154"/>
+<text text-anchor="start" x="808.22" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">show_images</text>
+<polygon fill="none" stroke="black" points="759.32,-132 759.32,-154 933.32,-154 933.32,-132 759.32,-132"/>
+<text text-anchor="start" x="807.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-110 759.32,-132 933.32,-132 933.32,-110 759.32,-110"/>
+<text text-anchor="start" x="788.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-88 759.32,-110 933.32,-110 933.32,-88 759.32,-88"/>
+<text text-anchor="start" x="812.69" y="-95.4" font-family="Times,serif" font-size="14.00">path: </text>
+<text text-anchor="start" x="844.19" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-66 759.32,-88 933.32,-88 933.32,-66 759.32,-66"/>
+<text text-anchor="start" x="812.69" y="-73.4" font-family="Times,serif" font-size="14.00">type: </text>
+<text text-anchor="start" x="844.19" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-44 759.32,-66 933.32,-66 933.32,-44 759.32,-44"/>
+<text text-anchor="start" x="812.69" y="-51.4" font-family="Times,serif" font-size="14.00">lang: </text>
+<text text-anchor="start" x="844.19" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="759.32,-22 759.32,-44 933.32,-44 933.32,-22 759.32,-22"/>
+<polygon fill="none" stroke="black" points="759.32,-22 759.32,-44 933.32,-44 933.32,-22 759.32,-22"/>
+<text text-anchor="start" x="826.11" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="759.32,0 759.32,-22 933.32,-22 933.32,0 759.32,0"/>
+<text text-anchor="start" x="761.94" y="-6.4" font-family="Times,serif" font-size="14.00">index_show_images_show_id</text>
+</g>
+<!-- show_images&#45;&gt;shows -->
+<g id="edge10" class="edge">
+<title>show_images:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M934.32,-121C1036.94,-121 1012.78,-226.43 1043.98,-324.2 1082.57,-445.12 990.75,-882.18 1105.78,-905.99"/>
+<polygon fill="black" stroke="black" points="1105.69,-909.5 1115.98,-907 1106.38,-902.53 1105.69,-909.5"/>
+<text text-anchor="middle" x="1034.65" y="-328.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/21.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/21.svg
@@ -1,0 +1,498 @@
+<svg width="1363px" height="1674px"
+ viewBox="0.00 0.00 1362.98 1674.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1638)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1638 1326.98,-1638 1326.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1116.48,-962 1116.48,-984 1291.48,-984 1291.48,-962 1116.48,-962"/>
+<polygon fill="none" stroke="black" points="1116.48,-962 1116.48,-984 1291.48,-984 1291.48,-962 1116.48,-962"/>
+<text text-anchor="start" x="1186.48" y="-969.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1116.48,-940 1116.48,-962 1291.48,-962 1291.48,-940 1116.48,-940"/>
+<text text-anchor="start" x="1164.91" y="-947.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1183.19" y="-947.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-918 1116.48,-940 1291.48,-940 1291.48,-918 1116.48,-918"/>
+<text text-anchor="start" x="1171.52" y="-925.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1200.68" y="-925.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-896 1116.48,-918 1291.48,-918 1291.48,-896 1116.48,-896"/>
+<text text-anchor="start" x="1146.24" y="-903.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1225.96" y="-903.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-874 1116.48,-896 1291.48,-896 1291.48,-874 1116.48,-874"/>
+<text text-anchor="start" x="1148.58" y="-881.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1199.52" y="-881.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-852 1116.48,-874 1291.48,-874 1291.48,-852 1116.48,-852"/>
+<text text-anchor="start" x="1147.02" y="-859.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1201.08" y="-859.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-830 1116.48,-852 1291.48,-852 1291.48,-830 1116.48,-830"/>
+<text text-anchor="start" x="1159.07" y="-837.4" font-family="Times,serif" font-size="14.00">imdb_id: </text>
+<text text-anchor="start" x="1213.13" y="-837.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-808 1116.48,-830 1291.48,-830 1291.48,-808 1116.48,-808"/>
+<text text-anchor="start" x="1156.36" y="-815.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1215.84" y="-815.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-786 1116.48,-808 1291.48,-808 1291.48,-786 1116.48,-786"/>
+<text text-anchor="start" x="1153.64" y="-793.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1218.56" y="-793.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-764 1116.48,-786 1291.48,-786 1291.48,-764 1116.48,-764"/>
+<text text-anchor="start" x="1149.36" y="-771.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1222.06" y="-771.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1116.48,-742 1116.48,-764 1291.48,-764 1291.48,-742 1116.48,-742"/>
+<text text-anchor="start" x="1148.59" y="-749.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1223.61" y="-749.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-720 1116.48,-742 1291.48,-742 1291.48,-720 1116.48,-720"/>
+<text text-anchor="start" x="1153.64" y="-727.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1218.56" y="-727.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-698 1116.48,-720 1291.48,-720 1291.48,-698 1116.48,-698"/>
+<text text-anchor="start" x="1161.02" y="-705.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1211.18" y="-705.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-676 1116.48,-698 1291.48,-698 1291.48,-676 1116.48,-676"/>
+<text text-anchor="start" x="1159.47" y="-683.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1212.73" y="-683.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-654 1116.48,-676 1291.48,-676 1291.48,-654 1116.48,-654"/>
+<text text-anchor="start" x="1148.58" y="-661.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1199.52" y="-661.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-632 1116.48,-654 1291.48,-654 1291.48,-632 1116.48,-632"/>
+<text text-anchor="start" x="1164.14" y="-639.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1208.06" y="-639.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-610 1116.48,-632 1291.48,-632 1291.48,-610 1116.48,-610"/>
+<text text-anchor="start" x="1119.04" y="-617.4" font-family="Times,serif" font-size="14.00">last_trakt_data_update: </text>
+<text text-anchor="start" x="1253.16" y="-617.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1116.48,-588 1116.48,-610 1291.48,-610 1291.48,-588 1116.48,-588"/>
+<polygon fill="none" stroke="black" points="1116.48,-588 1116.48,-610 1291.48,-610 1291.48,-588 1116.48,-588"/>
+<text text-anchor="start" x="1183.77" y="-595.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1116.48,-566 1116.48,-588 1291.48,-588 1291.48,-566 1116.48,-566"/>
+<text text-anchor="start" x="1142.16" y="-572.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1116.48,-544 1116.48,-566 1291.48,-566 1291.48,-544 1116.48,-544"/>
+<text text-anchor="start" x="1140.6" y="-550.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- shows_fts -->
+<g id="node2" class="node">
+<title>shows_fts</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-988 59.5,-1010 180.5,-1010 180.5,-988 59.5,-988"/>
+<polygon fill="none" stroke="black" points="59.5,-988 59.5,-1010 180.5,-1010 180.5,-988 59.5,-988"/>
+<text text-anchor="start" x="92" y="-995.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows_fts</text>
+<polygon fill="none" stroke="black" points="59.5,-966 59.5,-988 180.5,-988 180.5,-966 59.5,-966"/>
+<text text-anchor="start" x="87.53" y="-973.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="116.7" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-944 59.5,-966 180.5,-966 180.5,-944 59.5,-944"/>
+<text text-anchor="start" x="62.26" y="-951.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="141.98" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- trending_shows -->
+<g id="node3" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="753.32,-1580 753.32,-1602 940.32,-1602 940.32,-1580 753.32,-1580"/>
+<polygon fill="none" stroke="black" points="753.32,-1580 753.32,-1602 940.32,-1602 940.32,-1580 753.32,-1580"/>
+<text text-anchor="start" x="802.5" y="-1587.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="753.32,-1558 753.32,-1580 940.32,-1580 940.32,-1558 753.32,-1558"/>
+<text text-anchor="start" x="807.75" y="-1565.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1565.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1536 753.32,-1558 940.32,-1558 940.32,-1536 753.32,-1536"/>
+<text text-anchor="start" x="789.47" y="-1543.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1543.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1514 753.32,-1536 940.32,-1536 940.32,-1514 753.32,-1514"/>
+<text text-anchor="start" x="799.98" y="-1521.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1521.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1492 753.32,-1514 940.32,-1514 940.32,-1492 753.32,-1492"/>
+<text text-anchor="start" x="788.32" y="-1499.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="845.46" y="-1499.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="753.32,-1470 753.32,-1492 940.32,-1492 940.32,-1470 753.32,-1470"/>
+<polygon fill="none" stroke="black" points="753.32,-1470 753.32,-1492 940.32,-1492 940.32,-1470 753.32,-1470"/>
+<text text-anchor="start" x="826.61" y="-1477.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="753.32,-1448 753.32,-1470 940.32,-1470 940.32,-1448 753.32,-1448"/>
+<text text-anchor="start" x="756.22" y="-1454.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M941.32,-1547C973.6,-1547 1068.15,-1025.35 1108.46,-958.11"/>
+<polygon fill="black" stroke="black" points="1111.12,-960.41 1115.98,-951 1106.31,-955.33 1111.12,-960.41"/>
+<text text-anchor="middle" x="1034.65" y="-1253.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node4" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="755.32,-1390 755.32,-1412 938.32,-1412 938.32,-1390 755.32,-1390"/>
+<polygon fill="none" stroke="black" points="755.32,-1390 755.32,-1412 938.32,-1412 938.32,-1390 755.32,-1390"/>
+<text text-anchor="start" x="804.44" y="-1397.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="755.32,-1368 755.32,-1390 938.32,-1390 938.32,-1368 755.32,-1368"/>
+<text text-anchor="start" x="807.75" y="-1375.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1375.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1346 755.32,-1368 938.32,-1368 938.32,-1346 755.32,-1346"/>
+<text text-anchor="start" x="789.47" y="-1353.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1353.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1324 755.32,-1346 938.32,-1346 938.32,-1324 755.32,-1324"/>
+<text text-anchor="start" x="799.98" y="-1331.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1331.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1302 755.32,-1324 938.32,-1324 938.32,-1302 755.32,-1302"/>
+<text text-anchor="start" x="781.71" y="-1309.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="852.06" y="-1309.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="755.32,-1280 755.32,-1302 938.32,-1302 938.32,-1280 755.32,-1280"/>
+<polygon fill="none" stroke="black" points="755.32,-1280 755.32,-1302 938.32,-1302 938.32,-1280 755.32,-1280"/>
+<text text-anchor="start" x="826.61" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="755.32,-1258 755.32,-1280 938.32,-1280 938.32,-1258 755.32,-1258"/>
+<text text-anchor="start" x="758.17" y="-1264.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M939.32,-1357C985.54,-1357 1057.41,-998.68 1106.74,-955.28"/>
+<polygon fill="black" stroke="black" points="1108.38,-958.38 1115.98,-951 1105.44,-952.03 1108.38,-958.38"/>
+<text text-anchor="middle" x="1034.65" y="-1158.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node5" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-1288 53.5,-1310 186.5,-1310 186.5,-1288 53.5,-1288"/>
+<polygon fill="none" stroke="black" points="53.5,-1288 53.5,-1310 186.5,-1310 186.5,-1288 53.5,-1288"/>
+<text text-anchor="start" x="105.62" y="-1295.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-1266 53.5,-1288 186.5,-1288 186.5,-1266 53.5,-1266"/>
+<text text-anchor="start" x="80.93" y="-1273.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-1273.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-1244 53.5,-1266 186.5,-1266 186.5,-1244 53.5,-1244"/>
+<text text-anchor="start" x="71.6" y="-1251.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-1251.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1222 53.5,-1244 186.5,-1244 186.5,-1222 53.5,-1222"/>
+<text text-anchor="start" x="83.26" y="-1229.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-1229.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1200 53.5,-1222 186.5,-1222 186.5,-1200 53.5,-1200"/>
+<text text-anchor="start" x="65.76" y="-1207.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-1207.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1178 53.5,-1200 186.5,-1200 186.5,-1178 53.5,-1178"/>
+<text text-anchor="start" x="75.87" y="-1185.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-1185.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1156 53.5,-1178 186.5,-1178 186.5,-1156 53.5,-1156"/>
+<text text-anchor="start" x="82.87" y="-1163.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1134 53.5,-1156 186.5,-1156 186.5,-1134 53.5,-1134"/>
+<text text-anchor="start" x="70.05" y="-1141.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1112 53.5,-1134 186.5,-1134 186.5,-1112 53.5,-1112"/>
+<text text-anchor="start" x="77.43" y="-1119.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-1119.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-1090 53.5,-1112 186.5,-1112 186.5,-1090 53.5,-1090"/>
+<text text-anchor="start" x="69.65" y="-1097.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-1068 53.5,-1090 186.5,-1090 186.5,-1068 53.5,-1068"/>
+<polygon fill="none" stroke="black" points="53.5,-1068 53.5,-1090 186.5,-1090 186.5,-1068 53.5,-1068"/>
+<text text-anchor="start" x="99.79" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-1046 53.5,-1068 186.5,-1068 186.5,-1046 53.5,-1046"/>
+<text text-anchor="start" x="56.25" y="-1052.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node6" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="752.32,-1200 752.32,-1222 941.32,-1222 941.32,-1200 752.32,-1200"/>
+<polygon fill="none" stroke="black" points="752.32,-1200 752.32,-1222 941.32,-1222 941.32,-1200 752.32,-1200"/>
+<text text-anchor="start" x="801.34" y="-1207.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="752.32,-1178 752.32,-1200 941.32,-1200 941.32,-1178 752.32,-1178"/>
+<text text-anchor="start" x="807.75" y="-1185.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1185.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-1156 752.32,-1178 941.32,-1178 941.32,-1156 752.32,-1156"/>
+<text text-anchor="start" x="789.47" y="-1163.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-1134 752.32,-1156 941.32,-1156 941.32,-1134 752.32,-1134"/>
+<text text-anchor="start" x="788.7" y="-1141.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="869.17" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="752.32,-1112 752.32,-1134 941.32,-1134 941.32,-1112 752.32,-1112"/>
+<polygon fill="none" stroke="black" points="752.32,-1112 752.32,-1134 941.32,-1134 941.32,-1112 752.32,-1112"/>
+<text text-anchor="start" x="826.61" y="-1119.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="752.32,-1090 752.32,-1112 941.32,-1112 941.32,-1090 752.32,-1090"/>
+<text text-anchor="start" x="755.07" y="-1096.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M942.32,-1167C1062.01,-1167 996.76,-963.06 1105.98,-951.51"/>
+<polygon fill="black" stroke="black" points="1106.17,-955 1115.98,-951 1105.82,-948.01 1106.17,-955"/>
+<text text-anchor="middle" x="1034.65" y="-1075.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node7" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="749.32,-1032 749.32,-1054 944.32,-1054 944.32,-1032 749.32,-1032"/>
+<polygon fill="none" stroke="black" points="749.32,-1032 749.32,-1054 944.32,-1054 944.32,-1032 749.32,-1032"/>
+<text text-anchor="start" x="798.22" y="-1039.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="749.32,-1010 749.32,-1032 944.32,-1032 944.32,-1010 749.32,-1010"/>
+<text text-anchor="start" x="807.75" y="-1017.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1017.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-988 749.32,-1010 944.32,-1010 944.32,-988 749.32,-988"/>
+<text text-anchor="start" x="789.47" y="-995.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-966 749.32,-988 944.32,-988 944.32,-966 749.32,-966"/>
+<text text-anchor="start" x="791.81" y="-973.4" font-family="Times,serif" font-size="14.00">followed_at: </text>
+<text text-anchor="start" x="866.07" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="749.32,-944 749.32,-966 944.32,-966 944.32,-944 749.32,-944"/>
+<text text-anchor="start" x="782.09" y="-951.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="875.79" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="749.32,-922 749.32,-944 944.32,-944 944.32,-922 749.32,-922"/>
+<polygon fill="none" stroke="black" points="749.32,-922 749.32,-944 944.32,-944 944.32,-922 749.32,-922"/>
+<text text-anchor="start" x="826.61" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="749.32,-900 749.32,-922 944.32,-922 944.32,-900 749.32,-900"/>
+<text text-anchor="start" x="751.95" y="-906.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M945.32,-999C1020.57,-999 1035.88,-955.22 1105.75,-951.28"/>
+<polygon fill="black" stroke="black" points="1106.08,-954.77 1115.98,-951 1105.89,-947.78 1106.08,-954.77"/>
+<text text-anchor="middle" x="1034.65" y="-980.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node8" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="762.32,-842 762.32,-864 930.32,-864 930.32,-842 762.32,-842"/>
+<polygon fill="none" stroke="black" points="762.32,-842 762.32,-864 930.32,-864 930.32,-842 762.32,-842"/>
+<text text-anchor="start" x="824.94" y="-849.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="762.32,-820 762.32,-842 930.32,-842 930.32,-820 762.32,-820"/>
+<text text-anchor="start" x="807.25" y="-827.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-827.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-798 762.32,-820 930.32,-820 930.32,-798 762.32,-798"/>
+<text text-anchor="start" x="788.97" y="-805.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-776 762.32,-798 930.32,-798 930.32,-776 762.32,-776"/>
+<text text-anchor="start" x="790.92" y="-783.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="841.86" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-754 762.32,-776 930.32,-776 930.32,-754 762.32,-754"/>
+<text text-anchor="start" x="789.36" y="-761.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="843.42" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-732 762.32,-754 930.32,-754 930.32,-732 762.32,-732"/>
+<text text-anchor="start" x="813.86" y="-739.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="843.02" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-710 762.32,-732 930.32,-732 930.32,-710 762.32,-710"/>
+<text text-anchor="start" x="798.7" y="-717.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="858.18" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-688 762.32,-710 930.32,-710 930.32,-688 762.32,-688"/>
+<text text-anchor="start" x="791.31" y="-695.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="841.47" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-666 762.32,-688 930.32,-688 930.32,-666 762.32,-666"/>
+<text text-anchor="start" x="801.81" y="-673.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="855.07" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-644 762.32,-666 930.32,-666 930.32,-644 762.32,-644"/>
+<text text-anchor="start" x="787.03" y="-651.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="845.74" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-622 762.32,-644 930.32,-644 930.32,-622 762.32,-622"/>
+<text text-anchor="start" x="788.59" y="-629.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="844.18" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-600 762.32,-622 930.32,-622 930.32,-600 762.32,-600"/>
+<text text-anchor="start" x="791.7" y="-607.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="864.4" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="762.32,-578 762.32,-600 930.32,-600 930.32,-578 762.32,-578"/>
+<text text-anchor="start" x="781.59" y="-585.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="851.19" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-556 762.32,-578 930.32,-578 930.32,-556 762.32,-556"/>
+<text text-anchor="start" x="774.2" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="882.68" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-534 762.32,-556 930.32,-556 930.32,-534 762.32,-534"/>
+<text text-anchor="start" x="765.26" y="-541.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="891.62" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="762.32,-512 762.32,-534 930.32,-534 930.32,-512 762.32,-512"/>
+<polygon fill="none" stroke="black" points="762.32,-512 762.32,-534 930.32,-534 930.32,-512 762.32,-512"/>
+<text text-anchor="start" x="826.11" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="762.32,-490 762.32,-512 930.32,-512 930.32,-490 762.32,-490"/>
+<text text-anchor="start" x="780.61" y="-496.4" font-family="Times,serif" font-size="14.00">index_seasons_trakt_id</text>
+<polygon fill="none" stroke="black" points="762.32,-468 762.32,-490 930.32,-490 930.32,-468 762.32,-468"/>
+<text text-anchor="start" x="778.67" y="-474.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M931.32,-809C1031.31,-809 1013.83,-941.46 1105.8,-950.51"/>
+<polygon fill="black" stroke="black" points="1105.83,-954.02 1115.98,-951 1106.16,-947.03 1105.83,-954.02"/>
+<text text-anchor="middle" x="1034.65" y="-913.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node9" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="402.16,-864 402.16,-886 577.16,-886 577.16,-864 402.16,-864"/>
+<polygon fill="none" stroke="black" points="402.16,-864 402.16,-886 577.16,-886 577.16,-864 402.16,-864"/>
+<text text-anchor="start" x="465.56" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="402.16,-842 402.16,-864 577.16,-864 577.16,-842 402.16,-842"/>
+<text text-anchor="start" x="450.59" y="-849.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="468.87" y="-849.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-820 402.16,-842 577.16,-842 577.16,-820 402.16,-820"/>
+<text text-anchor="start" x="428.43" y="-827.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="491.03" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-798 402.16,-820 577.16,-820 577.16,-798 402.16,-798"/>
+<text text-anchor="start" x="434.26" y="-805.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="485.2" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-776 402.16,-798 577.16,-798 577.16,-776 402.16,-776"/>
+<text text-anchor="start" x="432.7" y="-783.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="486.76" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-754 402.16,-776 577.16,-776 577.16,-754 402.16,-754"/>
+<text text-anchor="start" x="457.19" y="-761.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="486.36" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-732 402.16,-754 577.16,-754 577.16,-732 402.16,-732"/>
+<text text-anchor="start" x="442.04" y="-739.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="501.52" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-710 402.16,-732 577.16,-732 577.16,-710 402.16,-710"/>
+<text text-anchor="start" x="434.65" y="-717.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="484.8" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-688 402.16,-710 577.16,-710 577.16,-688 402.16,-688"/>
+<text text-anchor="start" x="439.32" y="-695.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="504.24" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-666 402.16,-688 577.16,-688 577.16,-666 402.16,-666"/>
+<text text-anchor="start" x="435.03" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="507.74" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="402.16,-644 402.16,-666 577.16,-666 577.16,-644 402.16,-644"/>
+<text text-anchor="start" x="405.1" y="-651.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="514.35" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-622 402.16,-644 577.16,-644 577.16,-622 402.16,-622"/>
+<text text-anchor="start" x="408.59" y="-629.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="534.96" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="402.16,-600 402.16,-622 577.16,-622 577.16,-600 402.16,-600"/>
+<polygon fill="none" stroke="black" points="402.16,-600 402.16,-622 577.16,-622 577.16,-600 402.16,-600"/>
+<text text-anchor="start" x="469.45" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="402.16,-578 402.16,-600 577.16,-600 577.16,-578 402.16,-578"/>
+<text text-anchor="start" x="421.23" y="-584.4" font-family="Times,serif" font-size="14.00">index_episodes_trakt_id</text>
+<polygon fill="none" stroke="black" points="402.16,-556 402.16,-578 577.16,-578 577.16,-556 402.16,-556"/>
+<text text-anchor="start" x="415.4" y="-562.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M576.66,-831C655.21,-831 677.37,-831 751.07,-831"/>
+<polygon fill="black" stroke="black" points="751.32,-834.5 761.32,-831 751.32,-827.5 751.32,-834.5"/>
+<text text-anchor="middle" x="657.99" y="-835.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node10" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="739.32,-410 739.32,-432 953.32,-432 953.32,-410 739.32,-410"/>
+<polygon fill="none" stroke="black" points="739.32,-410 739.32,-432 953.32,-432 953.32,-410 739.32,-410"/>
+<text text-anchor="start" x="806.28" y="-417.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="739.32,-388 739.32,-410 953.32,-410 953.32,-388 739.32,-388"/>
+<text text-anchor="start" x="807.25" y="-395.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-395.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-366 739.32,-388 953.32,-388 953.32,-366 739.32,-366"/>
+<text text-anchor="start" x="788.97" y="-373.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-344 739.32,-366 953.32,-366 953.32,-344 739.32,-344"/>
+<text text-anchor="start" x="771.09" y="-351.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="861.69" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-322 739.32,-344 953.32,-344 953.32,-322 739.32,-322"/>
+<text text-anchor="start" x="778.87" y="-329.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="853.9" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="739.32,-300 739.32,-322 953.32,-322 953.32,-300 739.32,-300"/>
+<polygon fill="none" stroke="black" points="739.32,-300 739.32,-322 953.32,-322 953.32,-300 739.32,-300"/>
+<text text-anchor="start" x="826.11" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="739.32,-278 739.32,-300 953.32,-300 953.32,-278 739.32,-278"/>
+<text text-anchor="start" x="760.01" y="-284.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="739.32,-256 739.32,-278 953.32,-278 953.32,-256 739.32,-256"/>
+<text text-anchor="start" x="742.12" y="-262.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-355C1091.42,-355 1007.64,-518.97 1043.98,-652.2 1061.01,-714.62 1049.1,-926.9 1105.85,-949.12"/>
+<polygon fill="black" stroke="black" points="1105.51,-952.61 1115.98,-951 1106.79,-945.73 1105.51,-952.61"/>
+<text text-anchor="middle" x="1034.65" y="-656.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-377C1021.23,-377 1006.74,-608.68 1025.32,-674 1042.07,-732.89 1050.29,-927.97 1105.85,-949.13"/>
+<polygon fill="black" stroke="black" points="1105.51,-952.63 1115.98,-951 1106.78,-945.75 1105.51,-952.63"/>
+<text text-anchor="middle" x="1034.65" y="-787.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node11" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-886 0.5,-908 239.5,-908 239.5,-886 0.5,-886"/>
+<polygon fill="none" stroke="black" points="0.5,-886 0.5,-908 239.5,-908 239.5,-886 0.5,-886"/>
+<text text-anchor="start" x="56.25" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-864 0.5,-886 239.5,-886 239.5,-864 0.5,-864"/>
+<text text-anchor="start" x="80.93" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-871.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-842 0.5,-864 239.5,-864 239.5,-842 0.5,-842"/>
+<text text-anchor="start" x="56.04" y="-849.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-820 0.5,-842 239.5,-842 239.5,-820 0.5,-820"/>
+<text text-anchor="start" x="64.6" y="-827.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-798 0.5,-820 239.5,-820 239.5,-798 0.5,-798"/>
+<text text-anchor="start" x="66.55" y="-805.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-776 0.5,-798 239.5,-798 239.5,-776 0.5,-776"/>
+<text text-anchor="start" x="55.26" y="-783.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-754 0.5,-776 239.5,-776 239.5,-754 0.5,-754"/>
+<polygon fill="none" stroke="black" points="0.5,-754 0.5,-776 239.5,-776 239.5,-754 0.5,-754"/>
+<text text-anchor="start" x="99.79" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-732 0.5,-754 239.5,-754 239.5,-732 0.5,-732"/>
+<text text-anchor="start" x="3.37" y="-738.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-710 0.5,-732 239.5,-732 239.5,-710 0.5,-710"/>
+<text text-anchor="start" x="11.92" y="-716.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-853C307.76,-853 327.47,-853 391.45,-853"/>
+<polygon fill="black" stroke="black" points="391.66,-856.5 401.66,-853 391.66,-849.5 391.66,-856.5"/>
+<text text-anchor="middle" x="320.33" y="-857.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node12" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1478 9.5,-1500 229.5,-1500 229.5,-1478 9.5,-1478"/>
+<polygon fill="none" stroke="black" points="9.5,-1478 9.5,-1500 229.5,-1500 229.5,-1478 9.5,-1478"/>
+<text text-anchor="start" x="83.34" y="-1485.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1456 9.5,-1478 229.5,-1478 229.5,-1456 9.5,-1456"/>
+<text text-anchor="start" x="80.43" y="-1463.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1463.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1434 9.5,-1456 229.5,-1456 229.5,-1434 9.5,-1434"/>
+<text text-anchor="start" x="77.71" y="-1441.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1441.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1412 9.5,-1434 229.5,-1434 229.5,-1412 9.5,-1412"/>
+<text text-anchor="start" x="60.98" y="-1419.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1419.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1390 9.5,-1412 229.5,-1412 229.5,-1390 9.5,-1390"/>
+<text text-anchor="start" x="56.71" y="-1397.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1397.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-1368 9.5,-1390 229.5,-1390 229.5,-1368 9.5,-1368"/>
+<polygon fill="none" stroke="black" points="9.5,-1368 9.5,-1390 229.5,-1390 229.5,-1368 9.5,-1368"/>
+<text text-anchor="start" x="99.29" y="-1375.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-1346 9.5,-1368 229.5,-1368 229.5,-1346 9.5,-1346"/>
+<text text-anchor="start" x="12.19" y="-1352.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+<!-- show_images -->
+<g id="node13" class="node">
+<title>show_images</title>
+<polygon fill="#caff70" stroke="transparent" points="759.32,-198 759.32,-220 933.32,-220 933.32,-198 759.32,-198"/>
+<polygon fill="none" stroke="black" points="759.32,-198 759.32,-220 933.32,-220 933.32,-198 759.32,-198"/>
+<text text-anchor="start" x="808.22" y="-205.4" font-family="Times,serif" font-weight="bold" font-size="14.00">show_images</text>
+<polygon fill="none" stroke="black" points="759.32,-176 759.32,-198 933.32,-198 933.32,-176 759.32,-176"/>
+<text text-anchor="start" x="807.25" y="-183.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-183.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-154 759.32,-176 933.32,-176 933.32,-154 759.32,-154"/>
+<text text-anchor="start" x="788.97" y="-161.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-161.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-132 759.32,-154 933.32,-154 933.32,-132 759.32,-132"/>
+<text text-anchor="start" x="812.69" y="-139.4" font-family="Times,serif" font-size="14.00">path: </text>
+<text text-anchor="start" x="844.19" y="-139.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-110 759.32,-132 933.32,-132 933.32,-110 759.32,-110"/>
+<text text-anchor="start" x="812.69" y="-117.4" font-family="Times,serif" font-size="14.00">type: </text>
+<text text-anchor="start" x="844.19" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-88 759.32,-110 933.32,-110 933.32,-88 759.32,-88"/>
+<text text-anchor="start" x="812.69" y="-95.4" font-family="Times,serif" font-size="14.00">lang: </text>
+<text text-anchor="start" x="844.19" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-66 759.32,-88 933.32,-88 933.32,-66 759.32,-66"/>
+<text text-anchor="start" x="808.02" y="-73.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="848.07" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="759.32,-44 759.32,-66 933.32,-66 933.32,-44 759.32,-44"/>
+<text text-anchor="start" x="782.37" y="-51.4" font-family="Times,serif" font-size="14.00">is_primary: </text>
+<text text-anchor="start" x="850.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="759.32,-22 759.32,-44 933.32,-44 933.32,-22 759.32,-22"/>
+<polygon fill="none" stroke="black" points="759.32,-22 759.32,-44 933.32,-44 933.32,-22 759.32,-22"/>
+<text text-anchor="start" x="826.11" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="759.32,0 759.32,-22 933.32,-22 933.32,0 759.32,0"/>
+<text text-anchor="start" x="761.94" y="-6.4" font-family="Times,serif" font-size="14.00">index_show_images_show_id</text>
+</g>
+<!-- show_images&#45;&gt;shows -->
+<g id="edge10" class="edge">
+<title>show_images:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M934.32,-165C1036.94,-165 1012.78,-270.43 1043.98,-368.2 1082.57,-489.12 990.75,-926.18 1105.78,-949.99"/>
+<polygon fill="black" stroke="black" points="1105.69,-953.5 1115.98,-951 1106.38,-946.53 1105.69,-953.5"/>
+<text text-anchor="middle" x="1034.65" y="-372.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/3.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/3.svg
@@ -1,0 +1,424 @@
+<svg width="1385px" height="1418px"
+ viewBox="0.00 0.00 1384.98 1418.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1382)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1382 1348.98,-1382 1348.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1144.98,-754 1144.98,-776 1312.98,-776 1312.98,-754 1144.98,-754"/>
+<polygon fill="none" stroke="black" points="1144.98,-754 1144.98,-776 1312.98,-776 1312.98,-754 1144.98,-754"/>
+<text text-anchor="start" x="1211.48" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1144.98,-732 1144.98,-754 1312.98,-754 1312.98,-732 1144.98,-732"/>
+<text text-anchor="start" x="1189.91" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1208.19" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-710 1144.98,-732 1312.98,-732 1312.98,-710 1144.98,-710"/>
+<text text-anchor="start" x="1196.52" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1225.68" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-688 1144.98,-710 1312.98,-710 1312.98,-688 1144.98,-688"/>
+<text text-anchor="start" x="1171.24" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1250.96" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-666 1144.98,-688 1312.98,-688 1312.98,-666 1144.98,-666"/>
+<text text-anchor="start" x="1173.58" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1224.52" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-644 1144.98,-666 1312.98,-666 1312.98,-644 1144.98,-644"/>
+<text text-anchor="start" x="1172.02" y="-651.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1226.08" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-622 1144.98,-644 1312.98,-644 1312.98,-622 1144.98,-622"/>
+<text text-anchor="start" x="1156.86" y="-629.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1265.34" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-600 1144.98,-622 1312.98,-622 1312.98,-600 1144.98,-600"/>
+<text text-anchor="start" x="1147.92" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1274.28" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-578 1144.98,-600 1312.98,-600 1312.98,-578 1144.98,-578"/>
+<text text-anchor="start" x="1168.92" y="-585.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="1253.28" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-556 1144.98,-578 1312.98,-578 1312.98,-556 1144.98,-556"/>
+<text text-anchor="start" x="1167.35" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="1254.85" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-534 1144.98,-556 1312.98,-556 1312.98,-534 1144.98,-534"/>
+<text text-anchor="start" x="1181.36" y="-541.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1240.84" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-512 1144.98,-534 1312.98,-534 1312.98,-512 1144.98,-512"/>
+<text text-anchor="start" x="1178.64" y="-519.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1243.56" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-490 1144.98,-512 1312.98,-512 1312.98,-490 1144.98,-490"/>
+<text text-anchor="start" x="1190.68" y="-497.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="1230.73" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1144.98,-468 1144.98,-490 1312.98,-490 1312.98,-468 1144.98,-468"/>
+<text text-anchor="start" x="1173.59" y="-475.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1248.61" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-446 1144.98,-468 1312.98,-468 1312.98,-446 1144.98,-446"/>
+<text text-anchor="start" x="1186.02" y="-453.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1236.18" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-424 1144.98,-446 1312.98,-446 1312.98,-424 1144.98,-424"/>
+<text text-anchor="start" x="1184.47" y="-431.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1237.73" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-402 1144.98,-424 1312.98,-424 1312.98,-402 1144.98,-402"/>
+<text text-anchor="start" x="1173.58" y="-409.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1224.52" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-380 1144.98,-402 1312.98,-402 1312.98,-380 1144.98,-380"/>
+<text text-anchor="start" x="1189.14" y="-387.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1233.06" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<polygon fill="none" stroke="black" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<text text-anchor="start" x="1208.77" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<text text-anchor="start" x="1167.16" y="-342.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1144.98,-314 1144.98,-336 1312.98,-336 1312.98,-314 1144.98,-314"/>
+<text text-anchor="start" x="1165.6" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="782.32,-1324 782.32,-1346 969.32,-1346 969.32,-1324 782.32,-1324"/>
+<polygon fill="none" stroke="black" points="782.32,-1324 782.32,-1346 969.32,-1346 969.32,-1324 782.32,-1324"/>
+<text text-anchor="start" x="831.5" y="-1331.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="782.32,-1302 782.32,-1324 969.32,-1324 969.32,-1302 782.32,-1302"/>
+<text text-anchor="start" x="836.75" y="-1309.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1309.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<text text-anchor="start" x="818.47" y="-1287.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1258 782.32,-1280 969.32,-1280 969.32,-1258 782.32,-1258"/>
+<text text-anchor="start" x="828.98" y="-1265.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1236 782.32,-1258 969.32,-1258 969.32,-1236 782.32,-1236"/>
+<text text-anchor="start" x="817.32" y="-1243.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="874.46" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<polygon fill="none" stroke="black" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<text text-anchor="start" x="855.61" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="782.32,-1192 782.32,-1214 969.32,-1214 969.32,-1192 782.32,-1192"/>
+<text text-anchor="start" x="785.22" y="-1198.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M970.32,-1291C1000.15,-1291 1098.67,-813.36 1137.62,-749.93"/>
+<polygon fill="black" stroke="black" points="1140.1,-752.4 1144.98,-743 1135.3,-747.3 1140.1,-752.4"/>
+<text text-anchor="middle" x="1063.65" y="-1021.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="784.32,-1134 784.32,-1156 967.32,-1156 967.32,-1134 784.32,-1134"/>
+<polygon fill="none" stroke="black" points="784.32,-1134 784.32,-1156 967.32,-1156 967.32,-1134 784.32,-1134"/>
+<text text-anchor="start" x="833.44" y="-1141.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="784.32,-1112 784.32,-1134 967.32,-1134 967.32,-1112 784.32,-1112"/>
+<text text-anchor="start" x="836.75" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1119.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<text text-anchor="start" x="818.47" y="-1097.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1068 784.32,-1090 967.32,-1090 967.32,-1068 784.32,-1068"/>
+<text text-anchor="start" x="828.98" y="-1075.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1046 784.32,-1068 967.32,-1068 967.32,-1046 784.32,-1046"/>
+<text text-anchor="start" x="810.71" y="-1053.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="881.06" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<polygon fill="none" stroke="black" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<text text-anchor="start" x="855.61" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="784.32,-1002 784.32,-1024 967.32,-1024 967.32,-1002 784.32,-1002"/>
+<text text-anchor="start" x="787.17" y="-1008.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M968.32,-1101C1053.57,-1101 1056.19,-770.42 1134.98,-744.6"/>
+<polygon fill="black" stroke="black" points="1135.66,-748.03 1144.98,-743 1134.56,-741.12 1135.66,-748.03"/>
+<text text-anchor="middle" x="1063.65" y="-926.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="62.5,-886 62.5,-908 176.5,-908 176.5,-886 62.5,-886"/>
+<polygon fill="none" stroke="black" points="62.5,-886 62.5,-908 176.5,-908 176.5,-886 62.5,-886"/>
+<text text-anchor="start" x="105.12" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="62.5,-864 62.5,-886 176.5,-886 176.5,-864 62.5,-864"/>
+<text text-anchor="start" x="80.43" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-871.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="62.5,-842 62.5,-864 176.5,-864 176.5,-842 62.5,-842"/>
+<text text-anchor="start" x="71.1" y="-849.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.13" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-820 62.5,-842 176.5,-842 176.5,-820 62.5,-820"/>
+<text text-anchor="start" x="82.76" y="-827.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.47" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-798 62.5,-820 176.5,-820 176.5,-798 62.5,-798"/>
+<text text-anchor="start" x="65.26" y="-805.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="137.97" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-776 62.5,-798 176.5,-798 176.5,-776 62.5,-776"/>
+<text text-anchor="start" x="75.37" y="-783.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="127.86" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-754 62.5,-776 176.5,-776 176.5,-754 62.5,-754"/>
+<text text-anchor="start" x="82.37" y="-761.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="120.87" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-732 62.5,-754 176.5,-754 176.5,-732 62.5,-732"/>
+<text text-anchor="start" x="69.55" y="-739.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="133.69" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="781.32,-944 781.32,-966 970.32,-966 970.32,-944 781.32,-944"/>
+<polygon fill="none" stroke="black" points="781.32,-944 781.32,-966 970.32,-966 970.32,-944 781.32,-944"/>
+<text text-anchor="start" x="830.34" y="-951.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="781.32,-922 781.32,-944 970.32,-944 970.32,-922 781.32,-922"/>
+<text text-anchor="start" x="836.75" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-929.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<text text-anchor="start" x="818.47" y="-907.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-878 781.32,-900 970.32,-900 970.32,-878 781.32,-878"/>
+<text text-anchor="start" x="817.7" y="-885.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="898.17" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<polygon fill="none" stroke="black" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<text text-anchor="start" x="855.61" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="781.32,-834 781.32,-856 970.32,-856 970.32,-834 781.32,-834"/>
+<text text-anchor="start" x="784.07" y="-840.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M971.32,-911C1075.14,-911 1040.16,-753.97 1134.77,-743.54"/>
+<polygon fill="black" stroke="black" points="1135.18,-747.03 1144.98,-743 1134.81,-740.04 1135.18,-747.03"/>
+<text text-anchor="middle" x="1063.65" y="-836.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="778.32,-776 778.32,-798 973.32,-798 973.32,-776 778.32,-776"/>
+<polygon fill="none" stroke="black" points="778.32,-776 778.32,-798 973.32,-798 973.32,-776 778.32,-776"/>
+<text text-anchor="start" x="827.22" y="-783.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="778.32,-754 778.32,-776 973.32,-776 973.32,-754 778.32,-754"/>
+<text text-anchor="start" x="836.75" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-761.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<text text-anchor="start" x="818.47" y="-739.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<polygon fill="none" stroke="black" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<text text-anchor="start" x="855.61" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="778.32,-688 778.32,-710 973.32,-710 973.32,-688 778.32,-688"/>
+<text text-anchor="start" x="780.95" y="-694.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M974.32,-743C1046.61,-743 1067.23,-743 1134.68,-743"/>
+<polygon fill="black" stroke="black" points="1134.98,-746.5 1144.98,-743 1134.98,-739.5 1134.98,-746.5"/>
+<text text-anchor="middle" x="1063.65" y="-748.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="780.32,-630 780.32,-652 971.32,-652 971.32,-630 780.32,-630"/>
+<polygon fill="none" stroke="black" points="780.32,-630 780.32,-652 971.32,-652 971.32,-630 780.32,-630"/>
+<text text-anchor="start" x="854.44" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="780.32,-608 780.32,-630 971.32,-630 971.32,-608 780.32,-608"/>
+<text text-anchor="start" x="836.75" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-615.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-586 780.32,-608 971.32,-608 971.32,-586 780.32,-586"/>
+<text text-anchor="start" x="818.47" y="-593.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<text text-anchor="start" x="820.42" y="-571.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="871.36" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-542 780.32,-564 971.32,-564 971.32,-542 780.32,-542"/>
+<text text-anchor="start" x="818.86" y="-549.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="872.92" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-520 780.32,-542 971.32,-542 971.32,-520 780.32,-520"/>
+<text text-anchor="start" x="843.36" y="-527.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="872.52" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-498 780.32,-520 971.32,-520 971.32,-498 780.32,-498"/>
+<text text-anchor="start" x="828.2" y="-505.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="887.68" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-476 780.32,-498 971.32,-498 971.32,-476 780.32,-476"/>
+<text text-anchor="start" x="820.81" y="-483.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="870.97" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-454 780.32,-476 971.32,-476 971.32,-454 780.32,-454"/>
+<text text-anchor="start" x="816.53" y="-461.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="875.24" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-432 780.32,-454 971.32,-454 971.32,-432 780.32,-432"/>
+<text text-anchor="start" x="818.09" y="-439.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="873.68" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-410 780.32,-432 971.32,-432 971.32,-410 780.32,-410"/>
+<text text-anchor="start" x="837.52" y="-417.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="877.57" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="780.32,-388 780.32,-410 971.32,-410 971.32,-388 780.32,-388"/>
+<text text-anchor="start" x="831.31" y="-395.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="884.57" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-366 780.32,-388 971.32,-388 971.32,-366 780.32,-366"/>
+<text text-anchor="start" x="827.42" y="-373.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="864.36" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-344 780.32,-366 971.32,-366 971.32,-344 780.32,-344"/>
+<text text-anchor="start" x="803.7" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="912.18" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-322 780.32,-344 971.32,-344 971.32,-322 780.32,-322"/>
+<text text-anchor="start" x="794.76" y="-329.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="921.12" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-300 780.32,-322 971.32,-322 971.32,-300 780.32,-300"/>
+<text text-anchor="start" x="815.76" y="-307.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="900.12" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-278 780.32,-300 971.32,-300 971.32,-278 780.32,-278"/>
+<text text-anchor="start" x="814.19" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="901.68" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-256 780.32,-278 971.32,-278 971.32,-256 780.32,-256"/>
+<text text-anchor="start" x="804.48" y="-263.4" font-family="Times,serif" font-size="14.00">episodes_updated: </text>
+<text text-anchor="start" x="911.4" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<polygon fill="none" stroke="black" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<text text-anchor="start" x="855.61" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="780.32,-212 780.32,-234 971.32,-234 971.32,-212 780.32,-212"/>
+<text text-anchor="start" x="783.28" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M972.32,-597C1030.65,-597 1028.48,-643.49 1072.98,-681.2 1102.27,-706.01 1102.95,-736.85 1134.64,-742.19"/>
+<polygon fill="black" stroke="black" points="1134.74,-745.71 1144.98,-743 1135.28,-738.73 1134.74,-745.71"/>
+<text text-anchor="middle" x="1063.65" y="-686.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="401.66,-652 401.66,-674 605.66,-674 605.66,-652 401.66,-652"/>
+<polygon fill="none" stroke="black" points="401.66,-652 401.66,-674 605.66,-674 605.66,-652 401.66,-652"/>
+<text text-anchor="start" x="479.56" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="401.66,-630 401.66,-652 605.66,-652 605.66,-630 401.66,-630"/>
+<text text-anchor="start" x="464.59" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="482.87" y="-637.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-608 401.66,-630 605.66,-630 605.66,-608 401.66,-608"/>
+<text text-anchor="start" x="442.43" y="-615.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="505.03" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<text text-anchor="start" x="448.26" y="-593.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="499.2" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-564 401.66,-586 605.66,-586 605.66,-564 401.66,-564"/>
+<text text-anchor="start" x="446.7" y="-571.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="500.76" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-542 401.66,-564 605.66,-564 605.66,-542 401.66,-542"/>
+<text text-anchor="start" x="471.19" y="-549.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="500.36" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-520 401.66,-542 605.66,-542 605.66,-520 401.66,-520"/>
+<text text-anchor="start" x="456.04" y="-527.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="515.52" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-498 401.66,-520 605.66,-520 605.66,-498 401.66,-498"/>
+<text text-anchor="start" x="448.65" y="-505.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="498.8" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-476 401.66,-498 605.66,-498 605.66,-476 401.66,-476"/>
+<text text-anchor="start" x="453.32" y="-483.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="518.24" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-454 401.66,-476 605.66,-476 605.66,-454 401.66,-454"/>
+<text text-anchor="start" x="465.36" y="-461.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="505.41" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="401.66,-432 401.66,-454 605.66,-454 605.66,-432 401.66,-432"/>
+<text text-anchor="start" x="455.26" y="-439.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="492.2" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-410 401.66,-432 605.66,-432 605.66,-410 401.66,-410"/>
+<text text-anchor="start" x="431.53" y="-417.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="540.02" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-388 401.66,-410 605.66,-410 605.66,-388 401.66,-388"/>
+<text text-anchor="start" x="422.59" y="-395.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="548.96" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-366 401.66,-388 605.66,-388 605.66,-366 401.66,-366"/>
+<text text-anchor="start" x="443.59" y="-373.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="527.96" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-344 401.66,-366 605.66,-366 605.66,-344 401.66,-344"/>
+<text text-anchor="start" x="442.03" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="529.52" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<text text-anchor="start" x="436.99" y="-329.4" font-family="Times,serif" font-size="14.00">last_watched_at: </text>
+<text text-anchor="start" x="534.57" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<polygon fill="none" stroke="black" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<text text-anchor="start" x="483.45" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="401.66,-278 401.66,-300 605.66,-300 605.66,-278 401.66,-278"/>
+<text text-anchor="start" x="404.52" y="-284.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M605.66,-619C679.38,-619 700.29,-619 769.26,-619"/>
+<polygon fill="black" stroke="black" points="769.32,-622.5 779.32,-619 769.32,-615.5 769.32,-622.5"/>
+<text text-anchor="middle" x="686.99" y="-623.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<polygon fill="none" stroke="black" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<text text-anchor="start" x="835.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="768.32,-132 768.32,-154 982.32,-154 982.32,-132 768.32,-132"/>
+<text text-anchor="start" x="836.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="854.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-110 768.32,-132 982.32,-132 982.32,-110 768.32,-110"/>
+<text text-anchor="start" x="817.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="872.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-88 768.32,-110 982.32,-110 982.32,-88 768.32,-88"/>
+<text text-anchor="start" x="800.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="890.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-66 768.32,-88 982.32,-88 982.32,-66 768.32,-66"/>
+<text text-anchor="start" x="807.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="882.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<polygon fill="none" stroke="black" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<text text-anchor="start" x="855.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="768.32,-22 768.32,-44 982.32,-44 982.32,-22 768.32,-22"/>
+<text text-anchor="start" x="789.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="768.32,0 768.32,-22 982.32,-22 982.32,0 768.32,0"/>
+<text text-anchor="start" x="771.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-99C1123.82,-99 1038.1,-267.06 1072.98,-404.2 1091.07,-475.3 1070.16,-718.65 1134.81,-741.31"/>
+<polygon fill="black" stroke="black" points="1134.54,-744.81 1144.98,-743 1135.69,-737.9 1134.54,-744.81"/>
+<text text-anchor="middle" x="1063.65" y="-409.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-121C1051.96,-121 1036.74,-358.61 1054.32,-426 1071.91,-493.43 1071.77,-719.38 1134.77,-741.29"/>
+<polygon fill="black" stroke="black" points="1134.54,-744.8 1144.98,-743 1135.7,-737.9 1134.54,-744.8"/>
+<text text-anchor="middle" x="1063.65" y="-564.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node10" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-674 0.5,-696 239.5,-696 239.5,-674 0.5,-674"/>
+<polygon fill="none" stroke="black" points="0.5,-674 0.5,-696 239.5,-696 239.5,-674 0.5,-674"/>
+<text text-anchor="start" x="56.25" y="-681.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-652 0.5,-674 239.5,-674 239.5,-652 0.5,-652"/>
+<text text-anchor="start" x="80.93" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-659.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<text text-anchor="start" x="56.04" y="-637.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-637.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="64.6" y="-615.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="66.55" y="-593.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="43.21" y="-571.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="136.92" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="99.79" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="3.37" y="-526.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="11.92" y="-504.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-641C307.76,-641 327.47,-641 391.45,-641"/>
+<polygon fill="black" stroke="black" points="391.66,-644.5 401.66,-641 391.66,-637.5 391.66,-644.5"/>
+<text text-anchor="middle" x="320.33" y="-645.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/4.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/4.svg
@@ -1,0 +1,424 @@
+<svg width="1385px" height="1418px"
+ viewBox="0.00 0.00 1384.98 1418.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1382)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1382 1348.98,-1382 1348.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1144.98,-754 1144.98,-776 1312.98,-776 1312.98,-754 1144.98,-754"/>
+<polygon fill="none" stroke="black" points="1144.98,-754 1144.98,-776 1312.98,-776 1312.98,-754 1144.98,-754"/>
+<text text-anchor="start" x="1211.48" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1144.98,-732 1144.98,-754 1312.98,-754 1312.98,-732 1144.98,-732"/>
+<text text-anchor="start" x="1189.91" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1208.19" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-710 1144.98,-732 1312.98,-732 1312.98,-710 1144.98,-710"/>
+<text text-anchor="start" x="1196.52" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1225.68" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-688 1144.98,-710 1312.98,-710 1312.98,-688 1144.98,-688"/>
+<text text-anchor="start" x="1171.24" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1250.96" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-666 1144.98,-688 1312.98,-688 1312.98,-666 1144.98,-666"/>
+<text text-anchor="start" x="1173.58" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1224.52" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-644 1144.98,-666 1312.98,-666 1312.98,-644 1144.98,-644"/>
+<text text-anchor="start" x="1172.02" y="-651.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1226.08" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-622 1144.98,-644 1312.98,-644 1312.98,-622 1144.98,-622"/>
+<text text-anchor="start" x="1156.86" y="-629.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1265.34" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-600 1144.98,-622 1312.98,-622 1312.98,-600 1144.98,-600"/>
+<text text-anchor="start" x="1147.92" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1274.28" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-578 1144.98,-600 1312.98,-600 1312.98,-578 1144.98,-578"/>
+<text text-anchor="start" x="1168.92" y="-585.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="1253.28" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-556 1144.98,-578 1312.98,-578 1312.98,-556 1144.98,-556"/>
+<text text-anchor="start" x="1167.35" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="1254.85" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-534 1144.98,-556 1312.98,-556 1312.98,-534 1144.98,-534"/>
+<text text-anchor="start" x="1181.36" y="-541.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1240.84" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-512 1144.98,-534 1312.98,-534 1312.98,-512 1144.98,-512"/>
+<text text-anchor="start" x="1178.64" y="-519.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1243.56" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-490 1144.98,-512 1312.98,-512 1312.98,-490 1144.98,-490"/>
+<text text-anchor="start" x="1190.68" y="-497.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="1230.73" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1144.98,-468 1144.98,-490 1312.98,-490 1312.98,-468 1144.98,-468"/>
+<text text-anchor="start" x="1173.59" y="-475.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1248.61" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-446 1144.98,-468 1312.98,-468 1312.98,-446 1144.98,-446"/>
+<text text-anchor="start" x="1186.02" y="-453.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1236.18" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-424 1144.98,-446 1312.98,-446 1312.98,-424 1144.98,-424"/>
+<text text-anchor="start" x="1184.47" y="-431.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1237.73" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-402 1144.98,-424 1312.98,-424 1312.98,-402 1144.98,-402"/>
+<text text-anchor="start" x="1173.58" y="-409.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1224.52" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-380 1144.98,-402 1312.98,-402 1312.98,-380 1144.98,-380"/>
+<text text-anchor="start" x="1189.14" y="-387.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1233.06" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<polygon fill="none" stroke="black" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<text text-anchor="start" x="1208.77" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<text text-anchor="start" x="1167.16" y="-342.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1144.98,-314 1144.98,-336 1312.98,-336 1312.98,-314 1144.98,-314"/>
+<text text-anchor="start" x="1165.6" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="782.32,-1324 782.32,-1346 969.32,-1346 969.32,-1324 782.32,-1324"/>
+<polygon fill="none" stroke="black" points="782.32,-1324 782.32,-1346 969.32,-1346 969.32,-1324 782.32,-1324"/>
+<text text-anchor="start" x="831.5" y="-1331.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="782.32,-1302 782.32,-1324 969.32,-1324 969.32,-1302 782.32,-1302"/>
+<text text-anchor="start" x="836.75" y="-1309.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1309.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<text text-anchor="start" x="818.47" y="-1287.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1258 782.32,-1280 969.32,-1280 969.32,-1258 782.32,-1258"/>
+<text text-anchor="start" x="828.98" y="-1265.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1236 782.32,-1258 969.32,-1258 969.32,-1236 782.32,-1236"/>
+<text text-anchor="start" x="817.32" y="-1243.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="874.46" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<polygon fill="none" stroke="black" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<text text-anchor="start" x="855.61" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="782.32,-1192 782.32,-1214 969.32,-1214 969.32,-1192 782.32,-1192"/>
+<text text-anchor="start" x="785.22" y="-1198.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M970.32,-1291C1000.15,-1291 1098.67,-813.36 1137.62,-749.93"/>
+<polygon fill="black" stroke="black" points="1140.1,-752.4 1144.98,-743 1135.3,-747.3 1140.1,-752.4"/>
+<text text-anchor="middle" x="1063.65" y="-1021.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="784.32,-1134 784.32,-1156 967.32,-1156 967.32,-1134 784.32,-1134"/>
+<polygon fill="none" stroke="black" points="784.32,-1134 784.32,-1156 967.32,-1156 967.32,-1134 784.32,-1134"/>
+<text text-anchor="start" x="833.44" y="-1141.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="784.32,-1112 784.32,-1134 967.32,-1134 967.32,-1112 784.32,-1112"/>
+<text text-anchor="start" x="836.75" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1119.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<text text-anchor="start" x="818.47" y="-1097.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1068 784.32,-1090 967.32,-1090 967.32,-1068 784.32,-1068"/>
+<text text-anchor="start" x="828.98" y="-1075.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1046 784.32,-1068 967.32,-1068 967.32,-1046 784.32,-1046"/>
+<text text-anchor="start" x="810.71" y="-1053.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="881.06" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<polygon fill="none" stroke="black" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<text text-anchor="start" x="855.61" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="784.32,-1002 784.32,-1024 967.32,-1024 967.32,-1002 784.32,-1002"/>
+<text text-anchor="start" x="787.17" y="-1008.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M968.32,-1101C1053.57,-1101 1056.19,-770.42 1134.98,-744.6"/>
+<polygon fill="black" stroke="black" points="1135.66,-748.03 1144.98,-743 1134.56,-741.12 1135.66,-748.03"/>
+<text text-anchor="middle" x="1063.65" y="-926.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="62.5,-886 62.5,-908 176.5,-908 176.5,-886 62.5,-886"/>
+<polygon fill="none" stroke="black" points="62.5,-886 62.5,-908 176.5,-908 176.5,-886 62.5,-886"/>
+<text text-anchor="start" x="105.12" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="62.5,-864 62.5,-886 176.5,-886 176.5,-864 62.5,-864"/>
+<text text-anchor="start" x="80.43" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-871.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="62.5,-842 62.5,-864 176.5,-864 176.5,-842 62.5,-842"/>
+<text text-anchor="start" x="71.1" y="-849.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.13" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-820 62.5,-842 176.5,-842 176.5,-820 62.5,-820"/>
+<text text-anchor="start" x="82.76" y="-827.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.47" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-798 62.5,-820 176.5,-820 176.5,-798 62.5,-798"/>
+<text text-anchor="start" x="65.26" y="-805.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="137.97" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-776 62.5,-798 176.5,-798 176.5,-776 62.5,-776"/>
+<text text-anchor="start" x="75.37" y="-783.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="127.86" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-754 62.5,-776 176.5,-776 176.5,-754 62.5,-754"/>
+<text text-anchor="start" x="82.37" y="-761.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="120.87" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-732 62.5,-754 176.5,-754 176.5,-732 62.5,-732"/>
+<text text-anchor="start" x="69.55" y="-739.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="133.69" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="781.32,-944 781.32,-966 970.32,-966 970.32,-944 781.32,-944"/>
+<polygon fill="none" stroke="black" points="781.32,-944 781.32,-966 970.32,-966 970.32,-944 781.32,-944"/>
+<text text-anchor="start" x="830.34" y="-951.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="781.32,-922 781.32,-944 970.32,-944 970.32,-922 781.32,-922"/>
+<text text-anchor="start" x="836.75" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-929.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<text text-anchor="start" x="818.47" y="-907.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-878 781.32,-900 970.32,-900 970.32,-878 781.32,-878"/>
+<text text-anchor="start" x="817.7" y="-885.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="898.17" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<polygon fill="none" stroke="black" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<text text-anchor="start" x="855.61" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="781.32,-834 781.32,-856 970.32,-856 970.32,-834 781.32,-834"/>
+<text text-anchor="start" x="784.07" y="-840.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M971.32,-911C1075.14,-911 1040.16,-753.97 1134.77,-743.54"/>
+<polygon fill="black" stroke="black" points="1135.18,-747.03 1144.98,-743 1134.81,-740.04 1135.18,-747.03"/>
+<text text-anchor="middle" x="1063.65" y="-836.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="778.32,-776 778.32,-798 973.32,-798 973.32,-776 778.32,-776"/>
+<polygon fill="none" stroke="black" points="778.32,-776 778.32,-798 973.32,-798 973.32,-776 778.32,-776"/>
+<text text-anchor="start" x="827.22" y="-783.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="778.32,-754 778.32,-776 973.32,-776 973.32,-754 778.32,-754"/>
+<text text-anchor="start" x="836.75" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-761.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<text text-anchor="start" x="818.47" y="-739.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<polygon fill="none" stroke="black" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<text text-anchor="start" x="855.61" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="778.32,-688 778.32,-710 973.32,-710 973.32,-688 778.32,-688"/>
+<text text-anchor="start" x="780.95" y="-694.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M974.32,-743C1046.61,-743 1067.23,-743 1134.68,-743"/>
+<polygon fill="black" stroke="black" points="1134.98,-746.5 1144.98,-743 1134.98,-739.5 1134.98,-746.5"/>
+<text text-anchor="middle" x="1063.65" y="-748.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="780.32,-630 780.32,-652 971.32,-652 971.32,-630 780.32,-630"/>
+<polygon fill="none" stroke="black" points="780.32,-630 780.32,-652 971.32,-652 971.32,-630 780.32,-630"/>
+<text text-anchor="start" x="854.44" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="780.32,-608 780.32,-630 971.32,-630 971.32,-608 780.32,-608"/>
+<text text-anchor="start" x="836.75" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-615.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-586 780.32,-608 971.32,-608 971.32,-586 780.32,-586"/>
+<text text-anchor="start" x="818.47" y="-593.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<text text-anchor="start" x="820.42" y="-571.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="871.36" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-542 780.32,-564 971.32,-564 971.32,-542 780.32,-542"/>
+<text text-anchor="start" x="818.86" y="-549.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="872.92" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-520 780.32,-542 971.32,-542 971.32,-520 780.32,-520"/>
+<text text-anchor="start" x="843.36" y="-527.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="872.52" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-498 780.32,-520 971.32,-520 971.32,-498 780.32,-498"/>
+<text text-anchor="start" x="828.2" y="-505.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="887.68" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-476 780.32,-498 971.32,-498 971.32,-476 780.32,-476"/>
+<text text-anchor="start" x="820.81" y="-483.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="870.97" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-454 780.32,-476 971.32,-476 971.32,-454 780.32,-454"/>
+<text text-anchor="start" x="816.53" y="-461.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="875.24" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-432 780.32,-454 971.32,-454 971.32,-432 780.32,-432"/>
+<text text-anchor="start" x="818.09" y="-439.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="873.68" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-410 780.32,-432 971.32,-432 971.32,-410 780.32,-410"/>
+<text text-anchor="start" x="837.52" y="-417.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="877.57" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="780.32,-388 780.32,-410 971.32,-410 971.32,-388 780.32,-388"/>
+<text text-anchor="start" x="831.31" y="-395.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="884.57" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-366 780.32,-388 971.32,-388 971.32,-366 780.32,-366"/>
+<text text-anchor="start" x="827.42" y="-373.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="864.36" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-344 780.32,-366 971.32,-366 971.32,-344 780.32,-344"/>
+<text text-anchor="start" x="803.7" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="912.18" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-322 780.32,-344 971.32,-344 971.32,-322 780.32,-322"/>
+<text text-anchor="start" x="794.76" y="-329.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="921.12" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-300 780.32,-322 971.32,-322 971.32,-300 780.32,-300"/>
+<text text-anchor="start" x="815.76" y="-307.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="900.12" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-278 780.32,-300 971.32,-300 971.32,-278 780.32,-278"/>
+<text text-anchor="start" x="814.19" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="901.68" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-256 780.32,-278 971.32,-278 971.32,-256 780.32,-256"/>
+<text text-anchor="start" x="804.48" y="-263.4" font-family="Times,serif" font-size="14.00">episodes_updated: </text>
+<text text-anchor="start" x="911.4" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<polygon fill="none" stroke="black" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<text text-anchor="start" x="855.61" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="780.32,-212 780.32,-234 971.32,-234 971.32,-212 780.32,-212"/>
+<text text-anchor="start" x="783.28" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M972.32,-597C1030.65,-597 1028.48,-643.49 1072.98,-681.2 1102.27,-706.01 1102.95,-736.85 1134.64,-742.19"/>
+<polygon fill="black" stroke="black" points="1134.74,-745.71 1144.98,-743 1135.28,-738.73 1134.74,-745.71"/>
+<text text-anchor="middle" x="1063.65" y="-686.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="401.66,-652 401.66,-674 605.66,-674 605.66,-652 401.66,-652"/>
+<polygon fill="none" stroke="black" points="401.66,-652 401.66,-674 605.66,-674 605.66,-652 401.66,-652"/>
+<text text-anchor="start" x="479.56" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="401.66,-630 401.66,-652 605.66,-652 605.66,-630 401.66,-630"/>
+<text text-anchor="start" x="464.59" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="482.87" y="-637.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-608 401.66,-630 605.66,-630 605.66,-608 401.66,-608"/>
+<text text-anchor="start" x="442.43" y="-615.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="505.03" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<text text-anchor="start" x="448.26" y="-593.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="499.2" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-564 401.66,-586 605.66,-586 605.66,-564 401.66,-564"/>
+<text text-anchor="start" x="446.7" y="-571.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="500.76" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-542 401.66,-564 605.66,-564 605.66,-542 401.66,-542"/>
+<text text-anchor="start" x="471.19" y="-549.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="500.36" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-520 401.66,-542 605.66,-542 605.66,-520 401.66,-520"/>
+<text text-anchor="start" x="456.04" y="-527.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="515.52" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-498 401.66,-520 605.66,-520 605.66,-498 401.66,-498"/>
+<text text-anchor="start" x="448.65" y="-505.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="498.8" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-476 401.66,-498 605.66,-498 605.66,-476 401.66,-476"/>
+<text text-anchor="start" x="453.32" y="-483.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="518.24" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-454 401.66,-476 605.66,-476 605.66,-454 401.66,-454"/>
+<text text-anchor="start" x="465.36" y="-461.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="505.41" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="401.66,-432 401.66,-454 605.66,-454 605.66,-432 401.66,-432"/>
+<text text-anchor="start" x="455.26" y="-439.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="492.2" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-410 401.66,-432 605.66,-432 605.66,-410 401.66,-410"/>
+<text text-anchor="start" x="431.53" y="-417.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="540.02" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-388 401.66,-410 605.66,-410 605.66,-388 401.66,-388"/>
+<text text-anchor="start" x="422.59" y="-395.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="548.96" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-366 401.66,-388 605.66,-388 605.66,-366 401.66,-366"/>
+<text text-anchor="start" x="443.59" y="-373.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="527.96" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-344 401.66,-366 605.66,-366 605.66,-344 401.66,-344"/>
+<text text-anchor="start" x="442.03" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="529.52" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<text text-anchor="start" x="436.99" y="-329.4" font-family="Times,serif" font-size="14.00">last_watched_at: </text>
+<text text-anchor="start" x="534.57" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<polygon fill="none" stroke="black" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<text text-anchor="start" x="483.45" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="401.66,-278 401.66,-300 605.66,-300 605.66,-278 401.66,-278"/>
+<text text-anchor="start" x="404.52" y="-284.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M605.66,-619C679.38,-619 700.29,-619 769.26,-619"/>
+<polygon fill="black" stroke="black" points="769.32,-622.5 779.32,-619 769.32,-615.5 769.32,-622.5"/>
+<text text-anchor="middle" x="686.99" y="-623.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<polygon fill="none" stroke="black" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<text text-anchor="start" x="835.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="768.32,-132 768.32,-154 982.32,-154 982.32,-132 768.32,-132"/>
+<text text-anchor="start" x="836.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="854.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-110 768.32,-132 982.32,-132 982.32,-110 768.32,-110"/>
+<text text-anchor="start" x="817.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="872.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-88 768.32,-110 982.32,-110 982.32,-88 768.32,-88"/>
+<text text-anchor="start" x="800.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="890.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-66 768.32,-88 982.32,-88 982.32,-66 768.32,-66"/>
+<text text-anchor="start" x="807.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="882.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<polygon fill="none" stroke="black" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<text text-anchor="start" x="855.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="768.32,-22 768.32,-44 982.32,-44 982.32,-22 768.32,-22"/>
+<text text-anchor="start" x="789.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="768.32,0 768.32,-22 982.32,-22 982.32,0 768.32,0"/>
+<text text-anchor="start" x="771.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-99C1123.82,-99 1038.1,-267.06 1072.98,-404.2 1091.07,-475.3 1070.16,-718.65 1134.81,-741.31"/>
+<polygon fill="black" stroke="black" points="1134.54,-744.81 1144.98,-743 1135.69,-737.9 1134.54,-744.81"/>
+<text text-anchor="middle" x="1063.65" y="-409.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-121C1051.96,-121 1036.74,-358.61 1054.32,-426 1071.91,-493.43 1071.77,-719.38 1134.77,-741.29"/>
+<polygon fill="black" stroke="black" points="1134.54,-744.8 1144.98,-743 1135.7,-737.9 1134.54,-744.8"/>
+<text text-anchor="middle" x="1063.65" y="-564.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node10" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-674 0.5,-696 239.5,-696 239.5,-674 0.5,-674"/>
+<polygon fill="none" stroke="black" points="0.5,-674 0.5,-696 239.5,-696 239.5,-674 0.5,-674"/>
+<text text-anchor="start" x="56.25" y="-681.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-652 0.5,-674 239.5,-674 239.5,-652 0.5,-652"/>
+<text text-anchor="start" x="80.93" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-659.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<text text-anchor="start" x="56.04" y="-637.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-637.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="64.6" y="-615.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="66.55" y="-593.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="43.21" y="-571.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="136.92" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="99.79" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="3.37" y="-526.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="11.92" y="-504.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-641C307.76,-641 327.47,-641 391.45,-641"/>
+<polygon fill="black" stroke="black" points="391.66,-644.5 401.66,-641 391.66,-637.5 391.66,-644.5"/>
+<text text-anchor="middle" x="320.33" y="-645.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/5.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/5.svg
@@ -1,0 +1,424 @@
+<svg width="1385px" height="1418px"
+ viewBox="0.00 0.00 1384.98 1418.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1382)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1382 1348.98,-1382 1348.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1144.98,-754 1144.98,-776 1312.98,-776 1312.98,-754 1144.98,-754"/>
+<polygon fill="none" stroke="black" points="1144.98,-754 1144.98,-776 1312.98,-776 1312.98,-754 1144.98,-754"/>
+<text text-anchor="start" x="1211.48" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1144.98,-732 1144.98,-754 1312.98,-754 1312.98,-732 1144.98,-732"/>
+<text text-anchor="start" x="1189.91" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1208.19" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-710 1144.98,-732 1312.98,-732 1312.98,-710 1144.98,-710"/>
+<text text-anchor="start" x="1196.52" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1225.68" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-688 1144.98,-710 1312.98,-710 1312.98,-688 1144.98,-688"/>
+<text text-anchor="start" x="1171.24" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1250.96" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-666 1144.98,-688 1312.98,-688 1312.98,-666 1144.98,-666"/>
+<text text-anchor="start" x="1173.58" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1224.52" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-644 1144.98,-666 1312.98,-666 1312.98,-644 1144.98,-644"/>
+<text text-anchor="start" x="1172.02" y="-651.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1226.08" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-622 1144.98,-644 1312.98,-644 1312.98,-622 1144.98,-622"/>
+<text text-anchor="start" x="1156.86" y="-629.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1265.34" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-600 1144.98,-622 1312.98,-622 1312.98,-600 1144.98,-600"/>
+<text text-anchor="start" x="1147.92" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1274.28" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-578 1144.98,-600 1312.98,-600 1312.98,-578 1144.98,-578"/>
+<text text-anchor="start" x="1168.92" y="-585.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="1253.28" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-556 1144.98,-578 1312.98,-578 1312.98,-556 1144.98,-556"/>
+<text text-anchor="start" x="1167.35" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="1254.85" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-534 1144.98,-556 1312.98,-556 1312.98,-534 1144.98,-534"/>
+<text text-anchor="start" x="1181.36" y="-541.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1240.84" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-512 1144.98,-534 1312.98,-534 1312.98,-512 1144.98,-512"/>
+<text text-anchor="start" x="1178.64" y="-519.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1243.56" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-490 1144.98,-512 1312.98,-512 1312.98,-490 1144.98,-490"/>
+<text text-anchor="start" x="1190.68" y="-497.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="1230.73" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1144.98,-468 1144.98,-490 1312.98,-490 1312.98,-468 1144.98,-468"/>
+<text text-anchor="start" x="1173.59" y="-475.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1248.61" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-446 1144.98,-468 1312.98,-468 1312.98,-446 1144.98,-446"/>
+<text text-anchor="start" x="1186.02" y="-453.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1236.18" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-424 1144.98,-446 1312.98,-446 1312.98,-424 1144.98,-424"/>
+<text text-anchor="start" x="1184.47" y="-431.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1237.73" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-402 1144.98,-424 1312.98,-424 1312.98,-402 1144.98,-402"/>
+<text text-anchor="start" x="1173.58" y="-409.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1224.52" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-380 1144.98,-402 1312.98,-402 1312.98,-380 1144.98,-380"/>
+<text text-anchor="start" x="1189.14" y="-387.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1233.06" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<polygon fill="none" stroke="black" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<text text-anchor="start" x="1208.77" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<text text-anchor="start" x="1167.16" y="-342.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1144.98,-314 1144.98,-336 1312.98,-336 1312.98,-314 1144.98,-314"/>
+<text text-anchor="start" x="1165.6" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="782.32,-1324 782.32,-1346 969.32,-1346 969.32,-1324 782.32,-1324"/>
+<polygon fill="none" stroke="black" points="782.32,-1324 782.32,-1346 969.32,-1346 969.32,-1324 782.32,-1324"/>
+<text text-anchor="start" x="831.5" y="-1331.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="782.32,-1302 782.32,-1324 969.32,-1324 969.32,-1302 782.32,-1302"/>
+<text text-anchor="start" x="836.75" y="-1309.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1309.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<text text-anchor="start" x="818.47" y="-1287.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1258 782.32,-1280 969.32,-1280 969.32,-1258 782.32,-1258"/>
+<text text-anchor="start" x="828.98" y="-1265.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1236 782.32,-1258 969.32,-1258 969.32,-1236 782.32,-1236"/>
+<text text-anchor="start" x="817.32" y="-1243.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="874.46" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<polygon fill="none" stroke="black" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<text text-anchor="start" x="855.61" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="782.32,-1192 782.32,-1214 969.32,-1214 969.32,-1192 782.32,-1192"/>
+<text text-anchor="start" x="785.22" y="-1198.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M970.32,-1291C1000.15,-1291 1098.67,-813.36 1137.62,-749.93"/>
+<polygon fill="black" stroke="black" points="1140.1,-752.4 1144.98,-743 1135.3,-747.3 1140.1,-752.4"/>
+<text text-anchor="middle" x="1063.65" y="-1021.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="784.32,-1134 784.32,-1156 967.32,-1156 967.32,-1134 784.32,-1134"/>
+<polygon fill="none" stroke="black" points="784.32,-1134 784.32,-1156 967.32,-1156 967.32,-1134 784.32,-1134"/>
+<text text-anchor="start" x="833.44" y="-1141.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="784.32,-1112 784.32,-1134 967.32,-1134 967.32,-1112 784.32,-1112"/>
+<text text-anchor="start" x="836.75" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1119.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<text text-anchor="start" x="818.47" y="-1097.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1068 784.32,-1090 967.32,-1090 967.32,-1068 784.32,-1068"/>
+<text text-anchor="start" x="828.98" y="-1075.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1046 784.32,-1068 967.32,-1068 967.32,-1046 784.32,-1046"/>
+<text text-anchor="start" x="810.71" y="-1053.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="881.06" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<polygon fill="none" stroke="black" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<text text-anchor="start" x="855.61" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="784.32,-1002 784.32,-1024 967.32,-1024 967.32,-1002 784.32,-1002"/>
+<text text-anchor="start" x="787.17" y="-1008.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M968.32,-1101C1053.57,-1101 1056.19,-770.42 1134.98,-744.6"/>
+<polygon fill="black" stroke="black" points="1135.66,-748.03 1144.98,-743 1134.56,-741.12 1135.66,-748.03"/>
+<text text-anchor="middle" x="1063.65" y="-926.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="62.5,-886 62.5,-908 176.5,-908 176.5,-886 62.5,-886"/>
+<polygon fill="none" stroke="black" points="62.5,-886 62.5,-908 176.5,-908 176.5,-886 62.5,-886"/>
+<text text-anchor="start" x="105.12" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="62.5,-864 62.5,-886 176.5,-886 176.5,-864 62.5,-864"/>
+<text text-anchor="start" x="80.43" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-871.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="62.5,-842 62.5,-864 176.5,-864 176.5,-842 62.5,-842"/>
+<text text-anchor="start" x="71.1" y="-849.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.13" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-820 62.5,-842 176.5,-842 176.5,-820 62.5,-820"/>
+<text text-anchor="start" x="82.76" y="-827.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.47" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-798 62.5,-820 176.5,-820 176.5,-798 62.5,-798"/>
+<text text-anchor="start" x="65.26" y="-805.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="137.97" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-776 62.5,-798 176.5,-798 176.5,-776 62.5,-776"/>
+<text text-anchor="start" x="75.37" y="-783.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="127.86" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-754 62.5,-776 176.5,-776 176.5,-754 62.5,-754"/>
+<text text-anchor="start" x="82.37" y="-761.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="120.87" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-732 62.5,-754 176.5,-754 176.5,-732 62.5,-732"/>
+<text text-anchor="start" x="69.55" y="-739.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="133.69" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="781.32,-944 781.32,-966 970.32,-966 970.32,-944 781.32,-944"/>
+<polygon fill="none" stroke="black" points="781.32,-944 781.32,-966 970.32,-966 970.32,-944 781.32,-944"/>
+<text text-anchor="start" x="830.34" y="-951.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="781.32,-922 781.32,-944 970.32,-944 970.32,-922 781.32,-922"/>
+<text text-anchor="start" x="836.75" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-929.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<text text-anchor="start" x="818.47" y="-907.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-878 781.32,-900 970.32,-900 970.32,-878 781.32,-878"/>
+<text text-anchor="start" x="817.7" y="-885.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="898.17" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<polygon fill="none" stroke="black" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<text text-anchor="start" x="855.61" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="781.32,-834 781.32,-856 970.32,-856 970.32,-834 781.32,-834"/>
+<text text-anchor="start" x="784.07" y="-840.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M971.32,-911C1075.14,-911 1040.16,-753.97 1134.77,-743.54"/>
+<polygon fill="black" stroke="black" points="1135.18,-747.03 1144.98,-743 1134.81,-740.04 1135.18,-747.03"/>
+<text text-anchor="middle" x="1063.65" y="-836.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="778.32,-776 778.32,-798 973.32,-798 973.32,-776 778.32,-776"/>
+<polygon fill="none" stroke="black" points="778.32,-776 778.32,-798 973.32,-798 973.32,-776 778.32,-776"/>
+<text text-anchor="start" x="827.22" y="-783.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="778.32,-754 778.32,-776 973.32,-776 973.32,-754 778.32,-754"/>
+<text text-anchor="start" x="836.75" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-761.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<text text-anchor="start" x="818.47" y="-739.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<polygon fill="none" stroke="black" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<text text-anchor="start" x="855.61" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="778.32,-688 778.32,-710 973.32,-710 973.32,-688 778.32,-688"/>
+<text text-anchor="start" x="780.95" y="-694.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M974.32,-743C1046.61,-743 1067.23,-743 1134.68,-743"/>
+<polygon fill="black" stroke="black" points="1134.98,-746.5 1144.98,-743 1134.98,-739.5 1134.98,-746.5"/>
+<text text-anchor="middle" x="1063.65" y="-748.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="780.32,-630 780.32,-652 971.32,-652 971.32,-630 780.32,-630"/>
+<polygon fill="none" stroke="black" points="780.32,-630 780.32,-652 971.32,-652 971.32,-630 780.32,-630"/>
+<text text-anchor="start" x="854.44" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="780.32,-608 780.32,-630 971.32,-630 971.32,-608 780.32,-608"/>
+<text text-anchor="start" x="836.75" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-615.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-586 780.32,-608 971.32,-608 971.32,-586 780.32,-586"/>
+<text text-anchor="start" x="818.47" y="-593.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<text text-anchor="start" x="820.42" y="-571.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="871.36" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-542 780.32,-564 971.32,-564 971.32,-542 780.32,-542"/>
+<text text-anchor="start" x="818.86" y="-549.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="872.92" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-520 780.32,-542 971.32,-542 971.32,-520 780.32,-520"/>
+<text text-anchor="start" x="843.36" y="-527.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="872.52" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-498 780.32,-520 971.32,-520 971.32,-498 780.32,-498"/>
+<text text-anchor="start" x="828.2" y="-505.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="887.68" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-476 780.32,-498 971.32,-498 971.32,-476 780.32,-476"/>
+<text text-anchor="start" x="820.81" y="-483.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="870.97" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-454 780.32,-476 971.32,-476 971.32,-454 780.32,-454"/>
+<text text-anchor="start" x="816.53" y="-461.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="875.24" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-432 780.32,-454 971.32,-454 971.32,-432 780.32,-432"/>
+<text text-anchor="start" x="818.09" y="-439.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="873.68" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-410 780.32,-432 971.32,-432 971.32,-410 780.32,-410"/>
+<text text-anchor="start" x="837.52" y="-417.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="877.57" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="780.32,-388 780.32,-410 971.32,-410 971.32,-388 780.32,-388"/>
+<text text-anchor="start" x="831.31" y="-395.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="884.57" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-366 780.32,-388 971.32,-388 971.32,-366 780.32,-366"/>
+<text text-anchor="start" x="827.42" y="-373.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="864.36" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-344 780.32,-366 971.32,-366 971.32,-344 780.32,-344"/>
+<text text-anchor="start" x="803.7" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="912.18" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-322 780.32,-344 971.32,-344 971.32,-322 780.32,-322"/>
+<text text-anchor="start" x="794.76" y="-329.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="921.12" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-300 780.32,-322 971.32,-322 971.32,-300 780.32,-300"/>
+<text text-anchor="start" x="815.76" y="-307.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="900.12" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-278 780.32,-300 971.32,-300 971.32,-278 780.32,-278"/>
+<text text-anchor="start" x="814.19" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="901.68" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-256 780.32,-278 971.32,-278 971.32,-256 780.32,-256"/>
+<text text-anchor="start" x="804.48" y="-263.4" font-family="Times,serif" font-size="14.00">episodes_updated: </text>
+<text text-anchor="start" x="911.4" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<polygon fill="none" stroke="black" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<text text-anchor="start" x="855.61" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="780.32,-212 780.32,-234 971.32,-234 971.32,-212 780.32,-212"/>
+<text text-anchor="start" x="783.28" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M972.32,-597C1030.65,-597 1028.48,-643.49 1072.98,-681.2 1102.27,-706.01 1102.95,-736.85 1134.64,-742.19"/>
+<polygon fill="black" stroke="black" points="1134.74,-745.71 1144.98,-743 1135.28,-738.73 1134.74,-745.71"/>
+<text text-anchor="middle" x="1063.65" y="-686.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="401.66,-652 401.66,-674 605.66,-674 605.66,-652 401.66,-652"/>
+<polygon fill="none" stroke="black" points="401.66,-652 401.66,-674 605.66,-674 605.66,-652 401.66,-652"/>
+<text text-anchor="start" x="479.56" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="401.66,-630 401.66,-652 605.66,-652 605.66,-630 401.66,-630"/>
+<text text-anchor="start" x="464.59" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="482.87" y="-637.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-608 401.66,-630 605.66,-630 605.66,-608 401.66,-608"/>
+<text text-anchor="start" x="442.43" y="-615.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="505.03" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<text text-anchor="start" x="448.26" y="-593.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="499.2" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-564 401.66,-586 605.66,-586 605.66,-564 401.66,-564"/>
+<text text-anchor="start" x="446.7" y="-571.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="500.76" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-542 401.66,-564 605.66,-564 605.66,-542 401.66,-542"/>
+<text text-anchor="start" x="471.19" y="-549.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="500.36" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-520 401.66,-542 605.66,-542 605.66,-520 401.66,-520"/>
+<text text-anchor="start" x="456.04" y="-527.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="515.52" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-498 401.66,-520 605.66,-520 605.66,-498 401.66,-498"/>
+<text text-anchor="start" x="448.65" y="-505.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="498.8" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-476 401.66,-498 605.66,-498 605.66,-476 401.66,-476"/>
+<text text-anchor="start" x="453.32" y="-483.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="518.24" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-454 401.66,-476 605.66,-476 605.66,-454 401.66,-454"/>
+<text text-anchor="start" x="465.36" y="-461.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="505.41" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="401.66,-432 401.66,-454 605.66,-454 605.66,-432 401.66,-432"/>
+<text text-anchor="start" x="455.26" y="-439.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="492.2" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-410 401.66,-432 605.66,-432 605.66,-410 401.66,-410"/>
+<text text-anchor="start" x="431.53" y="-417.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="540.02" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-388 401.66,-410 605.66,-410 605.66,-388 401.66,-388"/>
+<text text-anchor="start" x="422.59" y="-395.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="548.96" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-366 401.66,-388 605.66,-388 605.66,-366 401.66,-366"/>
+<text text-anchor="start" x="443.59" y="-373.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="527.96" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-344 401.66,-366 605.66,-366 605.66,-344 401.66,-344"/>
+<text text-anchor="start" x="442.03" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="529.52" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<text text-anchor="start" x="436.99" y="-329.4" font-family="Times,serif" font-size="14.00">last_watched_at: </text>
+<text text-anchor="start" x="534.57" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<polygon fill="none" stroke="black" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<text text-anchor="start" x="483.45" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="401.66,-278 401.66,-300 605.66,-300 605.66,-278 401.66,-278"/>
+<text text-anchor="start" x="404.52" y="-284.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M605.66,-619C679.38,-619 700.29,-619 769.26,-619"/>
+<polygon fill="black" stroke="black" points="769.32,-622.5 779.32,-619 769.32,-615.5 769.32,-622.5"/>
+<text text-anchor="middle" x="686.99" y="-623.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<polygon fill="none" stroke="black" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<text text-anchor="start" x="835.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="768.32,-132 768.32,-154 982.32,-154 982.32,-132 768.32,-132"/>
+<text text-anchor="start" x="836.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="854.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-110 768.32,-132 982.32,-132 982.32,-110 768.32,-110"/>
+<text text-anchor="start" x="817.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="872.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-88 768.32,-110 982.32,-110 982.32,-88 768.32,-88"/>
+<text text-anchor="start" x="800.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="890.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-66 768.32,-88 982.32,-88 982.32,-66 768.32,-66"/>
+<text text-anchor="start" x="807.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="882.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<polygon fill="none" stroke="black" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<text text-anchor="start" x="855.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="768.32,-22 768.32,-44 982.32,-44 982.32,-22 768.32,-22"/>
+<text text-anchor="start" x="789.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="768.32,0 768.32,-22 982.32,-22 982.32,0 768.32,0"/>
+<text text-anchor="start" x="771.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-99C1123.82,-99 1038.1,-267.06 1072.98,-404.2 1091.07,-475.3 1070.16,-718.65 1134.81,-741.31"/>
+<polygon fill="black" stroke="black" points="1134.54,-744.81 1144.98,-743 1135.69,-737.9 1134.54,-744.81"/>
+<text text-anchor="middle" x="1063.65" y="-409.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-121C1051.96,-121 1036.74,-358.61 1054.32,-426 1071.91,-493.43 1071.77,-719.38 1134.77,-741.29"/>
+<polygon fill="black" stroke="black" points="1134.54,-744.8 1144.98,-743 1135.7,-737.9 1134.54,-744.8"/>
+<text text-anchor="middle" x="1063.65" y="-564.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node10" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-674 0.5,-696 239.5,-696 239.5,-674 0.5,-674"/>
+<polygon fill="none" stroke="black" points="0.5,-674 0.5,-696 239.5,-696 239.5,-674 0.5,-674"/>
+<text text-anchor="start" x="56.25" y="-681.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-652 0.5,-674 239.5,-674 239.5,-652 0.5,-652"/>
+<text text-anchor="start" x="80.93" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-659.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<text text-anchor="start" x="56.04" y="-637.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-637.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="64.6" y="-615.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="66.55" y="-593.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="55.26" y="-571.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="99.79" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="3.37" y="-526.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="11.92" y="-504.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-641C307.76,-641 327.47,-641 391.45,-641"/>
+<polygon fill="black" stroke="black" points="391.66,-644.5 401.66,-641 391.66,-637.5 391.66,-644.5"/>
+<text text-anchor="middle" x="320.33" y="-645.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/6.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/6.svg
@@ -1,0 +1,430 @@
+<svg width="1419px" height="1418px"
+ viewBox="0.00 0.00 1418.98 1418.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1382)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1382 1382.98,-1382 1382.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1144.98,-754 1144.98,-776 1346.98,-776 1346.98,-754 1144.98,-754"/>
+<polygon fill="none" stroke="black" points="1144.98,-754 1144.98,-776 1346.98,-776 1346.98,-754 1144.98,-754"/>
+<text text-anchor="start" x="1228.48" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1144.98,-732 1144.98,-754 1346.98,-754 1346.98,-732 1144.98,-732"/>
+<text text-anchor="start" x="1206.91" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1225.19" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-710 1144.98,-732 1346.98,-732 1346.98,-710 1144.98,-710"/>
+<text text-anchor="start" x="1213.52" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1242.68" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-688 1144.98,-710 1346.98,-710 1346.98,-688 1144.98,-688"/>
+<text text-anchor="start" x="1188.24" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1267.96" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-666 1144.98,-688 1346.98,-688 1346.98,-666 1144.98,-666"/>
+<text text-anchor="start" x="1190.58" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1241.52" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-644 1144.98,-666 1346.98,-666 1346.98,-644 1144.98,-644"/>
+<text text-anchor="start" x="1189.02" y="-651.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1243.08" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-622 1144.98,-644 1346.98,-644 1346.98,-622 1144.98,-622"/>
+<text text-anchor="start" x="1173.86" y="-629.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1282.34" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-600 1144.98,-622 1346.98,-622 1346.98,-600 1144.98,-600"/>
+<text text-anchor="start" x="1164.92" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1291.28" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-578 1144.98,-600 1346.98,-600 1346.98,-578 1144.98,-578"/>
+<text text-anchor="start" x="1185.92" y="-585.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="1270.28" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-556 1144.98,-578 1346.98,-578 1346.98,-556 1144.98,-556"/>
+<text text-anchor="start" x="1184.35" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="1271.85" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-534 1144.98,-556 1346.98,-556 1346.98,-534 1144.98,-534"/>
+<text text-anchor="start" x="1198.36" y="-541.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1257.84" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-512 1144.98,-534 1346.98,-534 1346.98,-512 1144.98,-512"/>
+<text text-anchor="start" x="1195.64" y="-519.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1260.56" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-490 1144.98,-512 1346.98,-512 1346.98,-490 1144.98,-490"/>
+<text text-anchor="start" x="1207.68" y="-497.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="1247.73" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1144.98,-468 1144.98,-490 1346.98,-490 1346.98,-468 1144.98,-468"/>
+<text text-anchor="start" x="1190.59" y="-475.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1265.61" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-446 1144.98,-468 1346.98,-468 1346.98,-446 1144.98,-446"/>
+<text text-anchor="start" x="1203.02" y="-453.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1253.18" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-424 1144.98,-446 1346.98,-446 1346.98,-424 1144.98,-424"/>
+<text text-anchor="start" x="1201.47" y="-431.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1254.73" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-402 1144.98,-424 1346.98,-424 1346.98,-402 1144.98,-402"/>
+<text text-anchor="start" x="1190.58" y="-409.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1241.52" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-380 1144.98,-402 1346.98,-402 1346.98,-380 1144.98,-380"/>
+<text text-anchor="start" x="1206.14" y="-387.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1250.06" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-358 1144.98,-380 1346.98,-380 1346.98,-358 1144.98,-358"/>
+<text text-anchor="start" x="1177.36" y="-365.4" font-family="Times,serif" font-size="14.00">seasons_updated: </text>
+<text text-anchor="start" x="1278.84" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-336 1144.98,-358 1346.98,-358 1346.98,-336 1144.98,-336"/>
+<text text-anchor="start" x="1147.82" y="-343.4" font-family="Times,serif" font-size="14.00">watched_episodes_updated: </text>
+<text text-anchor="start" x="1308.38" y="-343.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1144.98,-314 1144.98,-336 1346.98,-336 1346.98,-314 1144.98,-314"/>
+<polygon fill="none" stroke="black" points="1144.98,-314 1144.98,-336 1346.98,-336 1346.98,-314 1144.98,-314"/>
+<text text-anchor="start" x="1225.77" y="-321.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1144.98,-292 1144.98,-314 1346.98,-314 1346.98,-292 1144.98,-292"/>
+<text text-anchor="start" x="1184.16" y="-298.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1144.98,-270 1144.98,-292 1346.98,-292 1346.98,-270 1144.98,-270"/>
+<text text-anchor="start" x="1182.6" y="-276.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="782.32,-1324 782.32,-1346 969.32,-1346 969.32,-1324 782.32,-1324"/>
+<polygon fill="none" stroke="black" points="782.32,-1324 782.32,-1346 969.32,-1346 969.32,-1324 782.32,-1324"/>
+<text text-anchor="start" x="831.5" y="-1331.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="782.32,-1302 782.32,-1324 969.32,-1324 969.32,-1302 782.32,-1302"/>
+<text text-anchor="start" x="836.75" y="-1309.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1309.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<text text-anchor="start" x="818.47" y="-1287.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1258 782.32,-1280 969.32,-1280 969.32,-1258 782.32,-1258"/>
+<text text-anchor="start" x="828.98" y="-1265.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1236 782.32,-1258 969.32,-1258 969.32,-1236 782.32,-1236"/>
+<text text-anchor="start" x="817.32" y="-1243.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="874.46" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<polygon fill="none" stroke="black" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<text text-anchor="start" x="855.61" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="782.32,-1192 782.32,-1214 969.32,-1214 969.32,-1192 782.32,-1192"/>
+<text text-anchor="start" x="785.22" y="-1198.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M970.32,-1291C1000.15,-1291 1098.67,-813.36 1137.62,-749.93"/>
+<polygon fill="black" stroke="black" points="1140.1,-752.4 1144.98,-743 1135.3,-747.3 1140.1,-752.4"/>
+<text text-anchor="middle" x="1063.65" y="-1021.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="784.32,-1134 784.32,-1156 967.32,-1156 967.32,-1134 784.32,-1134"/>
+<polygon fill="none" stroke="black" points="784.32,-1134 784.32,-1156 967.32,-1156 967.32,-1134 784.32,-1134"/>
+<text text-anchor="start" x="833.44" y="-1141.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="784.32,-1112 784.32,-1134 967.32,-1134 967.32,-1112 784.32,-1112"/>
+<text text-anchor="start" x="836.75" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1119.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<text text-anchor="start" x="818.47" y="-1097.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1068 784.32,-1090 967.32,-1090 967.32,-1068 784.32,-1068"/>
+<text text-anchor="start" x="828.98" y="-1075.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1046 784.32,-1068 967.32,-1068 967.32,-1046 784.32,-1046"/>
+<text text-anchor="start" x="810.71" y="-1053.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="881.06" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<polygon fill="none" stroke="black" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<text text-anchor="start" x="855.61" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="784.32,-1002 784.32,-1024 967.32,-1024 967.32,-1002 784.32,-1002"/>
+<text text-anchor="start" x="787.17" y="-1008.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M968.32,-1101C1053.57,-1101 1056.19,-770.42 1134.98,-744.6"/>
+<polygon fill="black" stroke="black" points="1135.66,-748.03 1144.98,-743 1134.56,-741.12 1135.66,-748.03"/>
+<text text-anchor="middle" x="1063.65" y="-926.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="62.5,-864 62.5,-886 176.5,-886 176.5,-864 62.5,-864"/>
+<polygon fill="none" stroke="black" points="62.5,-864 62.5,-886 176.5,-886 176.5,-864 62.5,-864"/>
+<text text-anchor="start" x="105.12" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="62.5,-842 62.5,-864 176.5,-864 176.5,-842 62.5,-842"/>
+<text text-anchor="start" x="80.43" y="-849.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-849.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="62.5,-820 62.5,-842 176.5,-842 176.5,-820 62.5,-820"/>
+<text text-anchor="start" x="71.1" y="-827.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.13" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-798 62.5,-820 176.5,-820 176.5,-798 62.5,-798"/>
+<text text-anchor="start" x="82.76" y="-805.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.47" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-776 62.5,-798 176.5,-798 176.5,-776 62.5,-776"/>
+<text text-anchor="start" x="65.26" y="-783.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="137.97" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-754 62.5,-776 176.5,-776 176.5,-754 62.5,-754"/>
+<text text-anchor="start" x="75.37" y="-761.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="127.86" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-732 62.5,-754 176.5,-754 176.5,-732 62.5,-732"/>
+<text text-anchor="start" x="82.37" y="-739.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="120.87" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-710 62.5,-732 176.5,-732 176.5,-710 62.5,-710"/>
+<text text-anchor="start" x="69.55" y="-717.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="133.69" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="781.32,-944 781.32,-966 970.32,-966 970.32,-944 781.32,-944"/>
+<polygon fill="none" stroke="black" points="781.32,-944 781.32,-966 970.32,-966 970.32,-944 781.32,-944"/>
+<text text-anchor="start" x="830.34" y="-951.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="781.32,-922 781.32,-944 970.32,-944 970.32,-922 781.32,-922"/>
+<text text-anchor="start" x="836.75" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-929.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<text text-anchor="start" x="818.47" y="-907.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-878 781.32,-900 970.32,-900 970.32,-878 781.32,-878"/>
+<text text-anchor="start" x="817.7" y="-885.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="898.18" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<polygon fill="none" stroke="black" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<text text-anchor="start" x="855.61" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="781.32,-834 781.32,-856 970.32,-856 970.32,-834 781.32,-834"/>
+<text text-anchor="start" x="784.07" y="-840.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M971.32,-911C1075.14,-911 1040.16,-753.97 1134.77,-743.54"/>
+<polygon fill="black" stroke="black" points="1135.18,-747.03 1144.98,-743 1134.81,-740.04 1135.18,-747.03"/>
+<text text-anchor="middle" x="1063.65" y="-836.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="778.32,-776 778.32,-798 973.32,-798 973.32,-776 778.32,-776"/>
+<polygon fill="none" stroke="black" points="778.32,-776 778.32,-798 973.32,-798 973.32,-776 778.32,-776"/>
+<text text-anchor="start" x="827.22" y="-783.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="778.32,-754 778.32,-776 973.32,-776 973.32,-754 778.32,-754"/>
+<text text-anchor="start" x="836.75" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-761.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<text text-anchor="start" x="818.47" y="-739.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<text text-anchor="start" x="811.09" y="-717.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="904.79" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="778.32,-688 778.32,-710 973.32,-710 973.32,-688 778.32,-688"/>
+<polygon fill="none" stroke="black" points="778.32,-688 778.32,-710 973.32,-710 973.32,-688 778.32,-688"/>
+<text text-anchor="start" x="855.61" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="778.32,-666 778.32,-688 973.32,-688 973.32,-666 778.32,-666"/>
+<text text-anchor="start" x="780.95" y="-672.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M974.32,-743C1046.61,-743 1067.23,-743 1134.68,-743"/>
+<polygon fill="black" stroke="black" points="1134.98,-746.5 1144.98,-743 1134.98,-739.5 1134.98,-746.5"/>
+<text text-anchor="middle" x="1063.65" y="-748.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="780.32,-608 780.32,-630 971.32,-630 971.32,-608 780.32,-608"/>
+<polygon fill="none" stroke="black" points="780.32,-608 780.32,-630 971.32,-630 971.32,-608 780.32,-608"/>
+<text text-anchor="start" x="854.44" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="780.32,-586 780.32,-608 971.32,-608 971.32,-586 780.32,-586"/>
+<text text-anchor="start" x="836.75" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-593.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<text text-anchor="start" x="818.47" y="-571.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-542 780.32,-564 971.32,-564 971.32,-542 780.32,-542"/>
+<text text-anchor="start" x="820.42" y="-549.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="871.36" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-520 780.32,-542 971.32,-542 971.32,-520 780.32,-520"/>
+<text text-anchor="start" x="818.86" y="-527.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="872.92" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-498 780.32,-520 971.32,-520 971.32,-498 780.32,-498"/>
+<text text-anchor="start" x="843.36" y="-505.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="872.52" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-476 780.32,-498 971.32,-498 971.32,-476 780.32,-476"/>
+<text text-anchor="start" x="828.2" y="-483.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="887.68" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-454 780.32,-476 971.32,-476 971.32,-454 780.32,-454"/>
+<text text-anchor="start" x="820.81" y="-461.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="870.97" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-432 780.32,-454 971.32,-454 971.32,-432 780.32,-432"/>
+<text text-anchor="start" x="816.53" y="-439.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="875.24" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-410 780.32,-432 971.32,-432 971.32,-410 780.32,-410"/>
+<text text-anchor="start" x="818.09" y="-417.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="873.68" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-388 780.32,-410 971.32,-410 971.32,-388 780.32,-388"/>
+<text text-anchor="start" x="837.52" y="-395.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="877.57" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="780.32,-366 780.32,-388 971.32,-388 971.32,-366 780.32,-366"/>
+<text text-anchor="start" x="831.31" y="-373.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="884.57" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-344 780.32,-366 971.32,-366 971.32,-344 780.32,-344"/>
+<text text-anchor="start" x="827.42" y="-351.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="864.36" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-322 780.32,-344 971.32,-344 971.32,-322 780.32,-322"/>
+<text text-anchor="start" x="803.7" y="-329.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="912.18" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-300 780.32,-322 971.32,-322 971.32,-300 780.32,-300"/>
+<text text-anchor="start" x="794.76" y="-307.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="921.12" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-278 780.32,-300 971.32,-300 971.32,-278 780.32,-278"/>
+<text text-anchor="start" x="815.76" y="-285.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="900.12" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-256 780.32,-278 971.32,-278 971.32,-256 780.32,-256"/>
+<text text-anchor="start" x="814.19" y="-263.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="901.68" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<polygon fill="none" stroke="black" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<text text-anchor="start" x="855.61" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="780.32,-212 780.32,-234 971.32,-234 971.32,-212 780.32,-212"/>
+<text text-anchor="start" x="783.28" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M972.32,-575C1022.61,-575 1083.55,-723.27 1135.13,-741.23"/>
+<polygon fill="black" stroke="black" points="1134.52,-744.67 1144.98,-743 1135.76,-737.78 1134.52,-744.67"/>
+<text text-anchor="middle" x="1063.65" y="-683.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="401.66,-630 401.66,-652 605.66,-652 605.66,-630 401.66,-630"/>
+<polygon fill="none" stroke="black" points="401.66,-630 401.66,-652 605.66,-652 605.66,-630 401.66,-630"/>
+<text text-anchor="start" x="479.56" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="401.66,-608 401.66,-630 605.66,-630 605.66,-608 401.66,-608"/>
+<text text-anchor="start" x="464.59" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="482.87" y="-615.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<text text-anchor="start" x="442.43" y="-593.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="505.03" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-564 401.66,-586 605.66,-586 605.66,-564 401.66,-564"/>
+<text text-anchor="start" x="448.26" y="-571.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="499.2" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-542 401.66,-564 605.66,-564 605.66,-542 401.66,-542"/>
+<text text-anchor="start" x="446.7" y="-549.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="500.76" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-520 401.66,-542 605.66,-542 605.66,-520 401.66,-520"/>
+<text text-anchor="start" x="471.19" y="-527.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="500.36" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-498 401.66,-520 605.66,-520 605.66,-498 401.66,-498"/>
+<text text-anchor="start" x="456.04" y="-505.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="515.52" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-476 401.66,-498 605.66,-498 605.66,-476 401.66,-476"/>
+<text text-anchor="start" x="448.65" y="-483.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="498.8" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-454 401.66,-476 605.66,-476 605.66,-454 401.66,-454"/>
+<text text-anchor="start" x="453.32" y="-461.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="518.24" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-432 401.66,-454 605.66,-454 605.66,-432 401.66,-432"/>
+<text text-anchor="start" x="465.36" y="-439.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="505.41" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="401.66,-410 401.66,-432 605.66,-432 605.66,-410 401.66,-410"/>
+<text text-anchor="start" x="455.26" y="-417.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="492.2" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-388 401.66,-410 605.66,-410 605.66,-388 401.66,-388"/>
+<text text-anchor="start" x="431.53" y="-395.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="540.02" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-366 401.66,-388 605.66,-388 605.66,-366 401.66,-366"/>
+<text text-anchor="start" x="422.6" y="-373.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="548.96" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-344 401.66,-366 605.66,-366 605.66,-344 401.66,-344"/>
+<text text-anchor="start" x="443.6" y="-351.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="527.96" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<text text-anchor="start" x="442.03" y="-329.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="529.52" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<text text-anchor="start" x="436.99" y="-307.4" font-family="Times,serif" font-size="14.00">last_watched_at: </text>
+<text text-anchor="start" x="534.57" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="401.66,-278 401.66,-300 605.66,-300 605.66,-278 401.66,-278"/>
+<polygon fill="none" stroke="black" points="401.66,-278 401.66,-300 605.66,-300 605.66,-278 401.66,-278"/>
+<text text-anchor="start" x="483.45" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="401.66,-256 401.66,-278 605.66,-278 605.66,-256 401.66,-256"/>
+<text text-anchor="start" x="404.52" y="-262.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M605.66,-597C679.38,-597 700.29,-597 769.26,-597"/>
+<polygon fill="black" stroke="black" points="769.32,-600.5 779.32,-597 769.32,-593.5 769.32,-600.5"/>
+<text text-anchor="middle" x="686.99" y="-601.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<polygon fill="none" stroke="black" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<text text-anchor="start" x="835.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="768.32,-132 768.32,-154 982.32,-154 982.32,-132 768.32,-132"/>
+<text text-anchor="start" x="836.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="854.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-110 768.32,-132 982.32,-132 982.32,-110 768.32,-110"/>
+<text text-anchor="start" x="817.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="872.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-88 768.32,-110 982.32,-110 982.32,-88 768.32,-88"/>
+<text text-anchor="start" x="800.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="890.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-66 768.32,-88 982.32,-88 982.32,-66 768.32,-66"/>
+<text text-anchor="start" x="807.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="882.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<polygon fill="none" stroke="black" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<text text-anchor="start" x="855.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="768.32,-22 768.32,-44 982.32,-44 982.32,-22 768.32,-22"/>
+<text text-anchor="start" x="789.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="768.32,0 768.32,-22 982.32,-22 982.32,0 768.32,0"/>
+<text text-anchor="start" x="771.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-99C1119.14,-99 1039,-260.66 1072.98,-393.2 1091.81,-466.62 1067.96,-718.88 1134.92,-741.39"/>
+<polygon fill="black" stroke="black" points="1134.55,-744.88 1144.98,-743 1135.66,-737.96 1134.55,-744.88"/>
+<text text-anchor="middle" x="1063.65" y="-398.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-121C1049.59,-121 1037.36,-349.91 1054.32,-415 1072.5,-484.75 1069.69,-719.51 1134.86,-741.37"/>
+<polygon fill="black" stroke="black" points="1134.55,-744.86 1144.98,-743 1135.67,-737.95 1134.55,-744.86"/>
+<text text-anchor="middle" x="1063.65" y="-567.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node10" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-652 0.5,-674 239.5,-674 239.5,-652 0.5,-652"/>
+<polygon fill="none" stroke="black" points="0.5,-652 0.5,-674 239.5,-674 239.5,-652 0.5,-652"/>
+<text text-anchor="start" x="56.25" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<text text-anchor="start" x="80.93" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-637.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="56.04" y="-615.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="64.6" y="-593.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="66.55" y="-571.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="55.26" y="-549.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="99.79" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="3.37" y="-504.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<text text-anchor="start" x="11.92" y="-482.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-619C307.76,-619 327.47,-619 391.45,-619"/>
+<polygon fill="black" stroke="black" points="391.66,-622.5 401.66,-619 391.66,-615.5 391.66,-622.5"/>
+<text text-anchor="middle" x="320.33" y="-623.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/7.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/7.svg
@@ -1,0 +1,433 @@
+<svg width="1419px" height="1418px"
+ viewBox="0.00 0.00 1418.98 1418.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1382)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1382 1382.98,-1382 1382.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1144.98,-754 1144.98,-776 1346.98,-776 1346.98,-754 1144.98,-754"/>
+<polygon fill="none" stroke="black" points="1144.98,-754 1144.98,-776 1346.98,-776 1346.98,-754 1144.98,-754"/>
+<text text-anchor="start" x="1228.48" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1144.98,-732 1144.98,-754 1346.98,-754 1346.98,-732 1144.98,-732"/>
+<text text-anchor="start" x="1206.91" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1225.19" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-710 1144.98,-732 1346.98,-732 1346.98,-710 1144.98,-710"/>
+<text text-anchor="start" x="1213.52" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1242.68" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-688 1144.98,-710 1346.98,-710 1346.98,-688 1144.98,-688"/>
+<text text-anchor="start" x="1188.24" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1267.96" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-666 1144.98,-688 1346.98,-688 1346.98,-666 1144.98,-666"/>
+<text text-anchor="start" x="1190.58" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1241.52" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-644 1144.98,-666 1346.98,-666 1346.98,-644 1144.98,-644"/>
+<text text-anchor="start" x="1189.02" y="-651.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1243.08" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-622 1144.98,-644 1346.98,-644 1346.98,-622 1144.98,-622"/>
+<text text-anchor="start" x="1173.86" y="-629.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1282.34" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-600 1144.98,-622 1346.98,-622 1346.98,-600 1144.98,-600"/>
+<text text-anchor="start" x="1164.92" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1291.28" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-578 1144.98,-600 1346.98,-600 1346.98,-578 1144.98,-578"/>
+<text text-anchor="start" x="1185.92" y="-585.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="1270.28" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-556 1144.98,-578 1346.98,-578 1346.98,-556 1144.98,-556"/>
+<text text-anchor="start" x="1184.35" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="1271.85" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-534 1144.98,-556 1346.98,-556 1346.98,-534 1144.98,-534"/>
+<text text-anchor="start" x="1198.36" y="-541.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1257.84" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-512 1144.98,-534 1346.98,-534 1346.98,-512 1144.98,-512"/>
+<text text-anchor="start" x="1195.64" y="-519.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1260.56" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-490 1144.98,-512 1346.98,-512 1346.98,-490 1144.98,-490"/>
+<text text-anchor="start" x="1207.68" y="-497.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="1247.73" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1144.98,-468 1144.98,-490 1346.98,-490 1346.98,-468 1144.98,-468"/>
+<text text-anchor="start" x="1190.59" y="-475.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1265.61" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-446 1144.98,-468 1346.98,-468 1346.98,-446 1144.98,-446"/>
+<text text-anchor="start" x="1195.64" y="-453.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1260.56" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-424 1144.98,-446 1346.98,-446 1346.98,-424 1144.98,-424"/>
+<text text-anchor="start" x="1203.02" y="-431.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1253.18" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-402 1144.98,-424 1346.98,-424 1346.98,-402 1144.98,-402"/>
+<text text-anchor="start" x="1201.47" y="-409.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1254.73" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-380 1144.98,-402 1346.98,-402 1346.98,-380 1144.98,-380"/>
+<text text-anchor="start" x="1190.58" y="-387.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1241.52" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-358 1144.98,-380 1346.98,-380 1346.98,-358 1144.98,-358"/>
+<text text-anchor="start" x="1206.14" y="-365.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1250.06" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-336 1144.98,-358 1346.98,-358 1346.98,-336 1144.98,-336"/>
+<text text-anchor="start" x="1177.36" y="-343.4" font-family="Times,serif" font-size="14.00">seasons_updated: </text>
+<text text-anchor="start" x="1278.84" y="-343.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-314 1144.98,-336 1346.98,-336 1346.98,-314 1144.98,-314"/>
+<text text-anchor="start" x="1147.82" y="-321.4" font-family="Times,serif" font-size="14.00">watched_episodes_updated: </text>
+<text text-anchor="start" x="1308.38" y="-321.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1144.98,-292 1144.98,-314 1346.98,-314 1346.98,-292 1144.98,-292"/>
+<polygon fill="none" stroke="black" points="1144.98,-292 1144.98,-314 1346.98,-314 1346.98,-292 1144.98,-292"/>
+<text text-anchor="start" x="1225.77" y="-299.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1144.98,-270 1144.98,-292 1346.98,-292 1346.98,-270 1144.98,-270"/>
+<text text-anchor="start" x="1184.16" y="-276.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1144.98,-248 1144.98,-270 1346.98,-270 1346.98,-248 1144.98,-248"/>
+<text text-anchor="start" x="1182.6" y="-254.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="782.32,-1324 782.32,-1346 969.32,-1346 969.32,-1324 782.32,-1324"/>
+<polygon fill="none" stroke="black" points="782.32,-1324 782.32,-1346 969.32,-1346 969.32,-1324 782.32,-1324"/>
+<text text-anchor="start" x="831.5" y="-1331.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="782.32,-1302 782.32,-1324 969.32,-1324 969.32,-1302 782.32,-1302"/>
+<text text-anchor="start" x="836.75" y="-1309.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1309.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<text text-anchor="start" x="818.47" y="-1287.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1258 782.32,-1280 969.32,-1280 969.32,-1258 782.32,-1258"/>
+<text text-anchor="start" x="828.98" y="-1265.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1236 782.32,-1258 969.32,-1258 969.32,-1236 782.32,-1236"/>
+<text text-anchor="start" x="817.32" y="-1243.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="874.46" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<polygon fill="none" stroke="black" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<text text-anchor="start" x="855.61" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="782.32,-1192 782.32,-1214 969.32,-1214 969.32,-1192 782.32,-1192"/>
+<text text-anchor="start" x="785.22" y="-1198.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M970.32,-1291C1000.15,-1291 1098.67,-813.36 1137.62,-749.93"/>
+<polygon fill="black" stroke="black" points="1140.1,-752.4 1144.98,-743 1135.3,-747.3 1140.1,-752.4"/>
+<text text-anchor="middle" x="1063.65" y="-1021.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="784.32,-1134 784.32,-1156 967.32,-1156 967.32,-1134 784.32,-1134"/>
+<polygon fill="none" stroke="black" points="784.32,-1134 784.32,-1156 967.32,-1156 967.32,-1134 784.32,-1134"/>
+<text text-anchor="start" x="833.44" y="-1141.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="784.32,-1112 784.32,-1134 967.32,-1134 967.32,-1112 784.32,-1112"/>
+<text text-anchor="start" x="836.75" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1119.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<text text-anchor="start" x="818.47" y="-1097.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1068 784.32,-1090 967.32,-1090 967.32,-1068 784.32,-1068"/>
+<text text-anchor="start" x="828.98" y="-1075.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1046 784.32,-1068 967.32,-1068 967.32,-1046 784.32,-1046"/>
+<text text-anchor="start" x="810.71" y="-1053.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="881.06" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<polygon fill="none" stroke="black" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<text text-anchor="start" x="855.61" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="784.32,-1002 784.32,-1024 967.32,-1024 967.32,-1002 784.32,-1002"/>
+<text text-anchor="start" x="787.17" y="-1008.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M968.32,-1101C1053.57,-1101 1056.19,-770.42 1134.98,-744.6"/>
+<polygon fill="black" stroke="black" points="1135.66,-748.03 1144.98,-743 1134.56,-741.12 1135.66,-748.03"/>
+<text text-anchor="middle" x="1063.65" y="-926.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="62.5,-864 62.5,-886 176.5,-886 176.5,-864 62.5,-864"/>
+<polygon fill="none" stroke="black" points="62.5,-864 62.5,-886 176.5,-886 176.5,-864 62.5,-864"/>
+<text text-anchor="start" x="105.12" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="62.5,-842 62.5,-864 176.5,-864 176.5,-842 62.5,-842"/>
+<text text-anchor="start" x="80.43" y="-849.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-849.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="62.5,-820 62.5,-842 176.5,-842 176.5,-820 62.5,-820"/>
+<text text-anchor="start" x="71.1" y="-827.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.13" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-798 62.5,-820 176.5,-820 176.5,-798 62.5,-798"/>
+<text text-anchor="start" x="82.76" y="-805.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.47" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-776 62.5,-798 176.5,-798 176.5,-776 62.5,-776"/>
+<text text-anchor="start" x="65.26" y="-783.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="137.97" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-754 62.5,-776 176.5,-776 176.5,-754 62.5,-754"/>
+<text text-anchor="start" x="75.37" y="-761.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="127.86" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-732 62.5,-754 176.5,-754 176.5,-732 62.5,-732"/>
+<text text-anchor="start" x="82.37" y="-739.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="120.87" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-710 62.5,-732 176.5,-732 176.5,-710 62.5,-710"/>
+<text text-anchor="start" x="69.55" y="-717.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="133.69" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="781.32,-944 781.32,-966 970.32,-966 970.32,-944 781.32,-944"/>
+<polygon fill="none" stroke="black" points="781.32,-944 781.32,-966 970.32,-966 970.32,-944 781.32,-944"/>
+<text text-anchor="start" x="830.34" y="-951.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="781.32,-922 781.32,-944 970.32,-944 970.32,-922 781.32,-922"/>
+<text text-anchor="start" x="836.75" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-929.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<text text-anchor="start" x="818.47" y="-907.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-878 781.32,-900 970.32,-900 970.32,-878 781.32,-878"/>
+<text text-anchor="start" x="817.7" y="-885.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="898.18" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<polygon fill="none" stroke="black" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<text text-anchor="start" x="855.61" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="781.32,-834 781.32,-856 970.32,-856 970.32,-834 781.32,-834"/>
+<text text-anchor="start" x="784.07" y="-840.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M971.32,-911C1075.14,-911 1040.16,-753.97 1134.77,-743.54"/>
+<polygon fill="black" stroke="black" points="1135.18,-747.03 1144.98,-743 1134.81,-740.04 1135.18,-747.03"/>
+<text text-anchor="middle" x="1063.65" y="-836.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="778.32,-776 778.32,-798 973.32,-798 973.32,-776 778.32,-776"/>
+<polygon fill="none" stroke="black" points="778.32,-776 778.32,-798 973.32,-798 973.32,-776 778.32,-776"/>
+<text text-anchor="start" x="827.22" y="-783.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="778.32,-754 778.32,-776 973.32,-776 973.32,-754 778.32,-754"/>
+<text text-anchor="start" x="836.75" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-761.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<text text-anchor="start" x="818.47" y="-739.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<text text-anchor="start" x="811.09" y="-717.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="904.79" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="778.32,-688 778.32,-710 973.32,-710 973.32,-688 778.32,-688"/>
+<polygon fill="none" stroke="black" points="778.32,-688 778.32,-710 973.32,-710 973.32,-688 778.32,-688"/>
+<text text-anchor="start" x="855.61" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="778.32,-666 778.32,-688 973.32,-688 973.32,-666 778.32,-666"/>
+<text text-anchor="start" x="780.95" y="-672.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M974.32,-743C1046.61,-743 1067.23,-743 1134.68,-743"/>
+<polygon fill="black" stroke="black" points="1134.98,-746.5 1144.98,-743 1134.98,-739.5 1134.98,-746.5"/>
+<text text-anchor="middle" x="1063.65" y="-748.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="780.32,-608 780.32,-630 971.32,-630 971.32,-608 780.32,-608"/>
+<polygon fill="none" stroke="black" points="780.32,-608 780.32,-630 971.32,-630 971.32,-608 780.32,-608"/>
+<text text-anchor="start" x="854.44" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="780.32,-586 780.32,-608 971.32,-608 971.32,-586 780.32,-586"/>
+<text text-anchor="start" x="836.75" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-593.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<text text-anchor="start" x="818.47" y="-571.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-542 780.32,-564 971.32,-564 971.32,-542 780.32,-542"/>
+<text text-anchor="start" x="820.42" y="-549.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="871.36" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-520 780.32,-542 971.32,-542 971.32,-520 780.32,-520"/>
+<text text-anchor="start" x="818.86" y="-527.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="872.92" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-498 780.32,-520 971.32,-520 971.32,-498 780.32,-498"/>
+<text text-anchor="start" x="843.36" y="-505.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="872.52" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-476 780.32,-498 971.32,-498 971.32,-476 780.32,-476"/>
+<text text-anchor="start" x="828.2" y="-483.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="887.68" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-454 780.32,-476 971.32,-476 971.32,-454 780.32,-454"/>
+<text text-anchor="start" x="820.81" y="-461.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="870.97" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-432 780.32,-454 971.32,-454 971.32,-432 780.32,-432"/>
+<text text-anchor="start" x="816.53" y="-439.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="875.24" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-410 780.32,-432 971.32,-432 971.32,-410 780.32,-410"/>
+<text text-anchor="start" x="818.09" y="-417.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="873.68" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-388 780.32,-410 971.32,-410 971.32,-388 780.32,-388"/>
+<text text-anchor="start" x="837.52" y="-395.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="877.57" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="780.32,-366 780.32,-388 971.32,-388 971.32,-366 780.32,-366"/>
+<text text-anchor="start" x="831.31" y="-373.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="884.57" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-344 780.32,-366 971.32,-366 971.32,-344 780.32,-344"/>
+<text text-anchor="start" x="827.42" y="-351.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="864.36" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-322 780.32,-344 971.32,-344 971.32,-322 780.32,-322"/>
+<text text-anchor="start" x="803.7" y="-329.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="912.18" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-300 780.32,-322 971.32,-322 971.32,-300 780.32,-300"/>
+<text text-anchor="start" x="794.76" y="-307.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="921.12" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-278 780.32,-300 971.32,-300 971.32,-278 780.32,-278"/>
+<text text-anchor="start" x="815.76" y="-285.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="900.12" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-256 780.32,-278 971.32,-278 971.32,-256 780.32,-256"/>
+<text text-anchor="start" x="814.19" y="-263.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="901.68" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<polygon fill="none" stroke="black" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<text text-anchor="start" x="855.61" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="780.32,-212 780.32,-234 971.32,-234 971.32,-212 780.32,-212"/>
+<text text-anchor="start" x="783.28" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M972.32,-575C1022.61,-575 1083.55,-723.27 1135.13,-741.23"/>
+<polygon fill="black" stroke="black" points="1134.52,-744.67 1144.98,-743 1135.76,-737.78 1134.52,-744.67"/>
+<text text-anchor="middle" x="1063.65" y="-683.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="401.66,-630 401.66,-652 605.66,-652 605.66,-630 401.66,-630"/>
+<polygon fill="none" stroke="black" points="401.66,-630 401.66,-652 605.66,-652 605.66,-630 401.66,-630"/>
+<text text-anchor="start" x="479.56" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="401.66,-608 401.66,-630 605.66,-630 605.66,-608 401.66,-608"/>
+<text text-anchor="start" x="464.59" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="482.87" y="-615.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<text text-anchor="start" x="442.43" y="-593.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="505.03" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-564 401.66,-586 605.66,-586 605.66,-564 401.66,-564"/>
+<text text-anchor="start" x="448.26" y="-571.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="499.2" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-542 401.66,-564 605.66,-564 605.66,-542 401.66,-542"/>
+<text text-anchor="start" x="446.7" y="-549.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="500.76" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-520 401.66,-542 605.66,-542 605.66,-520 401.66,-520"/>
+<text text-anchor="start" x="471.19" y="-527.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="500.36" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-498 401.66,-520 605.66,-520 605.66,-498 401.66,-498"/>
+<text text-anchor="start" x="456.04" y="-505.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="515.52" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-476 401.66,-498 605.66,-498 605.66,-476 401.66,-476"/>
+<text text-anchor="start" x="448.65" y="-483.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="498.8" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-454 401.66,-476 605.66,-476 605.66,-454 401.66,-454"/>
+<text text-anchor="start" x="453.32" y="-461.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="518.24" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-432 401.66,-454 605.66,-454 605.66,-432 401.66,-432"/>
+<text text-anchor="start" x="465.36" y="-439.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="505.41" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="401.66,-410 401.66,-432 605.66,-432 605.66,-410 401.66,-410"/>
+<text text-anchor="start" x="455.26" y="-417.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="492.2" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-388 401.66,-410 605.66,-410 605.66,-388 401.66,-388"/>
+<text text-anchor="start" x="431.53" y="-395.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="540.02" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-366 401.66,-388 605.66,-388 605.66,-366 401.66,-366"/>
+<text text-anchor="start" x="422.6" y="-373.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="548.96" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-344 401.66,-366 605.66,-366 605.66,-344 401.66,-344"/>
+<text text-anchor="start" x="443.6" y="-351.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="527.96" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<text text-anchor="start" x="442.03" y="-329.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="529.52" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<text text-anchor="start" x="436.99" y="-307.4" font-family="Times,serif" font-size="14.00">last_watched_at: </text>
+<text text-anchor="start" x="534.57" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="401.66,-278 401.66,-300 605.66,-300 605.66,-278 401.66,-278"/>
+<polygon fill="none" stroke="black" points="401.66,-278 401.66,-300 605.66,-300 605.66,-278 401.66,-278"/>
+<text text-anchor="start" x="483.45" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="401.66,-256 401.66,-278 605.66,-278 605.66,-256 401.66,-256"/>
+<text text-anchor="start" x="404.52" y="-262.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M605.66,-597C679.38,-597 700.29,-597 769.26,-597"/>
+<polygon fill="black" stroke="black" points="769.32,-600.5 779.32,-597 769.32,-593.5 769.32,-600.5"/>
+<text text-anchor="middle" x="686.99" y="-601.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<polygon fill="none" stroke="black" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<text text-anchor="start" x="835.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="768.32,-132 768.32,-154 982.32,-154 982.32,-132 768.32,-132"/>
+<text text-anchor="start" x="836.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="854.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-110 768.32,-132 982.32,-132 982.32,-110 768.32,-110"/>
+<text text-anchor="start" x="817.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="872.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-88 768.32,-110 982.32,-110 982.32,-88 768.32,-88"/>
+<text text-anchor="start" x="800.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="890.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-66 768.32,-88 982.32,-88 982.32,-66 768.32,-66"/>
+<text text-anchor="start" x="807.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="882.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<polygon fill="none" stroke="black" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<text text-anchor="start" x="855.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="768.32,-22 768.32,-44 982.32,-44 982.32,-22 768.32,-22"/>
+<text text-anchor="start" x="789.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="768.32,0 768.32,-22 982.32,-22 982.32,0 768.32,0"/>
+<text text-anchor="start" x="771.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-99C1119.14,-99 1039,-260.66 1072.98,-393.2 1091.81,-466.62 1067.96,-718.88 1134.92,-741.39"/>
+<polygon fill="black" stroke="black" points="1134.55,-744.88 1144.98,-743 1135.66,-737.96 1134.55,-744.88"/>
+<text text-anchor="middle" x="1063.65" y="-398.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-121C1049.59,-121 1037.36,-349.91 1054.32,-415 1072.5,-484.75 1069.69,-719.51 1134.86,-741.37"/>
+<polygon fill="black" stroke="black" points="1134.55,-744.86 1144.98,-743 1135.67,-737.95 1134.55,-744.86"/>
+<text text-anchor="middle" x="1063.65" y="-567.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node10" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-652 0.5,-674 239.5,-674 239.5,-652 0.5,-652"/>
+<polygon fill="none" stroke="black" points="0.5,-652 0.5,-674 239.5,-674 239.5,-652 0.5,-652"/>
+<text text-anchor="start" x="56.25" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<text text-anchor="start" x="80.93" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-637.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="56.04" y="-615.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="64.6" y="-593.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="66.55" y="-571.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="55.26" y="-549.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="99.79" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="3.37" y="-504.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<text text-anchor="start" x="11.92" y="-482.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-619C307.76,-619 327.47,-619 391.45,-619"/>
+<polygon fill="black" stroke="black" points="391.66,-622.5 401.66,-619 391.66,-615.5 391.66,-622.5"/>
+<text text-anchor="middle" x="320.33" y="-623.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/8.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/8.svg
@@ -1,0 +1,433 @@
+<svg width="1431px" height="1374px"
+ viewBox="0.00 0.00 1430.98 1374.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1338)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1338 1394.98,-1338 1394.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1190.98,-710 1190.98,-732 1358.98,-732 1358.98,-710 1190.98,-710"/>
+<polygon fill="none" stroke="black" points="1190.98,-710 1190.98,-732 1358.98,-732 1358.98,-710 1190.98,-710"/>
+<text text-anchor="start" x="1257.48" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1190.98,-688 1190.98,-710 1358.98,-710 1358.98,-688 1190.98,-688"/>
+<text text-anchor="start" x="1235.91" y="-695.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1254.19" y="-695.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1190.98,-666 1190.98,-688 1358.98,-688 1358.98,-666 1190.98,-666"/>
+<text text-anchor="start" x="1242.52" y="-673.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1271.68" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1190.98,-644 1190.98,-666 1358.98,-666 1358.98,-644 1190.98,-644"/>
+<text text-anchor="start" x="1217.24" y="-651.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1296.96" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1190.98,-622 1190.98,-644 1358.98,-644 1358.98,-622 1190.98,-622"/>
+<text text-anchor="start" x="1219.58" y="-629.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1270.52" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1190.98,-600 1190.98,-622 1358.98,-622 1358.98,-600 1190.98,-600"/>
+<text text-anchor="start" x="1218.02" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1272.08" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1190.98,-578 1190.98,-600 1358.98,-600 1358.98,-578 1190.98,-578"/>
+<text text-anchor="start" x="1202.86" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1311.34" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1190.98,-556 1190.98,-578 1358.98,-578 1358.98,-556 1190.98,-556"/>
+<text text-anchor="start" x="1193.92" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1320.28" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1190.98,-534 1190.98,-556 1358.98,-556 1358.98,-534 1190.98,-534"/>
+<text text-anchor="start" x="1227.36" y="-541.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1286.84" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1190.98,-512 1190.98,-534 1358.98,-534 1358.98,-512 1190.98,-512"/>
+<text text-anchor="start" x="1224.64" y="-519.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1289.56" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1190.98,-490 1190.98,-512 1358.98,-512 1358.98,-490 1190.98,-490"/>
+<text text-anchor="start" x="1236.68" y="-497.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="1276.73" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1190.98,-468 1190.98,-490 1358.98,-490 1358.98,-468 1190.98,-468"/>
+<text text-anchor="start" x="1219.59" y="-475.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1294.61" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1190.98,-446 1190.98,-468 1358.98,-468 1358.98,-446 1190.98,-446"/>
+<text text-anchor="start" x="1224.64" y="-453.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1289.56" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1190.98,-424 1190.98,-446 1358.98,-446 1358.98,-424 1190.98,-424"/>
+<text text-anchor="start" x="1232.02" y="-431.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1282.18" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1190.98,-402 1190.98,-424 1358.98,-424 1358.98,-402 1190.98,-402"/>
+<text text-anchor="start" x="1230.47" y="-409.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1283.73" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1190.98,-380 1190.98,-402 1358.98,-402 1358.98,-380 1190.98,-380"/>
+<text text-anchor="start" x="1219.58" y="-387.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1270.52" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1190.98,-358 1190.98,-380 1358.98,-380 1358.98,-358 1190.98,-358"/>
+<text text-anchor="start" x="1235.14" y="-365.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1279.06" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1190.98,-336 1190.98,-358 1358.98,-358 1358.98,-336 1190.98,-336"/>
+<polygon fill="none" stroke="black" points="1190.98,-336 1190.98,-358 1358.98,-358 1358.98,-336 1190.98,-336"/>
+<text text-anchor="start" x="1254.77" y="-343.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1190.98,-314 1190.98,-336 1358.98,-336 1358.98,-314 1190.98,-314"/>
+<text text-anchor="start" x="1213.16" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1190.98,-292 1190.98,-314 1358.98,-314 1358.98,-292 1190.98,-292"/>
+<text text-anchor="start" x="1211.6" y="-298.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="828.32,-1280 828.32,-1302 1015.32,-1302 1015.32,-1280 828.32,-1280"/>
+<polygon fill="none" stroke="black" points="828.32,-1280 828.32,-1302 1015.32,-1302 1015.32,-1280 828.32,-1280"/>
+<text text-anchor="start" x="877.5" y="-1287.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="828.32,-1258 828.32,-1280 1015.32,-1280 1015.32,-1258 828.32,-1258"/>
+<text text-anchor="start" x="882.75" y="-1265.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="901.03" y="-1265.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="828.32,-1236 828.32,-1258 1015.32,-1258 1015.32,-1236 828.32,-1236"/>
+<text text-anchor="start" x="864.47" y="-1243.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="919.3" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="828.32,-1214 828.32,-1236 1015.32,-1236 1015.32,-1214 828.32,-1214"/>
+<text text-anchor="start" x="874.98" y="-1221.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="908.8" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="828.32,-1192 828.32,-1214 1015.32,-1214 1015.32,-1192 828.32,-1192"/>
+<text text-anchor="start" x="863.32" y="-1199.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="920.46" y="-1199.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="828.32,-1170 828.32,-1192 1015.32,-1192 1015.32,-1170 828.32,-1170"/>
+<polygon fill="none" stroke="black" points="828.32,-1170 828.32,-1192 1015.32,-1192 1015.32,-1170 828.32,-1170"/>
+<text text-anchor="start" x="901.61" y="-1177.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="828.32,-1148 828.32,-1170 1015.32,-1170 1015.32,-1148 828.32,-1148"/>
+<text text-anchor="start" x="831.22" y="-1154.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M1016.32,-1247C1046.15,-1247 1144.67,-769.36 1183.62,-705.93"/>
+<polygon fill="black" stroke="black" points="1186.1,-708.4 1190.98,-699 1181.3,-703.3 1186.1,-708.4"/>
+<text text-anchor="middle" x="1109.65" y="-977.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="830.32,-1090 830.32,-1112 1013.32,-1112 1013.32,-1090 830.32,-1090"/>
+<polygon fill="none" stroke="black" points="830.32,-1090 830.32,-1112 1013.32,-1112 1013.32,-1090 830.32,-1090"/>
+<text text-anchor="start" x="879.44" y="-1097.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="830.32,-1068 830.32,-1090 1013.32,-1090 1013.32,-1068 830.32,-1068"/>
+<text text-anchor="start" x="882.75" y="-1075.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="901.03" y="-1075.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="830.32,-1046 830.32,-1068 1013.32,-1068 1013.32,-1046 830.32,-1046"/>
+<text text-anchor="start" x="864.47" y="-1053.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="919.3" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="830.32,-1024 830.32,-1046 1013.32,-1046 1013.32,-1024 830.32,-1024"/>
+<text text-anchor="start" x="874.98" y="-1031.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="908.8" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="830.32,-1002 830.32,-1024 1013.32,-1024 1013.32,-1002 830.32,-1002"/>
+<text text-anchor="start" x="856.71" y="-1009.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="927.06" y="-1009.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="830.32,-980 830.32,-1002 1013.32,-1002 1013.32,-980 830.32,-980"/>
+<polygon fill="none" stroke="black" points="830.32,-980 830.32,-1002 1013.32,-1002 1013.32,-980 830.32,-980"/>
+<text text-anchor="start" x="901.61" y="-987.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="830.32,-958 830.32,-980 1013.32,-980 1013.32,-958 830.32,-958"/>
+<text text-anchor="start" x="833.17" y="-964.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M1014.32,-1057C1099.57,-1057 1102.19,-726.42 1180.98,-700.6"/>
+<polygon fill="black" stroke="black" points="1181.66,-704.03 1190.98,-699 1180.56,-697.12 1181.66,-704.03"/>
+<text text-anchor="middle" x="1109.65" y="-882.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="85.5,-820 85.5,-842 199.5,-842 199.5,-820 85.5,-820"/>
+<polygon fill="none" stroke="black" points="85.5,-820 85.5,-842 199.5,-842 199.5,-820 85.5,-820"/>
+<text text-anchor="start" x="128.12" y="-827.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="85.5,-798 85.5,-820 199.5,-820 199.5,-798 85.5,-798"/>
+<text text-anchor="start" x="103.43" y="-805.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="121.71" y="-805.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="85.5,-776 85.5,-798 199.5,-798 199.5,-776 85.5,-776"/>
+<text text-anchor="start" x="94.1" y="-783.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="155.13" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="85.5,-754 85.5,-776 199.5,-776 199.5,-754 85.5,-754"/>
+<text text-anchor="start" x="105.76" y="-761.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="143.47" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="85.5,-732 85.5,-754 199.5,-754 199.5,-732 85.5,-732"/>
+<text text-anchor="start" x="88.26" y="-739.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="160.97" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="85.5,-710 85.5,-732 199.5,-732 199.5,-710 85.5,-710"/>
+<text text-anchor="start" x="98.37" y="-717.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="150.86" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="85.5,-688 85.5,-710 199.5,-710 199.5,-688 85.5,-688"/>
+<text text-anchor="start" x="105.37" y="-695.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="143.87" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="85.5,-666 85.5,-688 199.5,-688 199.5,-666 85.5,-666"/>
+<text text-anchor="start" x="92.55" y="-673.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="156.69" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="827.32,-900 827.32,-922 1016.32,-922 1016.32,-900 827.32,-900"/>
+<polygon fill="none" stroke="black" points="827.32,-900 827.32,-922 1016.32,-922 1016.32,-900 827.32,-900"/>
+<text text-anchor="start" x="876.34" y="-907.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="827.32,-878 827.32,-900 1016.32,-900 1016.32,-878 827.32,-878"/>
+<text text-anchor="start" x="882.75" y="-885.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="901.03" y="-885.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="827.32,-856 827.32,-878 1016.32,-878 1016.32,-856 827.32,-856"/>
+<text text-anchor="start" x="864.47" y="-863.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="919.3" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="827.32,-834 827.32,-856 1016.32,-856 1016.32,-834 827.32,-834"/>
+<text text-anchor="start" x="863.7" y="-841.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="944.17" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="827.32,-812 827.32,-834 1016.32,-834 1016.32,-812 827.32,-812"/>
+<polygon fill="none" stroke="black" points="827.32,-812 827.32,-834 1016.32,-834 1016.32,-812 827.32,-812"/>
+<text text-anchor="start" x="901.61" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="827.32,-790 827.32,-812 1016.32,-812 1016.32,-790 827.32,-790"/>
+<text text-anchor="start" x="830.07" y="-796.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M1017.32,-867C1121.14,-867 1086.16,-709.97 1180.77,-699.54"/>
+<polygon fill="black" stroke="black" points="1181.18,-703.03 1190.98,-699 1180.81,-696.04 1181.18,-703.03"/>
+<text text-anchor="middle" x="1109.65" y="-792.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="824.32,-732 824.32,-754 1019.32,-754 1019.32,-732 824.32,-732"/>
+<polygon fill="none" stroke="black" points="824.32,-732 824.32,-754 1019.32,-754 1019.32,-732 824.32,-732"/>
+<text text-anchor="start" x="873.22" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="824.32,-710 824.32,-732 1019.32,-732 1019.32,-710 824.32,-710"/>
+<text text-anchor="start" x="882.75" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="901.03" y="-717.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="824.32,-688 824.32,-710 1019.32,-710 1019.32,-688 824.32,-688"/>
+<text text-anchor="start" x="864.47" y="-695.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="919.3" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="824.32,-666 824.32,-688 1019.32,-688 1019.32,-666 824.32,-666"/>
+<text text-anchor="start" x="857.09" y="-673.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="950.79" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="824.32,-644 824.32,-666 1019.32,-666 1019.32,-644 824.32,-644"/>
+<polygon fill="none" stroke="black" points="824.32,-644 824.32,-666 1019.32,-666 1019.32,-644 824.32,-644"/>
+<text text-anchor="start" x="901.61" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="824.32,-622 824.32,-644 1019.32,-644 1019.32,-622 824.32,-622"/>
+<text text-anchor="start" x="826.95" y="-628.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M1020.32,-699C1092.61,-699 1113.23,-699 1180.68,-699"/>
+<polygon fill="black" stroke="black" points="1180.98,-702.5 1190.98,-699 1180.98,-695.5 1180.98,-702.5"/>
+<text text-anchor="middle" x="1109.65" y="-704.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="826.32,-564 826.32,-586 1017.32,-586 1017.32,-564 826.32,-564"/>
+<polygon fill="none" stroke="black" points="826.32,-564 826.32,-586 1017.32,-586 1017.32,-564 826.32,-564"/>
+<text text-anchor="start" x="900.44" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="826.32,-542 826.32,-564 1017.32,-564 1017.32,-542 826.32,-542"/>
+<text text-anchor="start" x="882.75" y="-549.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="901.03" y="-549.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="826.32,-520 826.32,-542 1017.32,-542 1017.32,-520 826.32,-520"/>
+<text text-anchor="start" x="864.47" y="-527.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="919.3" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="826.32,-498 826.32,-520 1017.32,-520 1017.32,-498 826.32,-498"/>
+<text text-anchor="start" x="866.42" y="-505.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="917.36" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="826.32,-476 826.32,-498 1017.32,-498 1017.32,-476 826.32,-476"/>
+<text text-anchor="start" x="864.86" y="-483.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="918.92" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="826.32,-454 826.32,-476 1017.32,-476 1017.32,-454 826.32,-454"/>
+<text text-anchor="start" x="889.36" y="-461.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="918.52" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="826.32,-432 826.32,-454 1017.32,-454 1017.32,-432 826.32,-432"/>
+<text text-anchor="start" x="874.2" y="-439.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="933.68" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="826.32,-410 826.32,-432 1017.32,-432 1017.32,-410 826.32,-410"/>
+<text text-anchor="start" x="866.81" y="-417.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="916.97" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="826.32,-388 826.32,-410 1017.32,-410 1017.32,-388 826.32,-388"/>
+<text text-anchor="start" x="862.53" y="-395.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="921.24" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="826.32,-366 826.32,-388 1017.32,-388 1017.32,-366 826.32,-366"/>
+<text text-anchor="start" x="864.09" y="-373.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="919.68" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="826.32,-344 826.32,-366 1017.32,-366 1017.32,-344 826.32,-344"/>
+<text text-anchor="start" x="883.52" y="-351.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="923.57" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="826.32,-322 826.32,-344 1017.32,-344 1017.32,-322 826.32,-322"/>
+<text text-anchor="start" x="877.31" y="-329.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="930.57" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="826.32,-300 826.32,-322 1017.32,-322 1017.32,-300 826.32,-300"/>
+<text text-anchor="start" x="873.42" y="-307.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="910.36" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="826.32,-278 826.32,-300 1017.32,-300 1017.32,-278 826.32,-278"/>
+<text text-anchor="start" x="849.7" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="958.18" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="826.32,-256 826.32,-278 1017.32,-278 1017.32,-256 826.32,-256"/>
+<text text-anchor="start" x="840.76" y="-263.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="967.12" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="826.32,-234 826.32,-256 1017.32,-256 1017.32,-234 826.32,-234"/>
+<polygon fill="none" stroke="black" points="826.32,-234 826.32,-256 1017.32,-256 1017.32,-234 826.32,-234"/>
+<text text-anchor="start" x="901.61" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="826.32,-212 826.32,-234 1017.32,-234 1017.32,-212 826.32,-212"/>
+<text text-anchor="start" x="829.28" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M1018.32,-531C1068.61,-531 1129.55,-679.27 1181.13,-697.23"/>
+<polygon fill="black" stroke="black" points="1180.52,-700.67 1190.98,-699 1181.76,-693.78 1180.52,-700.67"/>
+<text text-anchor="middle" x="1109.65" y="-639.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="447.66,-586 447.66,-608 651.66,-608 651.66,-586 447.66,-586"/>
+<polygon fill="none" stroke="black" points="447.66,-586 447.66,-608 651.66,-608 651.66,-586 447.66,-586"/>
+<text text-anchor="start" x="525.56" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="447.66,-564 447.66,-586 651.66,-586 651.66,-564 447.66,-564"/>
+<text text-anchor="start" x="510.59" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="528.87" y="-571.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="447.66,-542 447.66,-564 651.66,-564 651.66,-542 447.66,-542"/>
+<text text-anchor="start" x="488.43" y="-549.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="551.03" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="447.66,-520 447.66,-542 651.66,-542 651.66,-520 447.66,-520"/>
+<text text-anchor="start" x="494.26" y="-527.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="545.2" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="447.66,-498 447.66,-520 651.66,-520 651.66,-498 447.66,-498"/>
+<text text-anchor="start" x="492.7" y="-505.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="546.76" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="447.66,-476 447.66,-498 651.66,-498 651.66,-476 447.66,-476"/>
+<text text-anchor="start" x="517.19" y="-483.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="546.36" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="447.66,-454 447.66,-476 651.66,-476 651.66,-454 447.66,-454"/>
+<text text-anchor="start" x="502.04" y="-461.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="561.52" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="447.66,-432 447.66,-454 651.66,-454 651.66,-432 447.66,-432"/>
+<text text-anchor="start" x="494.65" y="-439.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="544.8" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="447.66,-410 447.66,-432 651.66,-432 651.66,-410 447.66,-410"/>
+<text text-anchor="start" x="499.32" y="-417.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="564.24" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="447.66,-388 447.66,-410 651.66,-410 651.66,-388 447.66,-388"/>
+<text text-anchor="start" x="511.36" y="-395.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="551.41" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="447.66,-366 447.66,-388 651.66,-388 651.66,-366 447.66,-366"/>
+<text text-anchor="start" x="501.26" y="-373.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="538.2" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="447.66,-344 447.66,-366 651.66,-366 651.66,-344 447.66,-344"/>
+<text text-anchor="start" x="477.53" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="586.02" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="447.66,-322 447.66,-344 651.66,-344 651.66,-322 447.66,-322"/>
+<text text-anchor="start" x="468.59" y="-329.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="594.96" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="447.66,-300 447.66,-322 651.66,-322 651.66,-300 447.66,-300"/>
+<text text-anchor="start" x="482.99" y="-307.4" font-family="Times,serif" font-size="14.00">last_watched_at: </text>
+<text text-anchor="start" x="580.57" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="447.66,-278 447.66,-300 651.66,-300 651.66,-278 447.66,-278"/>
+<polygon fill="none" stroke="black" points="447.66,-278 447.66,-300 651.66,-300 651.66,-278 447.66,-278"/>
+<text text-anchor="start" x="529.45" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="447.66,-256 447.66,-278 651.66,-278 651.66,-256 447.66,-256"/>
+<text text-anchor="start" x="450.52" y="-262.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M651.66,-553C725.38,-553 746.29,-553 815.26,-553"/>
+<polygon fill="black" stroke="black" points="815.32,-556.5 825.32,-553 815.32,-549.5 815.32,-556.5"/>
+<text text-anchor="middle" x="732.99" y="-557.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="814.32,-154 814.32,-176 1028.32,-176 1028.32,-154 814.32,-154"/>
+<polygon fill="none" stroke="black" points="814.32,-154 814.32,-176 1028.32,-176 1028.32,-154 814.32,-154"/>
+<text text-anchor="start" x="881.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="814.32,-132 814.32,-154 1028.32,-154 1028.32,-132 814.32,-132"/>
+<text text-anchor="start" x="882.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="900.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="814.32,-110 814.32,-132 1028.32,-132 1028.32,-110 814.32,-110"/>
+<text text-anchor="start" x="863.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="918.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="814.32,-88 814.32,-110 1028.32,-110 1028.32,-88 814.32,-88"/>
+<text text-anchor="start" x="846.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="936.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="814.32,-66 814.32,-88 1028.32,-88 1028.32,-66 814.32,-66"/>
+<text text-anchor="start" x="853.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="928.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="814.32,-44 814.32,-66 1028.32,-66 1028.32,-44 814.32,-44"/>
+<polygon fill="none" stroke="black" points="814.32,-44 814.32,-66 1028.32,-66 1028.32,-44 814.32,-44"/>
+<text text-anchor="start" x="901.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="814.32,-22 814.32,-44 1028.32,-44 1028.32,-22 814.32,-22"/>
+<text text-anchor="start" x="835.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="814.32,0 814.32,-22 1028.32,-22 1028.32,0 814.32,0"/>
+<text text-anchor="start" x="817.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M1028.32,-99C1152.04,-99 1085.84,-243 1118.98,-362.2 1138.52,-432.48 1116.69,-674.75 1180.87,-697.31"/>
+<polygon fill="black" stroke="black" points="1180.54,-700.81 1190.98,-699 1181.69,-693.9 1180.54,-700.81"/>
+<text text-anchor="middle" x="1109.65" y="-367.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M1028.32,-121C1149.51,-121 1067.56,-267.32 1100.32,-384 1119.05,-450.71 1118.27,-675.5 1180.83,-697.3"/>
+<polygon fill="black" stroke="black" points="1180.54,-700.8 1190.98,-699 1181.7,-693.89 1180.54,-700.8"/>
+<text text-anchor="middle" x="1109.65" y="-521.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node10" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="23.5,-608 23.5,-630 262.5,-630 262.5,-608 23.5,-608"/>
+<polygon fill="none" stroke="black" points="23.5,-608 23.5,-630 262.5,-630 262.5,-608 23.5,-608"/>
+<text text-anchor="start" x="79.25" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="23.5,-586 23.5,-608 262.5,-608 262.5,-586 23.5,-586"/>
+<text text-anchor="start" x="103.93" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="122.21" y="-593.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="23.5,-564 23.5,-586 262.5,-586 262.5,-564 23.5,-564"/>
+<text text-anchor="start" x="79.04" y="-571.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="147.09" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="23.5,-542 23.5,-564 262.5,-564 262.5,-542 23.5,-542"/>
+<text text-anchor="start" x="87.6" y="-549.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="138.53" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="23.5,-520 23.5,-542 262.5,-542 262.5,-520 23.5,-520"/>
+<text text-anchor="start" x="89.55" y="-527.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="160.69" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="23.5,-498 23.5,-520 262.5,-520 262.5,-498 23.5,-498"/>
+<text text-anchor="start" x="78.26" y="-505.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="171.97" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="23.5,-476 23.5,-498 262.5,-498 262.5,-476 23.5,-476"/>
+<polygon fill="none" stroke="black" points="23.5,-476 23.5,-498 262.5,-498 262.5,-476 23.5,-476"/>
+<text text-anchor="start" x="122.79" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="23.5,-454 23.5,-476 262.5,-476 262.5,-454 23.5,-454"/>
+<text text-anchor="start" x="26.37" y="-460.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="23.5,-432 23.5,-454 262.5,-454 262.5,-432 23.5,-432"/>
+<text text-anchor="start" x="34.92" y="-438.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M263.5,-575C341.83,-575 363.94,-575 437.44,-575"/>
+<polygon fill="black" stroke="black" points="437.66,-578.5 447.66,-575 437.66,-571.5 437.66,-578.5"/>
+<text text-anchor="middle" x="366.33" y="-579.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node11" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-1010 0.5,-1032 285.5,-1032 285.5,-1010 0.5,-1010"/>
+<polygon fill="none" stroke="black" points="0.5,-1010 0.5,-1032 285.5,-1032 285.5,-1010 0.5,-1010"/>
+<text text-anchor="start" x="106.84" y="-1017.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="0.5,-988 0.5,-1010 285.5,-1010 285.5,-988 0.5,-988"/>
+<text text-anchor="start" x="103.93" y="-995.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="122.21" y="-995.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-966 0.5,-988 285.5,-988 285.5,-966 0.5,-966"/>
+<text text-anchor="start" x="101.21" y="-973.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="149.03" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-944 0.5,-966 285.5,-966 285.5,-944 0.5,-944"/>
+<text text-anchor="start" x="84.48" y="-951.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="141.65" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-922 0.5,-944 285.5,-944 285.5,-922 0.5,-922"/>
+<text text-anchor="start" x="80.21" y="-929.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="145.92" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-900 0.5,-922 285.5,-922 285.5,-900 0.5,-900"/>
+<polygon fill="none" stroke="black" points="0.5,-900 0.5,-922 285.5,-922 285.5,-900 0.5,-900"/>
+<text text-anchor="start" x="122.79" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-878 0.5,-900 285.5,-900 285.5,-878 0.5,-878"/>
+<text text-anchor="start" x="3.03" y="-884.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_timestamp_entity_id</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviDatabase/9.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviDatabase/9.svg
@@ -1,0 +1,433 @@
+<svg width="1385px" height="1374px"
+ viewBox="0.00 0.00 1384.98 1374.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1338)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1338 1348.98,-1338 1348.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1144.98,-710 1144.98,-732 1312.98,-732 1312.98,-710 1144.98,-710"/>
+<polygon fill="none" stroke="black" points="1144.98,-710 1144.98,-732 1312.98,-732 1312.98,-710 1144.98,-710"/>
+<text text-anchor="start" x="1211.48" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1144.98,-688 1144.98,-710 1312.98,-710 1312.98,-688 1144.98,-688"/>
+<text text-anchor="start" x="1189.91" y="-695.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1208.19" y="-695.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-666 1144.98,-688 1312.98,-688 1312.98,-666 1144.98,-666"/>
+<text text-anchor="start" x="1196.52" y="-673.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1225.68" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-644 1144.98,-666 1312.98,-666 1312.98,-644 1144.98,-644"/>
+<text text-anchor="start" x="1171.24" y="-651.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1250.96" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-622 1144.98,-644 1312.98,-644 1312.98,-622 1144.98,-622"/>
+<text text-anchor="start" x="1173.58" y="-629.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1224.52" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-600 1144.98,-622 1312.98,-622 1312.98,-600 1144.98,-600"/>
+<text text-anchor="start" x="1172.02" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1226.08" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-578 1144.98,-600 1312.98,-600 1312.98,-578 1144.98,-578"/>
+<text text-anchor="start" x="1156.86" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1265.34" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-556 1144.98,-578 1312.98,-578 1312.98,-556 1144.98,-556"/>
+<text text-anchor="start" x="1147.92" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1274.28" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-534 1144.98,-556 1312.98,-556 1312.98,-534 1144.98,-534"/>
+<text text-anchor="start" x="1181.36" y="-541.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1240.84" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-512 1144.98,-534 1312.98,-534 1312.98,-512 1144.98,-512"/>
+<text text-anchor="start" x="1178.64" y="-519.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1243.56" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-490 1144.98,-512 1312.98,-512 1312.98,-490 1144.98,-490"/>
+<text text-anchor="start" x="1190.68" y="-497.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="1230.73" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1144.98,-468 1144.98,-490 1312.98,-490 1312.98,-468 1144.98,-468"/>
+<text text-anchor="start" x="1173.59" y="-475.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1248.61" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-446 1144.98,-468 1312.98,-468 1312.98,-446 1144.98,-446"/>
+<text text-anchor="start" x="1178.64" y="-453.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1243.56" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-424 1144.98,-446 1312.98,-446 1312.98,-424 1144.98,-424"/>
+<text text-anchor="start" x="1186.02" y="-431.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1236.18" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-402 1144.98,-424 1312.98,-424 1312.98,-402 1144.98,-402"/>
+<text text-anchor="start" x="1184.47" y="-409.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1237.73" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-380 1144.98,-402 1312.98,-402 1312.98,-380 1144.98,-380"/>
+<text text-anchor="start" x="1173.58" y="-387.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1224.52" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<text text-anchor="start" x="1189.14" y="-365.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1233.06" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<polygon fill="none" stroke="black" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<text text-anchor="start" x="1208.77" y="-343.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1144.98,-314 1144.98,-336 1312.98,-336 1312.98,-314 1144.98,-314"/>
+<text text-anchor="start" x="1167.16" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1144.98,-292 1144.98,-314 1312.98,-314 1312.98,-292 1144.98,-292"/>
+<text text-anchor="start" x="1165.6" y="-298.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<polygon fill="none" stroke="black" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<text text-anchor="start" x="831.5" y="-1287.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="782.32,-1258 782.32,-1280 969.32,-1280 969.32,-1258 782.32,-1258"/>
+<text text-anchor="start" x="836.75" y="-1265.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1265.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1236 782.32,-1258 969.32,-1258 969.32,-1236 782.32,-1236"/>
+<text text-anchor="start" x="818.47" y="-1243.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<text text-anchor="start" x="828.98" y="-1221.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1192 782.32,-1214 969.32,-1214 969.32,-1192 782.32,-1192"/>
+<text text-anchor="start" x="817.32" y="-1199.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="874.46" y="-1199.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="782.32,-1170 782.32,-1192 969.32,-1192 969.32,-1170 782.32,-1170"/>
+<polygon fill="none" stroke="black" points="782.32,-1170 782.32,-1192 969.32,-1192 969.32,-1170 782.32,-1170"/>
+<text text-anchor="start" x="855.61" y="-1177.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="782.32,-1148 782.32,-1170 969.32,-1170 969.32,-1148 782.32,-1148"/>
+<text text-anchor="start" x="785.22" y="-1154.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M970.32,-1247C1000.15,-1247 1098.67,-769.36 1137.62,-705.93"/>
+<polygon fill="black" stroke="black" points="1140.1,-708.4 1144.98,-699 1135.3,-703.3 1140.1,-708.4"/>
+<text text-anchor="middle" x="1063.65" y="-977.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<polygon fill="none" stroke="black" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<text text-anchor="start" x="833.44" y="-1097.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="784.32,-1068 784.32,-1090 967.32,-1090 967.32,-1068 784.32,-1068"/>
+<text text-anchor="start" x="836.75" y="-1075.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1075.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1046 784.32,-1068 967.32,-1068 967.32,-1046 784.32,-1046"/>
+<text text-anchor="start" x="818.47" y="-1053.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<text text-anchor="start" x="828.98" y="-1031.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1002 784.32,-1024 967.32,-1024 967.32,-1002 784.32,-1002"/>
+<text text-anchor="start" x="810.71" y="-1009.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="881.06" y="-1009.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="784.32,-980 784.32,-1002 967.32,-1002 967.32,-980 784.32,-980"/>
+<polygon fill="none" stroke="black" points="784.32,-980 784.32,-1002 967.32,-1002 967.32,-980 784.32,-980"/>
+<text text-anchor="start" x="855.61" y="-987.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="784.32,-958 784.32,-980 967.32,-980 967.32,-958 784.32,-958"/>
+<text text-anchor="start" x="787.17" y="-964.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M968.32,-1057C1053.57,-1057 1056.19,-726.42 1134.98,-700.6"/>
+<polygon fill="black" stroke="black" points="1135.66,-704.03 1144.98,-699 1134.56,-697.12 1135.66,-704.03"/>
+<text text-anchor="middle" x="1063.65" y="-882.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="62.5,-820 62.5,-842 176.5,-842 176.5,-820 62.5,-820"/>
+<polygon fill="none" stroke="black" points="62.5,-820 62.5,-842 176.5,-842 176.5,-820 62.5,-820"/>
+<text text-anchor="start" x="105.12" y="-827.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="62.5,-798 62.5,-820 176.5,-820 176.5,-798 62.5,-798"/>
+<text text-anchor="start" x="80.43" y="-805.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-805.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="62.5,-776 62.5,-798 176.5,-798 176.5,-776 62.5,-776"/>
+<text text-anchor="start" x="71.1" y="-783.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.13" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-754 62.5,-776 176.5,-776 176.5,-754 62.5,-754"/>
+<text text-anchor="start" x="82.76" y="-761.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.47" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-732 62.5,-754 176.5,-754 176.5,-732 62.5,-732"/>
+<text text-anchor="start" x="65.26" y="-739.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="137.97" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-710 62.5,-732 176.5,-732 176.5,-710 62.5,-710"/>
+<text text-anchor="start" x="75.37" y="-717.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="127.86" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-688 62.5,-710 176.5,-710 176.5,-688 62.5,-688"/>
+<text text-anchor="start" x="82.37" y="-695.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="120.87" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-666 62.5,-688 176.5,-688 176.5,-666 62.5,-666"/>
+<text text-anchor="start" x="69.55" y="-673.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="133.69" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<polygon fill="none" stroke="black" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<text text-anchor="start" x="830.34" y="-907.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="781.32,-878 781.32,-900 970.32,-900 970.32,-878 781.32,-878"/>
+<text text-anchor="start" x="836.75" y="-885.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-885.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<text text-anchor="start" x="818.47" y="-863.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-834 781.32,-856 970.32,-856 970.32,-834 781.32,-834"/>
+<text text-anchor="start" x="817.7" y="-841.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="898.17" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="781.32,-812 781.32,-834 970.32,-834 970.32,-812 781.32,-812"/>
+<polygon fill="none" stroke="black" points="781.32,-812 781.32,-834 970.32,-834 970.32,-812 781.32,-812"/>
+<text text-anchor="start" x="855.61" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="781.32,-790 781.32,-812 970.32,-812 970.32,-790 781.32,-790"/>
+<text text-anchor="start" x="784.07" y="-796.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M971.32,-867C1075.14,-867 1040.16,-709.97 1134.77,-699.54"/>
+<polygon fill="black" stroke="black" points="1135.18,-703.03 1144.98,-699 1134.81,-696.04 1135.18,-703.03"/>
+<text text-anchor="middle" x="1063.65" y="-792.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<polygon fill="none" stroke="black" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<text text-anchor="start" x="827.22" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<text text-anchor="start" x="836.75" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-717.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-688 778.32,-710 973.32,-710 973.32,-688 778.32,-688"/>
+<text text-anchor="start" x="818.47" y="-695.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-666 778.32,-688 973.32,-688 973.32,-666 778.32,-666"/>
+<text text-anchor="start" x="811.09" y="-673.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="904.79" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="778.32,-644 778.32,-666 973.32,-666 973.32,-644 778.32,-644"/>
+<polygon fill="none" stroke="black" points="778.32,-644 778.32,-666 973.32,-666 973.32,-644 778.32,-644"/>
+<text text-anchor="start" x="855.61" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="778.32,-622 778.32,-644 973.32,-644 973.32,-622 778.32,-622"/>
+<text text-anchor="start" x="780.95" y="-628.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M974.32,-699C1046.61,-699 1067.23,-699 1134.68,-699"/>
+<polygon fill="black" stroke="black" points="1134.98,-702.5 1144.98,-699 1134.98,-695.5 1134.98,-702.5"/>
+<text text-anchor="middle" x="1063.65" y="-704.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<polygon fill="none" stroke="black" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<text text-anchor="start" x="854.44" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="780.32,-542 780.32,-564 971.32,-564 971.32,-542 780.32,-542"/>
+<text text-anchor="start" x="836.75" y="-549.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-549.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-520 780.32,-542 971.32,-542 971.32,-520 780.32,-520"/>
+<text text-anchor="start" x="818.47" y="-527.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-498 780.32,-520 971.32,-520 971.32,-498 780.32,-498"/>
+<text text-anchor="start" x="820.42" y="-505.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="871.36" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-476 780.32,-498 971.32,-498 971.32,-476 780.32,-476"/>
+<text text-anchor="start" x="818.86" y="-483.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="872.92" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-454 780.32,-476 971.32,-476 971.32,-454 780.32,-454"/>
+<text text-anchor="start" x="843.36" y="-461.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="872.52" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-432 780.32,-454 971.32,-454 971.32,-432 780.32,-432"/>
+<text text-anchor="start" x="828.2" y="-439.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="887.68" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-410 780.32,-432 971.32,-432 971.32,-410 780.32,-410"/>
+<text text-anchor="start" x="820.81" y="-417.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="870.97" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-388 780.32,-410 971.32,-410 971.32,-388 780.32,-388"/>
+<text text-anchor="start" x="816.53" y="-395.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="875.24" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-366 780.32,-388 971.32,-388 971.32,-366 780.32,-366"/>
+<text text-anchor="start" x="818.09" y="-373.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="873.68" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-344 780.32,-366 971.32,-366 971.32,-344 780.32,-344"/>
+<text text-anchor="start" x="837.52" y="-351.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="877.57" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="780.32,-322 780.32,-344 971.32,-344 971.32,-322 780.32,-322"/>
+<text text-anchor="start" x="831.31" y="-329.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="884.57" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-300 780.32,-322 971.32,-322 971.32,-300 780.32,-300"/>
+<text text-anchor="start" x="827.42" y="-307.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="864.36" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-278 780.32,-300 971.32,-300 971.32,-278 780.32,-278"/>
+<text text-anchor="start" x="803.7" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="912.18" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-256 780.32,-278 971.32,-278 971.32,-256 780.32,-256"/>
+<text text-anchor="start" x="794.76" y="-263.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="921.12" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<polygon fill="none" stroke="black" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<text text-anchor="start" x="855.61" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="780.32,-212 780.32,-234 971.32,-234 971.32,-212 780.32,-212"/>
+<text text-anchor="start" x="783.28" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M972.32,-531C1022.61,-531 1083.55,-679.27 1135.13,-697.23"/>
+<polygon fill="black" stroke="black" points="1134.52,-700.67 1144.98,-699 1135.76,-693.78 1134.52,-700.67"/>
+<text text-anchor="middle" x="1063.65" y="-639.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<polygon fill="none" stroke="black" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<text text-anchor="start" x="479.56" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="401.66,-564 401.66,-586 605.66,-586 605.66,-564 401.66,-564"/>
+<text text-anchor="start" x="464.59" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="482.87" y="-571.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-542 401.66,-564 605.66,-564 605.66,-542 401.66,-542"/>
+<text text-anchor="start" x="442.43" y="-549.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="505.03" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-520 401.66,-542 605.66,-542 605.66,-520 401.66,-520"/>
+<text text-anchor="start" x="448.26" y="-527.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="499.2" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-498 401.66,-520 605.66,-520 605.66,-498 401.66,-498"/>
+<text text-anchor="start" x="446.7" y="-505.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="500.76" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-476 401.66,-498 605.66,-498 605.66,-476 401.66,-476"/>
+<text text-anchor="start" x="471.19" y="-483.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="500.36" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-454 401.66,-476 605.66,-476 605.66,-454 401.66,-454"/>
+<text text-anchor="start" x="456.04" y="-461.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="515.52" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-432 401.66,-454 605.66,-454 605.66,-432 401.66,-432"/>
+<text text-anchor="start" x="448.65" y="-439.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="498.8" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-410 401.66,-432 605.66,-432 605.66,-410 401.66,-410"/>
+<text text-anchor="start" x="453.32" y="-417.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="518.24" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-388 401.66,-410 605.66,-410 605.66,-388 401.66,-388"/>
+<text text-anchor="start" x="465.36" y="-395.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="505.41" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="401.66,-366 401.66,-388 605.66,-388 605.66,-366 401.66,-366"/>
+<text text-anchor="start" x="455.26" y="-373.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="492.2" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-344 401.66,-366 605.66,-366 605.66,-344 401.66,-344"/>
+<text text-anchor="start" x="431.53" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="540.02" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<text text-anchor="start" x="422.59" y="-329.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="548.96" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<text text-anchor="start" x="436.99" y="-307.4" font-family="Times,serif" font-size="14.00">last_watched_at: </text>
+<text text-anchor="start" x="534.57" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="401.66,-278 401.66,-300 605.66,-300 605.66,-278 401.66,-278"/>
+<polygon fill="none" stroke="black" points="401.66,-278 401.66,-300 605.66,-300 605.66,-278 401.66,-278"/>
+<text text-anchor="start" x="483.45" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="401.66,-256 401.66,-278 605.66,-278 605.66,-256 401.66,-256"/>
+<text text-anchor="start" x="404.52" y="-262.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M605.66,-553C679.38,-553 700.29,-553 769.26,-553"/>
+<polygon fill="black" stroke="black" points="769.32,-556.5 779.32,-553 769.32,-549.5 769.32,-556.5"/>
+<text text-anchor="middle" x="686.99" y="-557.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<polygon fill="none" stroke="black" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<text text-anchor="start" x="835.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="768.32,-132 768.32,-154 982.32,-154 982.32,-132 768.32,-132"/>
+<text text-anchor="start" x="836.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="854.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-110 768.32,-132 982.32,-132 982.32,-110 768.32,-110"/>
+<text text-anchor="start" x="817.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="872.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-88 768.32,-110 982.32,-110 982.32,-88 768.32,-88"/>
+<text text-anchor="start" x="800.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="890.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-66 768.32,-88 982.32,-88 982.32,-66 768.32,-66"/>
+<text text-anchor="start" x="807.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="882.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<polygon fill="none" stroke="black" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<text text-anchor="start" x="855.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="768.32,-22 768.32,-44 982.32,-44 982.32,-22 768.32,-22"/>
+<text text-anchor="start" x="789.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="768.32,0 768.32,-22 982.32,-22 982.32,0 768.32,0"/>
+<text text-anchor="start" x="771.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-99C1106.04,-99 1039.84,-243 1072.98,-362.2 1092.52,-432.48 1070.69,-674.75 1134.87,-697.31"/>
+<polygon fill="black" stroke="black" points="1134.54,-700.81 1144.98,-699 1135.69,-693.9 1134.54,-700.81"/>
+<text text-anchor="middle" x="1063.65" y="-367.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-121C1103.51,-121 1021.56,-267.32 1054.32,-384 1073.05,-450.71 1072.27,-675.5 1134.83,-697.3"/>
+<polygon fill="black" stroke="black" points="1134.54,-700.8 1144.98,-699 1135.7,-693.89 1134.54,-700.8"/>
+<text text-anchor="middle" x="1063.65" y="-521.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node10" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="56.25" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="80.93" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-593.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="56.04" y="-571.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="64.6" y="-549.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="66.55" y="-527.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="55.26" y="-505.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<polygon fill="none" stroke="black" points="0.5,-476 0.5,-498 239.5,-498 239.5,-476 0.5,-476"/>
+<text text-anchor="start" x="99.79" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-454 0.5,-476 239.5,-476 239.5,-454 0.5,-454"/>
+<text text-anchor="start" x="3.37" y="-460.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-432 0.5,-454 239.5,-454 239.5,-432 0.5,-432"/>
+<text text-anchor="start" x="11.92" y="-438.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-575C307.76,-575 327.47,-575 391.45,-575"/>
+<polygon fill="black" stroke="black" points="391.66,-578.5 401.66,-575 391.66,-571.5 391.66,-578.5"/>
+<text text-anchor="middle" x="320.33" y="-579.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node11" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1010 9.5,-1032 229.5,-1032 229.5,-1010 9.5,-1010"/>
+<polygon fill="none" stroke="black" points="9.5,-1010 9.5,-1032 229.5,-1032 229.5,-1010 9.5,-1010"/>
+<text text-anchor="start" x="83.34" y="-1017.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-988 9.5,-1010 229.5,-1010 229.5,-988 9.5,-988"/>
+<text text-anchor="start" x="80.43" y="-995.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-995.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-966 9.5,-988 229.5,-988 229.5,-966 9.5,-966"/>
+<text text-anchor="start" x="77.71" y="-973.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-944 9.5,-966 229.5,-966 229.5,-944 9.5,-944"/>
+<text text-anchor="start" x="60.98" y="-951.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-922 9.5,-944 229.5,-944 229.5,-922 9.5,-922"/>
+<text text-anchor="start" x="56.71" y="-929.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-900 9.5,-922 229.5,-922 229.5,-900 9.5,-900"/>
+<polygon fill="none" stroke="black" points="9.5,-900 9.5,-922 229.5,-922 229.5,-900 9.5,-900"/>
+<text text-anchor="start" x="99.29" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-878 9.5,-900 229.5,-900 229.5,-878 9.5,-878"/>
+<text text-anchor="start" x="12.19" y="-884.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviRoomDatabase/21.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviRoomDatabase/21.svg
@@ -1,0 +1,498 @@
+<svg width="1363px" height="1674px"
+ viewBox="0.00 0.00 1362.98 1674.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1638)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1638 1326.98,-1638 1326.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1116.48,-962 1116.48,-984 1291.48,-984 1291.48,-962 1116.48,-962"/>
+<polygon fill="none" stroke="black" points="1116.48,-962 1116.48,-984 1291.48,-984 1291.48,-962 1116.48,-962"/>
+<text text-anchor="start" x="1186.48" y="-969.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1116.48,-940 1116.48,-962 1291.48,-962 1291.48,-940 1116.48,-940"/>
+<text text-anchor="start" x="1164.91" y="-947.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1183.19" y="-947.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-918 1116.48,-940 1291.48,-940 1291.48,-918 1116.48,-918"/>
+<text text-anchor="start" x="1171.52" y="-925.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1200.68" y="-925.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-896 1116.48,-918 1291.48,-918 1291.48,-896 1116.48,-896"/>
+<text text-anchor="start" x="1146.24" y="-903.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1225.96" y="-903.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-874 1116.48,-896 1291.48,-896 1291.48,-874 1116.48,-874"/>
+<text text-anchor="start" x="1148.58" y="-881.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1199.52" y="-881.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-852 1116.48,-874 1291.48,-874 1291.48,-852 1116.48,-852"/>
+<text text-anchor="start" x="1147.02" y="-859.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1201.08" y="-859.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-830 1116.48,-852 1291.48,-852 1291.48,-830 1116.48,-830"/>
+<text text-anchor="start" x="1159.07" y="-837.4" font-family="Times,serif" font-size="14.00">imdb_id: </text>
+<text text-anchor="start" x="1213.13" y="-837.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-808 1116.48,-830 1291.48,-830 1291.48,-808 1116.48,-808"/>
+<text text-anchor="start" x="1156.36" y="-815.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1215.84" y="-815.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-786 1116.48,-808 1291.48,-808 1291.48,-786 1116.48,-786"/>
+<text text-anchor="start" x="1153.64" y="-793.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1218.56" y="-793.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-764 1116.48,-786 1291.48,-786 1291.48,-764 1116.48,-764"/>
+<text text-anchor="start" x="1149.36" y="-771.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1222.06" y="-771.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1116.48,-742 1116.48,-764 1291.48,-764 1291.48,-742 1116.48,-742"/>
+<text text-anchor="start" x="1148.59" y="-749.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1223.61" y="-749.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-720 1116.48,-742 1291.48,-742 1291.48,-720 1116.48,-720"/>
+<text text-anchor="start" x="1153.64" y="-727.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1218.56" y="-727.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-698 1116.48,-720 1291.48,-720 1291.48,-698 1116.48,-698"/>
+<text text-anchor="start" x="1161.02" y="-705.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1211.18" y="-705.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-676 1116.48,-698 1291.48,-698 1291.48,-676 1116.48,-676"/>
+<text text-anchor="start" x="1159.47" y="-683.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1212.73" y="-683.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-654 1116.48,-676 1291.48,-676 1291.48,-654 1116.48,-654"/>
+<text text-anchor="start" x="1148.58" y="-661.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1199.52" y="-661.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-632 1116.48,-654 1291.48,-654 1291.48,-632 1116.48,-632"/>
+<text text-anchor="start" x="1164.14" y="-639.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1208.06" y="-639.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-610 1116.48,-632 1291.48,-632 1291.48,-610 1116.48,-610"/>
+<text text-anchor="start" x="1119.04" y="-617.4" font-family="Times,serif" font-size="14.00">last_trakt_data_update: </text>
+<text text-anchor="start" x="1253.16" y="-617.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1116.48,-588 1116.48,-610 1291.48,-610 1291.48,-588 1116.48,-588"/>
+<polygon fill="none" stroke="black" points="1116.48,-588 1116.48,-610 1291.48,-610 1291.48,-588 1116.48,-588"/>
+<text text-anchor="start" x="1183.77" y="-595.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1116.48,-566 1116.48,-588 1291.48,-588 1291.48,-566 1116.48,-566"/>
+<text text-anchor="start" x="1142.16" y="-572.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1116.48,-544 1116.48,-566 1291.48,-566 1291.48,-544 1116.48,-544"/>
+<text text-anchor="start" x="1140.6" y="-550.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- shows_fts -->
+<g id="node2" class="node">
+<title>shows_fts</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-988 59.5,-1010 180.5,-1010 180.5,-988 59.5,-988"/>
+<polygon fill="none" stroke="black" points="59.5,-988 59.5,-1010 180.5,-1010 180.5,-988 59.5,-988"/>
+<text text-anchor="start" x="92" y="-995.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows_fts</text>
+<polygon fill="none" stroke="black" points="59.5,-966 59.5,-988 180.5,-988 180.5,-966 59.5,-966"/>
+<text text-anchor="start" x="87.53" y="-973.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="116.7" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-944 59.5,-966 180.5,-966 180.5,-944 59.5,-944"/>
+<text text-anchor="start" x="62.26" y="-951.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="141.98" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- trending_shows -->
+<g id="node3" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="753.32,-1580 753.32,-1602 940.32,-1602 940.32,-1580 753.32,-1580"/>
+<polygon fill="none" stroke="black" points="753.32,-1580 753.32,-1602 940.32,-1602 940.32,-1580 753.32,-1580"/>
+<text text-anchor="start" x="802.5" y="-1587.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="753.32,-1558 753.32,-1580 940.32,-1580 940.32,-1558 753.32,-1558"/>
+<text text-anchor="start" x="807.75" y="-1565.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1565.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1536 753.32,-1558 940.32,-1558 940.32,-1536 753.32,-1536"/>
+<text text-anchor="start" x="789.47" y="-1543.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1543.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1514 753.32,-1536 940.32,-1536 940.32,-1514 753.32,-1514"/>
+<text text-anchor="start" x="799.98" y="-1521.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1521.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1492 753.32,-1514 940.32,-1514 940.32,-1492 753.32,-1492"/>
+<text text-anchor="start" x="788.32" y="-1499.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="845.46" y="-1499.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="753.32,-1470 753.32,-1492 940.32,-1492 940.32,-1470 753.32,-1470"/>
+<polygon fill="none" stroke="black" points="753.32,-1470 753.32,-1492 940.32,-1492 940.32,-1470 753.32,-1470"/>
+<text text-anchor="start" x="826.61" y="-1477.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="753.32,-1448 753.32,-1470 940.32,-1470 940.32,-1448 753.32,-1448"/>
+<text text-anchor="start" x="756.22" y="-1454.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M941.32,-1547C973.6,-1547 1068.15,-1025.35 1108.46,-958.11"/>
+<polygon fill="black" stroke="black" points="1111.12,-960.41 1115.98,-951 1106.31,-955.33 1111.12,-960.41"/>
+<text text-anchor="middle" x="1034.65" y="-1253.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node4" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="755.32,-1390 755.32,-1412 938.32,-1412 938.32,-1390 755.32,-1390"/>
+<polygon fill="none" stroke="black" points="755.32,-1390 755.32,-1412 938.32,-1412 938.32,-1390 755.32,-1390"/>
+<text text-anchor="start" x="804.44" y="-1397.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="755.32,-1368 755.32,-1390 938.32,-1390 938.32,-1368 755.32,-1368"/>
+<text text-anchor="start" x="807.75" y="-1375.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1375.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1346 755.32,-1368 938.32,-1368 938.32,-1346 755.32,-1346"/>
+<text text-anchor="start" x="789.47" y="-1353.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1353.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1324 755.32,-1346 938.32,-1346 938.32,-1324 755.32,-1324"/>
+<text text-anchor="start" x="799.98" y="-1331.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1331.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1302 755.32,-1324 938.32,-1324 938.32,-1302 755.32,-1302"/>
+<text text-anchor="start" x="781.71" y="-1309.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="852.06" y="-1309.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="755.32,-1280 755.32,-1302 938.32,-1302 938.32,-1280 755.32,-1280"/>
+<polygon fill="none" stroke="black" points="755.32,-1280 755.32,-1302 938.32,-1302 938.32,-1280 755.32,-1280"/>
+<text text-anchor="start" x="826.61" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="755.32,-1258 755.32,-1280 938.32,-1280 938.32,-1258 755.32,-1258"/>
+<text text-anchor="start" x="758.17" y="-1264.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M939.32,-1357C985.54,-1357 1057.41,-998.68 1106.74,-955.28"/>
+<polygon fill="black" stroke="black" points="1108.38,-958.38 1115.98,-951 1105.44,-952.03 1108.38,-958.38"/>
+<text text-anchor="middle" x="1034.65" y="-1158.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node5" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-1288 53.5,-1310 186.5,-1310 186.5,-1288 53.5,-1288"/>
+<polygon fill="none" stroke="black" points="53.5,-1288 53.5,-1310 186.5,-1310 186.5,-1288 53.5,-1288"/>
+<text text-anchor="start" x="105.62" y="-1295.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-1266 53.5,-1288 186.5,-1288 186.5,-1266 53.5,-1266"/>
+<text text-anchor="start" x="80.93" y="-1273.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-1273.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-1244 53.5,-1266 186.5,-1266 186.5,-1244 53.5,-1244"/>
+<text text-anchor="start" x="71.6" y="-1251.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-1251.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1222 53.5,-1244 186.5,-1244 186.5,-1222 53.5,-1222"/>
+<text text-anchor="start" x="83.26" y="-1229.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-1229.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1200 53.5,-1222 186.5,-1222 186.5,-1200 53.5,-1200"/>
+<text text-anchor="start" x="65.76" y="-1207.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-1207.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1178 53.5,-1200 186.5,-1200 186.5,-1178 53.5,-1178"/>
+<text text-anchor="start" x="75.87" y="-1185.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-1185.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1156 53.5,-1178 186.5,-1178 186.5,-1156 53.5,-1156"/>
+<text text-anchor="start" x="82.87" y="-1163.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1134 53.5,-1156 186.5,-1156 186.5,-1134 53.5,-1134"/>
+<text text-anchor="start" x="70.05" y="-1141.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1112 53.5,-1134 186.5,-1134 186.5,-1112 53.5,-1112"/>
+<text text-anchor="start" x="77.43" y="-1119.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-1119.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-1090 53.5,-1112 186.5,-1112 186.5,-1090 53.5,-1090"/>
+<text text-anchor="start" x="69.65" y="-1097.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-1068 53.5,-1090 186.5,-1090 186.5,-1068 53.5,-1068"/>
+<polygon fill="none" stroke="black" points="53.5,-1068 53.5,-1090 186.5,-1090 186.5,-1068 53.5,-1068"/>
+<text text-anchor="start" x="99.79" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-1046 53.5,-1068 186.5,-1068 186.5,-1046 53.5,-1046"/>
+<text text-anchor="start" x="56.25" y="-1052.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node6" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="752.32,-1200 752.32,-1222 941.32,-1222 941.32,-1200 752.32,-1200"/>
+<polygon fill="none" stroke="black" points="752.32,-1200 752.32,-1222 941.32,-1222 941.32,-1200 752.32,-1200"/>
+<text text-anchor="start" x="801.34" y="-1207.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="752.32,-1178 752.32,-1200 941.32,-1200 941.32,-1178 752.32,-1178"/>
+<text text-anchor="start" x="807.75" y="-1185.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1185.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-1156 752.32,-1178 941.32,-1178 941.32,-1156 752.32,-1156"/>
+<text text-anchor="start" x="789.47" y="-1163.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-1134 752.32,-1156 941.32,-1156 941.32,-1134 752.32,-1134"/>
+<text text-anchor="start" x="788.7" y="-1141.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="869.17" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="752.32,-1112 752.32,-1134 941.32,-1134 941.32,-1112 752.32,-1112"/>
+<polygon fill="none" stroke="black" points="752.32,-1112 752.32,-1134 941.32,-1134 941.32,-1112 752.32,-1112"/>
+<text text-anchor="start" x="826.61" y="-1119.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="752.32,-1090 752.32,-1112 941.32,-1112 941.32,-1090 752.32,-1090"/>
+<text text-anchor="start" x="755.07" y="-1096.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M942.32,-1167C1062.01,-1167 996.76,-963.06 1105.98,-951.51"/>
+<polygon fill="black" stroke="black" points="1106.17,-955 1115.98,-951 1105.82,-948.01 1106.17,-955"/>
+<text text-anchor="middle" x="1034.65" y="-1075.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node7" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="749.32,-1032 749.32,-1054 944.32,-1054 944.32,-1032 749.32,-1032"/>
+<polygon fill="none" stroke="black" points="749.32,-1032 749.32,-1054 944.32,-1054 944.32,-1032 749.32,-1032"/>
+<text text-anchor="start" x="798.22" y="-1039.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="749.32,-1010 749.32,-1032 944.32,-1032 944.32,-1010 749.32,-1010"/>
+<text text-anchor="start" x="807.75" y="-1017.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1017.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-988 749.32,-1010 944.32,-1010 944.32,-988 749.32,-988"/>
+<text text-anchor="start" x="789.47" y="-995.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-966 749.32,-988 944.32,-988 944.32,-966 749.32,-966"/>
+<text text-anchor="start" x="791.81" y="-973.4" font-family="Times,serif" font-size="14.00">followed_at: </text>
+<text text-anchor="start" x="866.07" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="749.32,-944 749.32,-966 944.32,-966 944.32,-944 749.32,-944"/>
+<text text-anchor="start" x="782.09" y="-951.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="875.79" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="749.32,-922 749.32,-944 944.32,-944 944.32,-922 749.32,-922"/>
+<polygon fill="none" stroke="black" points="749.32,-922 749.32,-944 944.32,-944 944.32,-922 749.32,-922"/>
+<text text-anchor="start" x="826.61" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="749.32,-900 749.32,-922 944.32,-922 944.32,-900 749.32,-900"/>
+<text text-anchor="start" x="751.95" y="-906.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M945.32,-999C1020.57,-999 1035.88,-955.22 1105.75,-951.28"/>
+<polygon fill="black" stroke="black" points="1106.08,-954.77 1115.98,-951 1105.89,-947.78 1106.08,-954.77"/>
+<text text-anchor="middle" x="1034.65" y="-980.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node8" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="762.32,-842 762.32,-864 930.32,-864 930.32,-842 762.32,-842"/>
+<polygon fill="none" stroke="black" points="762.32,-842 762.32,-864 930.32,-864 930.32,-842 762.32,-842"/>
+<text text-anchor="start" x="824.94" y="-849.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="762.32,-820 762.32,-842 930.32,-842 930.32,-820 762.32,-820"/>
+<text text-anchor="start" x="807.25" y="-827.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-827.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-798 762.32,-820 930.32,-820 930.32,-798 762.32,-798"/>
+<text text-anchor="start" x="788.97" y="-805.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-776 762.32,-798 930.32,-798 930.32,-776 762.32,-776"/>
+<text text-anchor="start" x="790.92" y="-783.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="841.86" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-754 762.32,-776 930.32,-776 930.32,-754 762.32,-754"/>
+<text text-anchor="start" x="789.36" y="-761.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="843.42" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-732 762.32,-754 930.32,-754 930.32,-732 762.32,-732"/>
+<text text-anchor="start" x="813.86" y="-739.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="843.02" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-710 762.32,-732 930.32,-732 930.32,-710 762.32,-710"/>
+<text text-anchor="start" x="798.7" y="-717.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="858.18" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-688 762.32,-710 930.32,-710 930.32,-688 762.32,-688"/>
+<text text-anchor="start" x="791.31" y="-695.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="841.47" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-666 762.32,-688 930.32,-688 930.32,-666 762.32,-666"/>
+<text text-anchor="start" x="801.81" y="-673.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="855.07" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-644 762.32,-666 930.32,-666 930.32,-644 762.32,-644"/>
+<text text-anchor="start" x="787.03" y="-651.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="845.74" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-622 762.32,-644 930.32,-644 930.32,-622 762.32,-622"/>
+<text text-anchor="start" x="788.59" y="-629.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="844.18" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-600 762.32,-622 930.32,-622 930.32,-600 762.32,-600"/>
+<text text-anchor="start" x="791.7" y="-607.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="864.4" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="762.32,-578 762.32,-600 930.32,-600 930.32,-578 762.32,-578"/>
+<text text-anchor="start" x="781.59" y="-585.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="851.19" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-556 762.32,-578 930.32,-578 930.32,-556 762.32,-556"/>
+<text text-anchor="start" x="774.2" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="882.68" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-534 762.32,-556 930.32,-556 930.32,-534 762.32,-534"/>
+<text text-anchor="start" x="765.26" y="-541.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="891.62" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="762.32,-512 762.32,-534 930.32,-534 930.32,-512 762.32,-512"/>
+<polygon fill="none" stroke="black" points="762.32,-512 762.32,-534 930.32,-534 930.32,-512 762.32,-512"/>
+<text text-anchor="start" x="826.11" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="762.32,-490 762.32,-512 930.32,-512 930.32,-490 762.32,-490"/>
+<text text-anchor="start" x="780.61" y="-496.4" font-family="Times,serif" font-size="14.00">index_seasons_trakt_id</text>
+<polygon fill="none" stroke="black" points="762.32,-468 762.32,-490 930.32,-490 930.32,-468 762.32,-468"/>
+<text text-anchor="start" x="778.67" y="-474.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M931.32,-809C1031.31,-809 1013.83,-941.46 1105.8,-950.51"/>
+<polygon fill="black" stroke="black" points="1105.83,-954.02 1115.98,-951 1106.16,-947.03 1105.83,-954.02"/>
+<text text-anchor="middle" x="1034.65" y="-913.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node9" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="402.16,-864 402.16,-886 577.16,-886 577.16,-864 402.16,-864"/>
+<polygon fill="none" stroke="black" points="402.16,-864 402.16,-886 577.16,-886 577.16,-864 402.16,-864"/>
+<text text-anchor="start" x="465.56" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="402.16,-842 402.16,-864 577.16,-864 577.16,-842 402.16,-842"/>
+<text text-anchor="start" x="450.59" y="-849.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="468.87" y="-849.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-820 402.16,-842 577.16,-842 577.16,-820 402.16,-820"/>
+<text text-anchor="start" x="428.43" y="-827.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="491.03" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-798 402.16,-820 577.16,-820 577.16,-798 402.16,-798"/>
+<text text-anchor="start" x="434.26" y="-805.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="485.2" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-776 402.16,-798 577.16,-798 577.16,-776 402.16,-776"/>
+<text text-anchor="start" x="432.7" y="-783.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="486.76" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-754 402.16,-776 577.16,-776 577.16,-754 402.16,-754"/>
+<text text-anchor="start" x="457.19" y="-761.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="486.36" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-732 402.16,-754 577.16,-754 577.16,-732 402.16,-732"/>
+<text text-anchor="start" x="442.04" y="-739.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="501.52" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-710 402.16,-732 577.16,-732 577.16,-710 402.16,-710"/>
+<text text-anchor="start" x="434.65" y="-717.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="484.8" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-688 402.16,-710 577.16,-710 577.16,-688 402.16,-688"/>
+<text text-anchor="start" x="439.32" y="-695.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="504.24" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-666 402.16,-688 577.16,-688 577.16,-666 402.16,-666"/>
+<text text-anchor="start" x="435.03" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="507.74" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="402.16,-644 402.16,-666 577.16,-666 577.16,-644 402.16,-644"/>
+<text text-anchor="start" x="405.1" y="-651.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="514.35" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-622 402.16,-644 577.16,-644 577.16,-622 402.16,-622"/>
+<text text-anchor="start" x="408.59" y="-629.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="534.96" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="402.16,-600 402.16,-622 577.16,-622 577.16,-600 402.16,-600"/>
+<polygon fill="none" stroke="black" points="402.16,-600 402.16,-622 577.16,-622 577.16,-600 402.16,-600"/>
+<text text-anchor="start" x="469.45" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="402.16,-578 402.16,-600 577.16,-600 577.16,-578 402.16,-578"/>
+<text text-anchor="start" x="421.23" y="-584.4" font-family="Times,serif" font-size="14.00">index_episodes_trakt_id</text>
+<polygon fill="none" stroke="black" points="402.16,-556 402.16,-578 577.16,-578 577.16,-556 402.16,-556"/>
+<text text-anchor="start" x="415.4" y="-562.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M576.66,-831C655.21,-831 677.37,-831 751.07,-831"/>
+<polygon fill="black" stroke="black" points="751.32,-834.5 761.32,-831 751.32,-827.5 751.32,-834.5"/>
+<text text-anchor="middle" x="657.99" y="-835.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node10" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="739.32,-410 739.32,-432 953.32,-432 953.32,-410 739.32,-410"/>
+<polygon fill="none" stroke="black" points="739.32,-410 739.32,-432 953.32,-432 953.32,-410 739.32,-410"/>
+<text text-anchor="start" x="806.28" y="-417.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="739.32,-388 739.32,-410 953.32,-410 953.32,-388 739.32,-388"/>
+<text text-anchor="start" x="807.25" y="-395.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-395.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-366 739.32,-388 953.32,-388 953.32,-366 739.32,-366"/>
+<text text-anchor="start" x="788.97" y="-373.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-344 739.32,-366 953.32,-366 953.32,-344 739.32,-344"/>
+<text text-anchor="start" x="771.09" y="-351.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="861.69" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-322 739.32,-344 953.32,-344 953.32,-322 739.32,-322"/>
+<text text-anchor="start" x="778.87" y="-329.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="853.9" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="739.32,-300 739.32,-322 953.32,-322 953.32,-300 739.32,-300"/>
+<polygon fill="none" stroke="black" points="739.32,-300 739.32,-322 953.32,-322 953.32,-300 739.32,-300"/>
+<text text-anchor="start" x="826.11" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="739.32,-278 739.32,-300 953.32,-300 953.32,-278 739.32,-278"/>
+<text text-anchor="start" x="760.01" y="-284.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="739.32,-256 739.32,-278 953.32,-278 953.32,-256 739.32,-256"/>
+<text text-anchor="start" x="742.12" y="-262.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-355C1091.42,-355 1007.64,-518.97 1043.98,-652.2 1061.01,-714.62 1049.1,-926.9 1105.85,-949.12"/>
+<polygon fill="black" stroke="black" points="1105.51,-952.61 1115.98,-951 1106.79,-945.73 1105.51,-952.61"/>
+<text text-anchor="middle" x="1034.65" y="-656.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-377C1021.23,-377 1006.74,-608.68 1025.32,-674 1042.07,-732.89 1050.29,-927.97 1105.85,-949.13"/>
+<polygon fill="black" stroke="black" points="1105.51,-952.63 1115.98,-951 1106.78,-945.75 1105.51,-952.63"/>
+<text text-anchor="middle" x="1034.65" y="-787.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node11" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-886 0.5,-908 239.5,-908 239.5,-886 0.5,-886"/>
+<polygon fill="none" stroke="black" points="0.5,-886 0.5,-908 239.5,-908 239.5,-886 0.5,-886"/>
+<text text-anchor="start" x="56.25" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-864 0.5,-886 239.5,-886 239.5,-864 0.5,-864"/>
+<text text-anchor="start" x="80.93" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-871.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-842 0.5,-864 239.5,-864 239.5,-842 0.5,-842"/>
+<text text-anchor="start" x="56.04" y="-849.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-820 0.5,-842 239.5,-842 239.5,-820 0.5,-820"/>
+<text text-anchor="start" x="64.6" y="-827.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-798 0.5,-820 239.5,-820 239.5,-798 0.5,-798"/>
+<text text-anchor="start" x="66.55" y="-805.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-776 0.5,-798 239.5,-798 239.5,-776 0.5,-776"/>
+<text text-anchor="start" x="55.26" y="-783.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-754 0.5,-776 239.5,-776 239.5,-754 0.5,-754"/>
+<polygon fill="none" stroke="black" points="0.5,-754 0.5,-776 239.5,-776 239.5,-754 0.5,-754"/>
+<text text-anchor="start" x="99.79" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-732 0.5,-754 239.5,-754 239.5,-732 0.5,-732"/>
+<text text-anchor="start" x="3.37" y="-738.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-710 0.5,-732 239.5,-732 239.5,-710 0.5,-710"/>
+<text text-anchor="start" x="11.92" y="-716.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-853C307.76,-853 327.47,-853 391.45,-853"/>
+<polygon fill="black" stroke="black" points="391.66,-856.5 401.66,-853 391.66,-849.5 391.66,-856.5"/>
+<text text-anchor="middle" x="320.33" y="-857.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node12" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1478 9.5,-1500 229.5,-1500 229.5,-1478 9.5,-1478"/>
+<polygon fill="none" stroke="black" points="9.5,-1478 9.5,-1500 229.5,-1500 229.5,-1478 9.5,-1478"/>
+<text text-anchor="start" x="83.34" y="-1485.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1456 9.5,-1478 229.5,-1478 229.5,-1456 9.5,-1456"/>
+<text text-anchor="start" x="80.43" y="-1463.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1463.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1434 9.5,-1456 229.5,-1456 229.5,-1434 9.5,-1434"/>
+<text text-anchor="start" x="77.71" y="-1441.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1441.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1412 9.5,-1434 229.5,-1434 229.5,-1412 9.5,-1412"/>
+<text text-anchor="start" x="60.98" y="-1419.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1419.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1390 9.5,-1412 229.5,-1412 229.5,-1390 9.5,-1390"/>
+<text text-anchor="start" x="56.71" y="-1397.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1397.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-1368 9.5,-1390 229.5,-1390 229.5,-1368 9.5,-1368"/>
+<polygon fill="none" stroke="black" points="9.5,-1368 9.5,-1390 229.5,-1390 229.5,-1368 9.5,-1368"/>
+<text text-anchor="start" x="99.29" y="-1375.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-1346 9.5,-1368 229.5,-1368 229.5,-1346 9.5,-1346"/>
+<text text-anchor="start" x="12.19" y="-1352.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+<!-- show_images -->
+<g id="node13" class="node">
+<title>show_images</title>
+<polygon fill="#caff70" stroke="transparent" points="759.32,-198 759.32,-220 933.32,-220 933.32,-198 759.32,-198"/>
+<polygon fill="none" stroke="black" points="759.32,-198 759.32,-220 933.32,-220 933.32,-198 759.32,-198"/>
+<text text-anchor="start" x="808.22" y="-205.4" font-family="Times,serif" font-weight="bold" font-size="14.00">show_images</text>
+<polygon fill="none" stroke="black" points="759.32,-176 759.32,-198 933.32,-198 933.32,-176 759.32,-176"/>
+<text text-anchor="start" x="807.25" y="-183.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-183.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-154 759.32,-176 933.32,-176 933.32,-154 759.32,-154"/>
+<text text-anchor="start" x="788.97" y="-161.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-161.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-132 759.32,-154 933.32,-154 933.32,-132 759.32,-132"/>
+<text text-anchor="start" x="812.69" y="-139.4" font-family="Times,serif" font-size="14.00">path: </text>
+<text text-anchor="start" x="844.19" y="-139.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-110 759.32,-132 933.32,-132 933.32,-110 759.32,-110"/>
+<text text-anchor="start" x="812.69" y="-117.4" font-family="Times,serif" font-size="14.00">type: </text>
+<text text-anchor="start" x="844.19" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-88 759.32,-110 933.32,-110 933.32,-88 759.32,-88"/>
+<text text-anchor="start" x="812.69" y="-95.4" font-family="Times,serif" font-size="14.00">lang: </text>
+<text text-anchor="start" x="844.19" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-66 759.32,-88 933.32,-88 933.32,-66 759.32,-66"/>
+<text text-anchor="start" x="808.02" y="-73.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="848.07" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="759.32,-44 759.32,-66 933.32,-66 933.32,-44 759.32,-44"/>
+<text text-anchor="start" x="782.37" y="-51.4" font-family="Times,serif" font-size="14.00">is_primary: </text>
+<text text-anchor="start" x="850.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="759.32,-22 759.32,-44 933.32,-44 933.32,-22 759.32,-22"/>
+<polygon fill="none" stroke="black" points="759.32,-22 759.32,-44 933.32,-44 933.32,-22 759.32,-22"/>
+<text text-anchor="start" x="826.11" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="759.32,0 759.32,-22 933.32,-22 933.32,0 759.32,0"/>
+<text text-anchor="start" x="761.94" y="-6.4" font-family="Times,serif" font-size="14.00">index_show_images_show_id</text>
+</g>
+<!-- show_images&#45;&gt;shows -->
+<g id="edge10" class="edge">
+<title>show_images:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M934.32,-165C1036.94,-165 1012.78,-270.43 1043.98,-368.2 1082.57,-489.12 990.75,-926.18 1105.78,-949.99"/>
+<polygon fill="black" stroke="black" points="1105.69,-953.5 1115.98,-951 1106.38,-946.53 1105.69,-953.5"/>
+<text text-anchor="middle" x="1034.65" y="-372.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviRoomDatabase/22.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviRoomDatabase/22.svg
@@ -1,0 +1,498 @@
+<svg width="1363px" height="1674px"
+ viewBox="0.00 0.00 1362.98 1674.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1638)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1638 1326.98,-1638 1326.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1116.48,-962 1116.48,-984 1291.48,-984 1291.48,-962 1116.48,-962"/>
+<polygon fill="none" stroke="black" points="1116.48,-962 1116.48,-984 1291.48,-984 1291.48,-962 1116.48,-962"/>
+<text text-anchor="start" x="1186.48" y="-969.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1116.48,-940 1116.48,-962 1291.48,-962 1291.48,-940 1116.48,-940"/>
+<text text-anchor="start" x="1164.91" y="-947.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1183.19" y="-947.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-918 1116.48,-940 1291.48,-940 1291.48,-918 1116.48,-918"/>
+<text text-anchor="start" x="1171.52" y="-925.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1200.68" y="-925.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-896 1116.48,-918 1291.48,-918 1291.48,-896 1116.48,-896"/>
+<text text-anchor="start" x="1146.24" y="-903.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1225.96" y="-903.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-874 1116.48,-896 1291.48,-896 1291.48,-874 1116.48,-874"/>
+<text text-anchor="start" x="1148.58" y="-881.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1199.52" y="-881.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-852 1116.48,-874 1291.48,-874 1291.48,-852 1116.48,-852"/>
+<text text-anchor="start" x="1147.02" y="-859.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1201.08" y="-859.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-830 1116.48,-852 1291.48,-852 1291.48,-830 1116.48,-830"/>
+<text text-anchor="start" x="1159.07" y="-837.4" font-family="Times,serif" font-size="14.00">imdb_id: </text>
+<text text-anchor="start" x="1213.13" y="-837.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-808 1116.48,-830 1291.48,-830 1291.48,-808 1116.48,-808"/>
+<text text-anchor="start" x="1156.36" y="-815.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1215.84" y="-815.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-786 1116.48,-808 1291.48,-808 1291.48,-786 1116.48,-786"/>
+<text text-anchor="start" x="1153.64" y="-793.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1218.56" y="-793.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-764 1116.48,-786 1291.48,-786 1291.48,-764 1116.48,-764"/>
+<text text-anchor="start" x="1149.36" y="-771.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1222.06" y="-771.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1116.48,-742 1116.48,-764 1291.48,-764 1291.48,-742 1116.48,-742"/>
+<text text-anchor="start" x="1148.59" y="-749.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1223.61" y="-749.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-720 1116.48,-742 1291.48,-742 1291.48,-720 1116.48,-720"/>
+<text text-anchor="start" x="1153.64" y="-727.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1218.56" y="-727.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-698 1116.48,-720 1291.48,-720 1291.48,-698 1116.48,-698"/>
+<text text-anchor="start" x="1161.02" y="-705.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1211.18" y="-705.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-676 1116.48,-698 1291.48,-698 1291.48,-676 1116.48,-676"/>
+<text text-anchor="start" x="1159.47" y="-683.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1212.73" y="-683.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-654 1116.48,-676 1291.48,-676 1291.48,-654 1116.48,-654"/>
+<text text-anchor="start" x="1148.58" y="-661.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1199.52" y="-661.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-632 1116.48,-654 1291.48,-654 1291.48,-632 1116.48,-632"/>
+<text text-anchor="start" x="1164.14" y="-639.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1208.06" y="-639.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-610 1116.48,-632 1291.48,-632 1291.48,-610 1116.48,-610"/>
+<text text-anchor="start" x="1119.04" y="-617.4" font-family="Times,serif" font-size="14.00">last_trakt_data_update: </text>
+<text text-anchor="start" x="1253.16" y="-617.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1116.48,-588 1116.48,-610 1291.48,-610 1291.48,-588 1116.48,-588"/>
+<polygon fill="none" stroke="black" points="1116.48,-588 1116.48,-610 1291.48,-610 1291.48,-588 1116.48,-588"/>
+<text text-anchor="start" x="1183.77" y="-595.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1116.48,-566 1116.48,-588 1291.48,-588 1291.48,-566 1116.48,-566"/>
+<text text-anchor="start" x="1142.16" y="-572.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1116.48,-544 1116.48,-566 1291.48,-566 1291.48,-544 1116.48,-544"/>
+<text text-anchor="start" x="1140.6" y="-550.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- shows_fts -->
+<g id="node2" class="node">
+<title>shows_fts</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-988 59.5,-1010 180.5,-1010 180.5,-988 59.5,-988"/>
+<polygon fill="none" stroke="black" points="59.5,-988 59.5,-1010 180.5,-1010 180.5,-988 59.5,-988"/>
+<text text-anchor="start" x="92" y="-995.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows_fts</text>
+<polygon fill="none" stroke="black" points="59.5,-966 59.5,-988 180.5,-988 180.5,-966 59.5,-966"/>
+<text text-anchor="start" x="87.53" y="-973.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="116.7" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-944 59.5,-966 180.5,-966 180.5,-944 59.5,-944"/>
+<text text-anchor="start" x="62.26" y="-951.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="141.98" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- trending_shows -->
+<g id="node3" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="753.32,-1580 753.32,-1602 940.32,-1602 940.32,-1580 753.32,-1580"/>
+<polygon fill="none" stroke="black" points="753.32,-1580 753.32,-1602 940.32,-1602 940.32,-1580 753.32,-1580"/>
+<text text-anchor="start" x="802.5" y="-1587.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="753.32,-1558 753.32,-1580 940.32,-1580 940.32,-1558 753.32,-1558"/>
+<text text-anchor="start" x="807.75" y="-1565.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1565.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1536 753.32,-1558 940.32,-1558 940.32,-1536 753.32,-1536"/>
+<text text-anchor="start" x="789.47" y="-1543.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1543.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1514 753.32,-1536 940.32,-1536 940.32,-1514 753.32,-1514"/>
+<text text-anchor="start" x="799.98" y="-1521.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1521.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1492 753.32,-1514 940.32,-1514 940.32,-1492 753.32,-1492"/>
+<text text-anchor="start" x="788.32" y="-1499.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="845.46" y="-1499.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="753.32,-1470 753.32,-1492 940.32,-1492 940.32,-1470 753.32,-1470"/>
+<polygon fill="none" stroke="black" points="753.32,-1470 753.32,-1492 940.32,-1492 940.32,-1470 753.32,-1470"/>
+<text text-anchor="start" x="826.61" y="-1477.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="753.32,-1448 753.32,-1470 940.32,-1470 940.32,-1448 753.32,-1448"/>
+<text text-anchor="start" x="756.22" y="-1454.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M941.32,-1547C973.6,-1547 1068.15,-1025.35 1108.46,-958.11"/>
+<polygon fill="black" stroke="black" points="1111.12,-960.41 1115.98,-951 1106.31,-955.33 1111.12,-960.41"/>
+<text text-anchor="middle" x="1034.65" y="-1253.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node4" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="755.32,-1390 755.32,-1412 938.32,-1412 938.32,-1390 755.32,-1390"/>
+<polygon fill="none" stroke="black" points="755.32,-1390 755.32,-1412 938.32,-1412 938.32,-1390 755.32,-1390"/>
+<text text-anchor="start" x="804.44" y="-1397.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="755.32,-1368 755.32,-1390 938.32,-1390 938.32,-1368 755.32,-1368"/>
+<text text-anchor="start" x="807.75" y="-1375.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1375.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1346 755.32,-1368 938.32,-1368 938.32,-1346 755.32,-1346"/>
+<text text-anchor="start" x="789.47" y="-1353.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1353.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1324 755.32,-1346 938.32,-1346 938.32,-1324 755.32,-1324"/>
+<text text-anchor="start" x="799.98" y="-1331.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1331.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1302 755.32,-1324 938.32,-1324 938.32,-1302 755.32,-1302"/>
+<text text-anchor="start" x="781.71" y="-1309.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="852.06" y="-1309.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="755.32,-1280 755.32,-1302 938.32,-1302 938.32,-1280 755.32,-1280"/>
+<polygon fill="none" stroke="black" points="755.32,-1280 755.32,-1302 938.32,-1302 938.32,-1280 755.32,-1280"/>
+<text text-anchor="start" x="826.61" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="755.32,-1258 755.32,-1280 938.32,-1280 938.32,-1258 755.32,-1258"/>
+<text text-anchor="start" x="758.17" y="-1264.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M939.32,-1357C985.54,-1357 1057.41,-998.68 1106.74,-955.28"/>
+<polygon fill="black" stroke="black" points="1108.38,-958.38 1115.98,-951 1105.44,-952.03 1108.38,-958.38"/>
+<text text-anchor="middle" x="1034.65" y="-1158.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node5" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-1288 53.5,-1310 186.5,-1310 186.5,-1288 53.5,-1288"/>
+<polygon fill="none" stroke="black" points="53.5,-1288 53.5,-1310 186.5,-1310 186.5,-1288 53.5,-1288"/>
+<text text-anchor="start" x="105.62" y="-1295.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-1266 53.5,-1288 186.5,-1288 186.5,-1266 53.5,-1266"/>
+<text text-anchor="start" x="80.93" y="-1273.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-1273.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-1244 53.5,-1266 186.5,-1266 186.5,-1244 53.5,-1244"/>
+<text text-anchor="start" x="71.6" y="-1251.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-1251.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1222 53.5,-1244 186.5,-1244 186.5,-1222 53.5,-1222"/>
+<text text-anchor="start" x="83.26" y="-1229.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-1229.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1200 53.5,-1222 186.5,-1222 186.5,-1200 53.5,-1200"/>
+<text text-anchor="start" x="65.76" y="-1207.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-1207.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1178 53.5,-1200 186.5,-1200 186.5,-1178 53.5,-1178"/>
+<text text-anchor="start" x="75.87" y="-1185.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-1185.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1156 53.5,-1178 186.5,-1178 186.5,-1156 53.5,-1156"/>
+<text text-anchor="start" x="82.87" y="-1163.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1134 53.5,-1156 186.5,-1156 186.5,-1134 53.5,-1134"/>
+<text text-anchor="start" x="70.05" y="-1141.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1112 53.5,-1134 186.5,-1134 186.5,-1112 53.5,-1112"/>
+<text text-anchor="start" x="77.43" y="-1119.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-1119.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-1090 53.5,-1112 186.5,-1112 186.5,-1090 53.5,-1090"/>
+<text text-anchor="start" x="69.65" y="-1097.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-1068 53.5,-1090 186.5,-1090 186.5,-1068 53.5,-1068"/>
+<polygon fill="none" stroke="black" points="53.5,-1068 53.5,-1090 186.5,-1090 186.5,-1068 53.5,-1068"/>
+<text text-anchor="start" x="99.79" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-1046 53.5,-1068 186.5,-1068 186.5,-1046 53.5,-1046"/>
+<text text-anchor="start" x="56.25" y="-1052.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node6" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="752.32,-1200 752.32,-1222 941.32,-1222 941.32,-1200 752.32,-1200"/>
+<polygon fill="none" stroke="black" points="752.32,-1200 752.32,-1222 941.32,-1222 941.32,-1200 752.32,-1200"/>
+<text text-anchor="start" x="801.34" y="-1207.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="752.32,-1178 752.32,-1200 941.32,-1200 941.32,-1178 752.32,-1178"/>
+<text text-anchor="start" x="807.75" y="-1185.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1185.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-1156 752.32,-1178 941.32,-1178 941.32,-1156 752.32,-1156"/>
+<text text-anchor="start" x="789.47" y="-1163.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-1134 752.32,-1156 941.32,-1156 941.32,-1134 752.32,-1134"/>
+<text text-anchor="start" x="788.7" y="-1141.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="869.17" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="752.32,-1112 752.32,-1134 941.32,-1134 941.32,-1112 752.32,-1112"/>
+<polygon fill="none" stroke="black" points="752.32,-1112 752.32,-1134 941.32,-1134 941.32,-1112 752.32,-1112"/>
+<text text-anchor="start" x="826.61" y="-1119.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="752.32,-1090 752.32,-1112 941.32,-1112 941.32,-1090 752.32,-1090"/>
+<text text-anchor="start" x="755.07" y="-1096.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M942.32,-1167C1062.01,-1167 996.76,-963.06 1105.98,-951.51"/>
+<polygon fill="black" stroke="black" points="1106.17,-955 1115.98,-951 1105.82,-948.01 1106.17,-955"/>
+<text text-anchor="middle" x="1034.65" y="-1075.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node7" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="749.32,-1032 749.32,-1054 944.32,-1054 944.32,-1032 749.32,-1032"/>
+<polygon fill="none" stroke="black" points="749.32,-1032 749.32,-1054 944.32,-1054 944.32,-1032 749.32,-1032"/>
+<text text-anchor="start" x="798.22" y="-1039.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="749.32,-1010 749.32,-1032 944.32,-1032 944.32,-1010 749.32,-1010"/>
+<text text-anchor="start" x="807.75" y="-1017.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1017.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-988 749.32,-1010 944.32,-1010 944.32,-988 749.32,-988"/>
+<text text-anchor="start" x="789.47" y="-995.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-966 749.32,-988 944.32,-988 944.32,-966 749.32,-966"/>
+<text text-anchor="start" x="791.81" y="-973.4" font-family="Times,serif" font-size="14.00">followed_at: </text>
+<text text-anchor="start" x="866.07" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="749.32,-944 749.32,-966 944.32,-966 944.32,-944 749.32,-944"/>
+<text text-anchor="start" x="782.09" y="-951.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="875.79" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="749.32,-922 749.32,-944 944.32,-944 944.32,-922 749.32,-922"/>
+<polygon fill="none" stroke="black" points="749.32,-922 749.32,-944 944.32,-944 944.32,-922 749.32,-922"/>
+<text text-anchor="start" x="826.61" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="749.32,-900 749.32,-922 944.32,-922 944.32,-900 749.32,-900"/>
+<text text-anchor="start" x="751.95" y="-906.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M945.32,-999C1020.57,-999 1035.88,-955.22 1105.75,-951.28"/>
+<polygon fill="black" stroke="black" points="1106.08,-954.77 1115.98,-951 1105.89,-947.78 1106.08,-954.77"/>
+<text text-anchor="middle" x="1034.65" y="-980.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node8" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="762.32,-842 762.32,-864 930.32,-864 930.32,-842 762.32,-842"/>
+<polygon fill="none" stroke="black" points="762.32,-842 762.32,-864 930.32,-864 930.32,-842 762.32,-842"/>
+<text text-anchor="start" x="824.94" y="-849.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="762.32,-820 762.32,-842 930.32,-842 930.32,-820 762.32,-820"/>
+<text text-anchor="start" x="807.25" y="-827.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-827.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-798 762.32,-820 930.32,-820 930.32,-798 762.32,-798"/>
+<text text-anchor="start" x="788.97" y="-805.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-776 762.32,-798 930.32,-798 930.32,-776 762.32,-776"/>
+<text text-anchor="start" x="790.92" y="-783.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="841.86" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-754 762.32,-776 930.32,-776 930.32,-754 762.32,-754"/>
+<text text-anchor="start" x="789.36" y="-761.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="843.42" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-732 762.32,-754 930.32,-754 930.32,-732 762.32,-732"/>
+<text text-anchor="start" x="813.86" y="-739.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="843.02" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-710 762.32,-732 930.32,-732 930.32,-710 762.32,-710"/>
+<text text-anchor="start" x="798.7" y="-717.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="858.18" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-688 762.32,-710 930.32,-710 930.32,-688 762.32,-688"/>
+<text text-anchor="start" x="791.31" y="-695.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="841.47" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-666 762.32,-688 930.32,-688 930.32,-666 762.32,-666"/>
+<text text-anchor="start" x="801.81" y="-673.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="855.07" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-644 762.32,-666 930.32,-666 930.32,-644 762.32,-644"/>
+<text text-anchor="start" x="787.03" y="-651.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="845.74" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-622 762.32,-644 930.32,-644 930.32,-622 762.32,-622"/>
+<text text-anchor="start" x="788.59" y="-629.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="844.18" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-600 762.32,-622 930.32,-622 930.32,-600 762.32,-600"/>
+<text text-anchor="start" x="791.7" y="-607.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="864.4" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="762.32,-578 762.32,-600 930.32,-600 930.32,-578 762.32,-578"/>
+<text text-anchor="start" x="781.59" y="-585.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="851.19" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-556 762.32,-578 930.32,-578 930.32,-556 762.32,-556"/>
+<text text-anchor="start" x="774.2" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="882.68" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-534 762.32,-556 930.32,-556 930.32,-534 762.32,-534"/>
+<text text-anchor="start" x="765.26" y="-541.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="891.62" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="762.32,-512 762.32,-534 930.32,-534 930.32,-512 762.32,-512"/>
+<polygon fill="none" stroke="black" points="762.32,-512 762.32,-534 930.32,-534 930.32,-512 762.32,-512"/>
+<text text-anchor="start" x="826.11" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="762.32,-490 762.32,-512 930.32,-512 930.32,-490 762.32,-490"/>
+<text text-anchor="start" x="780.61" y="-496.4" font-family="Times,serif" font-size="14.00">index_seasons_trakt_id</text>
+<polygon fill="none" stroke="black" points="762.32,-468 762.32,-490 930.32,-490 930.32,-468 762.32,-468"/>
+<text text-anchor="start" x="778.67" y="-474.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M931.32,-809C1031.31,-809 1013.83,-941.46 1105.8,-950.51"/>
+<polygon fill="black" stroke="black" points="1105.83,-954.02 1115.98,-951 1106.16,-947.03 1105.83,-954.02"/>
+<text text-anchor="middle" x="1034.65" y="-913.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node9" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="402.16,-864 402.16,-886 577.16,-886 577.16,-864 402.16,-864"/>
+<polygon fill="none" stroke="black" points="402.16,-864 402.16,-886 577.16,-886 577.16,-864 402.16,-864"/>
+<text text-anchor="start" x="465.56" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="402.16,-842 402.16,-864 577.16,-864 577.16,-842 402.16,-842"/>
+<text text-anchor="start" x="450.59" y="-849.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="468.87" y="-849.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-820 402.16,-842 577.16,-842 577.16,-820 402.16,-820"/>
+<text text-anchor="start" x="428.43" y="-827.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="491.03" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-798 402.16,-820 577.16,-820 577.16,-798 402.16,-798"/>
+<text text-anchor="start" x="434.26" y="-805.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="485.2" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-776 402.16,-798 577.16,-798 577.16,-776 402.16,-776"/>
+<text text-anchor="start" x="432.7" y="-783.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="486.76" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-754 402.16,-776 577.16,-776 577.16,-754 402.16,-754"/>
+<text text-anchor="start" x="457.19" y="-761.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="486.36" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-732 402.16,-754 577.16,-754 577.16,-732 402.16,-732"/>
+<text text-anchor="start" x="442.04" y="-739.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="501.52" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-710 402.16,-732 577.16,-732 577.16,-710 402.16,-710"/>
+<text text-anchor="start" x="434.65" y="-717.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="484.8" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-688 402.16,-710 577.16,-710 577.16,-688 402.16,-688"/>
+<text text-anchor="start" x="439.32" y="-695.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="504.24" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-666 402.16,-688 577.16,-688 577.16,-666 402.16,-666"/>
+<text text-anchor="start" x="435.03" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="507.74" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="402.16,-644 402.16,-666 577.16,-666 577.16,-644 402.16,-644"/>
+<text text-anchor="start" x="405.1" y="-651.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="514.35" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-622 402.16,-644 577.16,-644 577.16,-622 402.16,-622"/>
+<text text-anchor="start" x="408.59" y="-629.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="534.96" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="402.16,-600 402.16,-622 577.16,-622 577.16,-600 402.16,-600"/>
+<polygon fill="none" stroke="black" points="402.16,-600 402.16,-622 577.16,-622 577.16,-600 402.16,-600"/>
+<text text-anchor="start" x="469.45" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="402.16,-578 402.16,-600 577.16,-600 577.16,-578 402.16,-578"/>
+<text text-anchor="start" x="421.23" y="-584.4" font-family="Times,serif" font-size="14.00">index_episodes_trakt_id</text>
+<polygon fill="none" stroke="black" points="402.16,-556 402.16,-578 577.16,-578 577.16,-556 402.16,-556"/>
+<text text-anchor="start" x="415.4" y="-562.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M576.66,-831C655.21,-831 677.37,-831 751.07,-831"/>
+<polygon fill="black" stroke="black" points="751.32,-834.5 761.32,-831 751.32,-827.5 751.32,-834.5"/>
+<text text-anchor="middle" x="657.99" y="-835.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node10" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="739.32,-410 739.32,-432 953.32,-432 953.32,-410 739.32,-410"/>
+<polygon fill="none" stroke="black" points="739.32,-410 739.32,-432 953.32,-432 953.32,-410 739.32,-410"/>
+<text text-anchor="start" x="806.28" y="-417.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="739.32,-388 739.32,-410 953.32,-410 953.32,-388 739.32,-388"/>
+<text text-anchor="start" x="807.25" y="-395.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-395.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-366 739.32,-388 953.32,-388 953.32,-366 739.32,-366"/>
+<text text-anchor="start" x="788.97" y="-373.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-344 739.32,-366 953.32,-366 953.32,-344 739.32,-344"/>
+<text text-anchor="start" x="771.09" y="-351.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="861.69" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-322 739.32,-344 953.32,-344 953.32,-322 739.32,-322"/>
+<text text-anchor="start" x="778.87" y="-329.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="853.9" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="739.32,-300 739.32,-322 953.32,-322 953.32,-300 739.32,-300"/>
+<polygon fill="none" stroke="black" points="739.32,-300 739.32,-322 953.32,-322 953.32,-300 739.32,-300"/>
+<text text-anchor="start" x="826.11" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="739.32,-278 739.32,-300 953.32,-300 953.32,-278 739.32,-278"/>
+<text text-anchor="start" x="760.01" y="-284.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="739.32,-256 739.32,-278 953.32,-278 953.32,-256 739.32,-256"/>
+<text text-anchor="start" x="742.12" y="-262.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-355C1091.42,-355 1007.64,-518.97 1043.98,-652.2 1061.01,-714.62 1049.1,-926.9 1105.85,-949.12"/>
+<polygon fill="black" stroke="black" points="1105.51,-952.61 1115.98,-951 1106.79,-945.73 1105.51,-952.61"/>
+<text text-anchor="middle" x="1034.65" y="-656.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-377C1021.23,-377 1006.74,-608.68 1025.32,-674 1042.07,-732.89 1050.29,-927.97 1105.85,-949.13"/>
+<polygon fill="black" stroke="black" points="1105.51,-952.63 1115.98,-951 1106.78,-945.75 1105.51,-952.63"/>
+<text text-anchor="middle" x="1034.65" y="-787.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node11" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-886 0.5,-908 239.5,-908 239.5,-886 0.5,-886"/>
+<polygon fill="none" stroke="black" points="0.5,-886 0.5,-908 239.5,-908 239.5,-886 0.5,-886"/>
+<text text-anchor="start" x="56.25" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-864 0.5,-886 239.5,-886 239.5,-864 0.5,-864"/>
+<text text-anchor="start" x="80.93" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-871.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-842 0.5,-864 239.5,-864 239.5,-842 0.5,-842"/>
+<text text-anchor="start" x="56.04" y="-849.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-820 0.5,-842 239.5,-842 239.5,-820 0.5,-820"/>
+<text text-anchor="start" x="64.6" y="-827.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-798 0.5,-820 239.5,-820 239.5,-798 0.5,-798"/>
+<text text-anchor="start" x="66.55" y="-805.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-776 0.5,-798 239.5,-798 239.5,-776 0.5,-776"/>
+<text text-anchor="start" x="55.26" y="-783.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-754 0.5,-776 239.5,-776 239.5,-754 0.5,-754"/>
+<polygon fill="none" stroke="black" points="0.5,-754 0.5,-776 239.5,-776 239.5,-754 0.5,-754"/>
+<text text-anchor="start" x="99.79" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-732 0.5,-754 239.5,-754 239.5,-732 0.5,-732"/>
+<text text-anchor="start" x="3.37" y="-738.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-710 0.5,-732 239.5,-732 239.5,-710 0.5,-710"/>
+<text text-anchor="start" x="11.92" y="-716.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-853C307.76,-853 327.47,-853 391.45,-853"/>
+<polygon fill="black" stroke="black" points="391.66,-856.5 401.66,-853 391.66,-849.5 391.66,-856.5"/>
+<text text-anchor="middle" x="320.33" y="-857.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node12" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1478 9.5,-1500 229.5,-1500 229.5,-1478 9.5,-1478"/>
+<polygon fill="none" stroke="black" points="9.5,-1478 9.5,-1500 229.5,-1500 229.5,-1478 9.5,-1478"/>
+<text text-anchor="start" x="83.34" y="-1485.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1456 9.5,-1478 229.5,-1478 229.5,-1456 9.5,-1456"/>
+<text text-anchor="start" x="80.43" y="-1463.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1463.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1434 9.5,-1456 229.5,-1456 229.5,-1434 9.5,-1434"/>
+<text text-anchor="start" x="77.71" y="-1441.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1441.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1412 9.5,-1434 229.5,-1434 229.5,-1412 9.5,-1412"/>
+<text text-anchor="start" x="60.98" y="-1419.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1419.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1390 9.5,-1412 229.5,-1412 229.5,-1390 9.5,-1390"/>
+<text text-anchor="start" x="56.71" y="-1397.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1397.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-1368 9.5,-1390 229.5,-1390 229.5,-1368 9.5,-1368"/>
+<polygon fill="none" stroke="black" points="9.5,-1368 9.5,-1390 229.5,-1390 229.5,-1368 9.5,-1368"/>
+<text text-anchor="start" x="99.29" y="-1375.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-1346 9.5,-1368 229.5,-1368 229.5,-1346 9.5,-1346"/>
+<text text-anchor="start" x="12.19" y="-1352.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+<!-- show_images -->
+<g id="node13" class="node">
+<title>show_images</title>
+<polygon fill="#caff70" stroke="transparent" points="759.32,-198 759.32,-220 933.32,-220 933.32,-198 759.32,-198"/>
+<polygon fill="none" stroke="black" points="759.32,-198 759.32,-220 933.32,-220 933.32,-198 759.32,-198"/>
+<text text-anchor="start" x="808.22" y="-205.4" font-family="Times,serif" font-weight="bold" font-size="14.00">show_images</text>
+<polygon fill="none" stroke="black" points="759.32,-176 759.32,-198 933.32,-198 933.32,-176 759.32,-176"/>
+<text text-anchor="start" x="807.25" y="-183.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-183.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-154 759.32,-176 933.32,-176 933.32,-154 759.32,-154"/>
+<text text-anchor="start" x="788.97" y="-161.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-161.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-132 759.32,-154 933.32,-154 933.32,-132 759.32,-132"/>
+<text text-anchor="start" x="812.69" y="-139.4" font-family="Times,serif" font-size="14.00">path: </text>
+<text text-anchor="start" x="844.19" y="-139.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-110 759.32,-132 933.32,-132 933.32,-110 759.32,-110"/>
+<text text-anchor="start" x="812.69" y="-117.4" font-family="Times,serif" font-size="14.00">type: </text>
+<text text-anchor="start" x="844.19" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-88 759.32,-110 933.32,-110 933.32,-88 759.32,-88"/>
+<text text-anchor="start" x="812.69" y="-95.4" font-family="Times,serif" font-size="14.00">lang: </text>
+<text text-anchor="start" x="844.19" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-66 759.32,-88 933.32,-88 933.32,-66 759.32,-66"/>
+<text text-anchor="start" x="808.02" y="-73.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="848.07" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="759.32,-44 759.32,-66 933.32,-66 933.32,-44 759.32,-44"/>
+<text text-anchor="start" x="782.37" y="-51.4" font-family="Times,serif" font-size="14.00">is_primary: </text>
+<text text-anchor="start" x="850.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="759.32,-22 759.32,-44 933.32,-44 933.32,-22 759.32,-22"/>
+<polygon fill="none" stroke="black" points="759.32,-22 759.32,-44 933.32,-44 933.32,-22 759.32,-22"/>
+<text text-anchor="start" x="826.11" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="759.32,0 759.32,-22 933.32,-22 933.32,0 759.32,0"/>
+<text text-anchor="start" x="761.94" y="-6.4" font-family="Times,serif" font-size="14.00">index_show_images_show_id</text>
+</g>
+<!-- show_images&#45;&gt;shows -->
+<g id="edge10" class="edge">
+<title>show_images:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M934.32,-165C1036.94,-165 1012.78,-270.43 1043.98,-368.2 1082.57,-489.12 990.75,-926.18 1105.78,-949.99"/>
+<polygon fill="black" stroke="black" points="1105.69,-953.5 1115.98,-951 1106.38,-946.53 1105.69,-953.5"/>
+<text text-anchor="middle" x="1034.65" y="-372.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviRoomDatabase/23.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviRoomDatabase/23.svg
@@ -1,0 +1,504 @@
+<svg width="1363px" height="1718px"
+ viewBox="0.00 0.00 1362.98 1718.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1682)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1682 1326.98,-1682 1326.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1116.48,-1001 1116.48,-1023 1291.48,-1023 1291.48,-1001 1116.48,-1001"/>
+<polygon fill="none" stroke="black" points="1116.48,-1001 1116.48,-1023 1291.48,-1023 1291.48,-1001 1116.48,-1001"/>
+<text text-anchor="start" x="1186.48" y="-1008.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1116.48,-979 1116.48,-1001 1291.48,-1001 1291.48,-979 1116.48,-979"/>
+<text text-anchor="start" x="1164.91" y="-986.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1183.19" y="-986.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-957 1116.48,-979 1291.48,-979 1291.48,-957 1116.48,-957"/>
+<text text-anchor="start" x="1171.52" y="-964.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1200.68" y="-964.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-935 1116.48,-957 1291.48,-957 1291.48,-935 1116.48,-935"/>
+<text text-anchor="start" x="1146.24" y="-942.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1225.96" y="-942.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-913 1116.48,-935 1291.48,-935 1291.48,-913 1116.48,-913"/>
+<text text-anchor="start" x="1148.58" y="-920.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1199.52" y="-920.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-891 1116.48,-913 1291.48,-913 1291.48,-891 1116.48,-891"/>
+<text text-anchor="start" x="1147.02" y="-898.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1201.08" y="-898.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-869 1116.48,-891 1291.48,-891 1291.48,-869 1116.48,-869"/>
+<text text-anchor="start" x="1159.07" y="-876.4" font-family="Times,serif" font-size="14.00">imdb_id: </text>
+<text text-anchor="start" x="1213.13" y="-876.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-847 1116.48,-869 1291.48,-869 1291.48,-847 1116.48,-847"/>
+<text text-anchor="start" x="1156.36" y="-854.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1215.84" y="-854.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-825 1116.48,-847 1291.48,-847 1291.48,-825 1116.48,-825"/>
+<text text-anchor="start" x="1153.64" y="-832.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1218.56" y="-832.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-803 1116.48,-825 1291.48,-825 1291.48,-803 1116.48,-803"/>
+<text text-anchor="start" x="1149.36" y="-810.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1222.06" y="-810.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1116.48,-781 1116.48,-803 1291.48,-803 1291.48,-781 1116.48,-781"/>
+<text text-anchor="start" x="1148.59" y="-788.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1223.61" y="-788.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-759 1116.48,-781 1291.48,-781 1291.48,-759 1116.48,-759"/>
+<text text-anchor="start" x="1153.64" y="-766.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1218.56" y="-766.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-737 1116.48,-759 1291.48,-759 1291.48,-737 1116.48,-737"/>
+<text text-anchor="start" x="1161.02" y="-744.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1211.18" y="-744.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-715 1116.48,-737 1291.48,-737 1291.48,-715 1116.48,-715"/>
+<text text-anchor="start" x="1159.47" y="-722.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1212.73" y="-722.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-693 1116.48,-715 1291.48,-715 1291.48,-693 1116.48,-693"/>
+<text text-anchor="start" x="1148.58" y="-700.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1199.52" y="-700.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-671 1116.48,-693 1291.48,-693 1291.48,-671 1116.48,-671"/>
+<text text-anchor="start" x="1164.14" y="-678.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1208.06" y="-678.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-649 1116.48,-671 1291.48,-671 1291.48,-649 1116.48,-649"/>
+<text text-anchor="start" x="1119.04" y="-656.4" font-family="Times,serif" font-size="14.00">last_trakt_data_update: </text>
+<text text-anchor="start" x="1253.16" y="-656.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1116.48,-627 1116.48,-649 1291.48,-649 1291.48,-627 1116.48,-627"/>
+<polygon fill="none" stroke="black" points="1116.48,-627 1116.48,-649 1291.48,-649 1291.48,-627 1116.48,-627"/>
+<text text-anchor="start" x="1183.77" y="-634.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1116.48,-605 1116.48,-627 1291.48,-627 1291.48,-605 1116.48,-605"/>
+<text text-anchor="start" x="1142.16" y="-611.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1116.48,-583 1116.48,-605 1291.48,-605 1291.48,-583 1116.48,-583"/>
+<text text-anchor="start" x="1140.6" y="-589.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- shows_fts -->
+<g id="node2" class="node">
+<title>shows_fts</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-1010 59.5,-1032 180.5,-1032 180.5,-1010 59.5,-1010"/>
+<polygon fill="none" stroke="black" points="59.5,-1010 59.5,-1032 180.5,-1032 180.5,-1010 59.5,-1010"/>
+<text text-anchor="start" x="92" y="-1017.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows_fts</text>
+<polygon fill="none" stroke="black" points="59.5,-988 59.5,-1010 180.5,-1010 180.5,-988 59.5,-988"/>
+<text text-anchor="start" x="87.53" y="-995.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="116.7" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-966 59.5,-988 180.5,-988 180.5,-966 59.5,-966"/>
+<text text-anchor="start" x="62.26" y="-973.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="141.98" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- trending_shows -->
+<g id="node3" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="753.32,-1624 753.32,-1646 940.32,-1646 940.32,-1624 753.32,-1624"/>
+<polygon fill="none" stroke="black" points="753.32,-1624 753.32,-1646 940.32,-1646 940.32,-1624 753.32,-1624"/>
+<text text-anchor="start" x="802.5" y="-1631.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="753.32,-1602 753.32,-1624 940.32,-1624 940.32,-1602 753.32,-1602"/>
+<text text-anchor="start" x="807.75" y="-1609.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1609.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1580 753.32,-1602 940.32,-1602 940.32,-1580 753.32,-1580"/>
+<text text-anchor="start" x="789.47" y="-1587.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1587.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1558 753.32,-1580 940.32,-1580 940.32,-1558 753.32,-1558"/>
+<text text-anchor="start" x="799.98" y="-1565.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1565.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1536 753.32,-1558 940.32,-1558 940.32,-1536 753.32,-1536"/>
+<text text-anchor="start" x="788.32" y="-1543.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="845.46" y="-1543.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="753.32,-1514 753.32,-1536 940.32,-1536 940.32,-1514 753.32,-1514"/>
+<polygon fill="none" stroke="black" points="753.32,-1514 753.32,-1536 940.32,-1536 940.32,-1514 753.32,-1514"/>
+<text text-anchor="start" x="826.61" y="-1521.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="753.32,-1492 753.32,-1514 940.32,-1514 940.32,-1492 753.32,-1492"/>
+<text text-anchor="start" x="756.22" y="-1498.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M941.32,-1591C973.85,-1591 1067.95,-1064.98 1108.42,-997.17"/>
+<polygon fill="black" stroke="black" points="1111.13,-999.42 1115.98,-990 1106.32,-994.34 1111.13,-999.42"/>
+<text text-anchor="middle" x="1034.65" y="-1294.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node4" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="755.32,-1434 755.32,-1456 938.32,-1456 938.32,-1434 755.32,-1434"/>
+<polygon fill="none" stroke="black" points="755.32,-1434 755.32,-1456 938.32,-1456 938.32,-1434 755.32,-1434"/>
+<text text-anchor="start" x="804.44" y="-1441.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="755.32,-1412 755.32,-1434 938.32,-1434 938.32,-1412 755.32,-1412"/>
+<text text-anchor="start" x="807.75" y="-1419.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1419.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1390 755.32,-1412 938.32,-1412 938.32,-1390 755.32,-1390"/>
+<text text-anchor="start" x="789.47" y="-1397.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1397.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1368 755.32,-1390 938.32,-1390 938.32,-1368 755.32,-1368"/>
+<text text-anchor="start" x="799.98" y="-1375.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1375.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1346 755.32,-1368 938.32,-1368 938.32,-1346 755.32,-1346"/>
+<text text-anchor="start" x="781.71" y="-1353.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="852.06" y="-1353.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="755.32,-1324 755.32,-1346 938.32,-1346 938.32,-1324 755.32,-1324"/>
+<polygon fill="none" stroke="black" points="755.32,-1324 755.32,-1346 938.32,-1346 938.32,-1324 755.32,-1324"/>
+<text text-anchor="start" x="826.61" y="-1331.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="755.32,-1302 755.32,-1324 938.32,-1324 938.32,-1302 755.32,-1302"/>
+<text text-anchor="start" x="758.17" y="-1308.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M939.32,-1401C986.02,-1401 1057.02,-1038.26 1106.66,-994.34"/>
+<polygon fill="black" stroke="black" points="1108.39,-997.39 1115.98,-990 1105.44,-991.05 1108.39,-997.39"/>
+<text text-anchor="middle" x="1034.65" y="-1199.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node5" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-1310 53.5,-1332 186.5,-1332 186.5,-1310 53.5,-1310"/>
+<polygon fill="none" stroke="black" points="53.5,-1310 53.5,-1332 186.5,-1332 186.5,-1310 53.5,-1310"/>
+<text text-anchor="start" x="105.62" y="-1317.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-1288 53.5,-1310 186.5,-1310 186.5,-1288 53.5,-1288"/>
+<text text-anchor="start" x="80.93" y="-1295.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-1295.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-1266 53.5,-1288 186.5,-1288 186.5,-1266 53.5,-1266"/>
+<text text-anchor="start" x="71.6" y="-1273.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-1273.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1244 53.5,-1266 186.5,-1266 186.5,-1244 53.5,-1244"/>
+<text text-anchor="start" x="83.26" y="-1251.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-1251.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1222 53.5,-1244 186.5,-1244 186.5,-1222 53.5,-1222"/>
+<text text-anchor="start" x="65.76" y="-1229.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-1229.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1200 53.5,-1222 186.5,-1222 186.5,-1200 53.5,-1200"/>
+<text text-anchor="start" x="75.87" y="-1207.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-1207.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1178 53.5,-1200 186.5,-1200 186.5,-1178 53.5,-1178"/>
+<text text-anchor="start" x="82.87" y="-1185.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-1185.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1156 53.5,-1178 186.5,-1178 186.5,-1156 53.5,-1156"/>
+<text text-anchor="start" x="70.05" y="-1163.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1134 53.5,-1156 186.5,-1156 186.5,-1134 53.5,-1134"/>
+<text text-anchor="start" x="77.43" y="-1141.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-1112 53.5,-1134 186.5,-1134 186.5,-1112 53.5,-1112"/>
+<text text-anchor="start" x="69.65" y="-1119.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-1119.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-1090 53.5,-1112 186.5,-1112 186.5,-1090 53.5,-1090"/>
+<polygon fill="none" stroke="black" points="53.5,-1090 53.5,-1112 186.5,-1112 186.5,-1090 53.5,-1090"/>
+<text text-anchor="start" x="99.79" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-1068 53.5,-1090 186.5,-1090 186.5,-1068 53.5,-1068"/>
+<text text-anchor="start" x="56.25" y="-1074.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node6" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="752.32,-1244 752.32,-1266 941.32,-1266 941.32,-1244 752.32,-1244"/>
+<polygon fill="none" stroke="black" points="752.32,-1244 752.32,-1266 941.32,-1266 941.32,-1244 752.32,-1244"/>
+<text text-anchor="start" x="801.34" y="-1251.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="752.32,-1222 752.32,-1244 941.32,-1244 941.32,-1222 752.32,-1222"/>
+<text text-anchor="start" x="807.75" y="-1229.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1229.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-1200 752.32,-1222 941.32,-1222 941.32,-1200 752.32,-1200"/>
+<text text-anchor="start" x="789.47" y="-1207.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1207.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-1178 752.32,-1200 941.32,-1200 941.32,-1178 752.32,-1178"/>
+<text text-anchor="start" x="788.7" y="-1185.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="869.17" y="-1185.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="752.32,-1156 752.32,-1178 941.32,-1178 941.32,-1156 752.32,-1156"/>
+<polygon fill="none" stroke="black" points="752.32,-1156 752.32,-1178 941.32,-1178 941.32,-1156 752.32,-1156"/>
+<text text-anchor="start" x="826.61" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="752.32,-1134 752.32,-1156 941.32,-1156 941.32,-1134 752.32,-1134"/>
+<text text-anchor="start" x="755.07" y="-1140.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M942.32,-1211C1063.7,-1211 995.22,-1002.34 1105.84,-990.52"/>
+<polygon fill="black" stroke="black" points="1106.17,-994.01 1115.98,-990 1105.82,-987.02 1106.17,-994.01"/>
+<text text-anchor="middle" x="1034.65" y="-1117.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node7" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="749.32,-1076 749.32,-1098 944.32,-1098 944.32,-1076 749.32,-1076"/>
+<polygon fill="none" stroke="black" points="749.32,-1076 749.32,-1098 944.32,-1098 944.32,-1076 749.32,-1076"/>
+<text text-anchor="start" x="798.22" y="-1083.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="749.32,-1054 749.32,-1076 944.32,-1076 944.32,-1054 749.32,-1054"/>
+<text text-anchor="start" x="807.75" y="-1061.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1061.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-1032 749.32,-1054 944.32,-1054 944.32,-1032 749.32,-1032"/>
+<text text-anchor="start" x="789.47" y="-1039.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1039.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-1010 749.32,-1032 944.32,-1032 944.32,-1010 749.32,-1010"/>
+<text text-anchor="start" x="791.81" y="-1017.4" font-family="Times,serif" font-size="14.00">followed_at: </text>
+<text text-anchor="start" x="866.07" y="-1017.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="749.32,-988 749.32,-1010 944.32,-1010 944.32,-988 749.32,-988"/>
+<text text-anchor="start" x="782.09" y="-995.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="875.79" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="749.32,-966 749.32,-988 944.32,-988 944.32,-966 749.32,-966"/>
+<text text-anchor="start" x="791.42" y="-973.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="842.36" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="749.32,-944 749.32,-966 944.32,-966 944.32,-944 749.32,-944"/>
+<polygon fill="none" stroke="black" points="749.32,-944 749.32,-966 944.32,-966 944.32,-944 749.32,-944"/>
+<text text-anchor="start" x="826.61" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="749.32,-922 749.32,-944 944.32,-944 944.32,-922 749.32,-922"/>
+<text text-anchor="start" x="751.95" y="-928.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M945.32,-1043C1021.18,-1043 1035.36,-994.65 1105.68,-990.31"/>
+<polygon fill="black" stroke="black" points="1106.09,-993.8 1115.98,-990 1105.88,-986.8 1106.09,-993.8"/>
+<text text-anchor="middle" x="1034.65" y="-1022.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node8" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="762.32,-864 762.32,-886 930.32,-886 930.32,-864 762.32,-864"/>
+<polygon fill="none" stroke="black" points="762.32,-864 762.32,-886 930.32,-886 930.32,-864 762.32,-864"/>
+<text text-anchor="start" x="824.94" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="762.32,-842 762.32,-864 930.32,-864 930.32,-842 762.32,-842"/>
+<text text-anchor="start" x="807.25" y="-849.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-849.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-820 762.32,-842 930.32,-842 930.32,-820 762.32,-820"/>
+<text text-anchor="start" x="788.97" y="-827.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-798 762.32,-820 930.32,-820 930.32,-798 762.32,-798"/>
+<text text-anchor="start" x="790.92" y="-805.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="841.86" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-776 762.32,-798 930.32,-798 930.32,-776 762.32,-776"/>
+<text text-anchor="start" x="789.36" y="-783.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="843.42" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-754 762.32,-776 930.32,-776 930.32,-754 762.32,-754"/>
+<text text-anchor="start" x="813.86" y="-761.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="843.02" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-732 762.32,-754 930.32,-754 930.32,-732 762.32,-732"/>
+<text text-anchor="start" x="798.7" y="-739.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="858.18" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-710 762.32,-732 930.32,-732 930.32,-710 762.32,-710"/>
+<text text-anchor="start" x="791.31" y="-717.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="841.47" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-688 762.32,-710 930.32,-710 930.32,-688 762.32,-688"/>
+<text text-anchor="start" x="801.81" y="-695.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="855.07" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-666 762.32,-688 930.32,-688 930.32,-666 762.32,-666"/>
+<text text-anchor="start" x="787.03" y="-673.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="845.74" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-644 762.32,-666 930.32,-666 930.32,-644 762.32,-644"/>
+<text text-anchor="start" x="788.59" y="-651.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="844.18" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-622 762.32,-644 930.32,-644 930.32,-622 762.32,-622"/>
+<text text-anchor="start" x="791.7" y="-629.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="864.4" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="762.32,-600 762.32,-622 930.32,-622 930.32,-600 762.32,-600"/>
+<text text-anchor="start" x="781.59" y="-607.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="851.19" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-578 762.32,-600 930.32,-600 930.32,-578 762.32,-578"/>
+<text text-anchor="start" x="774.2" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="882.68" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-556 762.32,-578 930.32,-578 930.32,-556 762.32,-556"/>
+<text text-anchor="start" x="765.26" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="891.62" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-534 762.32,-556 930.32,-556 930.32,-534 762.32,-534"/>
+<text text-anchor="start" x="791.31" y="-541.4" font-family="Times,serif" font-size="14.00">ignored: </text>
+<text text-anchor="start" x="841.47" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="762.32,-512 762.32,-534 930.32,-534 930.32,-512 762.32,-512"/>
+<polygon fill="none" stroke="black" points="762.32,-512 762.32,-534 930.32,-534 930.32,-512 762.32,-512"/>
+<text text-anchor="start" x="826.11" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="762.32,-490 762.32,-512 930.32,-512 930.32,-490 762.32,-490"/>
+<text text-anchor="start" x="780.61" y="-496.4" font-family="Times,serif" font-size="14.00">index_seasons_trakt_id</text>
+<polygon fill="none" stroke="black" points="762.32,-468 762.32,-490 930.32,-490 930.32,-468 762.32,-468"/>
+<text text-anchor="start" x="778.67" y="-474.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M931.32,-831C1036.13,-831 1009.59,-979.92 1105.94,-989.52"/>
+<polygon fill="black" stroke="black" points="1105.82,-993.01 1115.98,-990 1106.16,-986.02 1105.82,-993.01"/>
+<text text-anchor="middle" x="1034.65" y="-951.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node9" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="402.16,-886 402.16,-908 577.16,-908 577.16,-886 402.16,-886"/>
+<polygon fill="none" stroke="black" points="402.16,-886 402.16,-908 577.16,-908 577.16,-886 402.16,-886"/>
+<text text-anchor="start" x="465.56" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="402.16,-864 402.16,-886 577.16,-886 577.16,-864 402.16,-864"/>
+<text text-anchor="start" x="450.59" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="468.87" y="-871.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-842 402.16,-864 577.16,-864 577.16,-842 402.16,-842"/>
+<text text-anchor="start" x="428.43" y="-849.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="491.03" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-820 402.16,-842 577.16,-842 577.16,-820 402.16,-820"/>
+<text text-anchor="start" x="434.26" y="-827.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="485.2" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-798 402.16,-820 577.16,-820 577.16,-798 402.16,-798"/>
+<text text-anchor="start" x="432.7" y="-805.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="486.76" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-776 402.16,-798 577.16,-798 577.16,-776 402.16,-776"/>
+<text text-anchor="start" x="457.19" y="-783.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="486.36" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-754 402.16,-776 577.16,-776 577.16,-754 402.16,-754"/>
+<text text-anchor="start" x="442.04" y="-761.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="501.52" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-732 402.16,-754 577.16,-754 577.16,-732 402.16,-732"/>
+<text text-anchor="start" x="434.65" y="-739.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="484.8" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-710 402.16,-732 577.16,-732 577.16,-710 402.16,-710"/>
+<text text-anchor="start" x="439.32" y="-717.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="504.24" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-688 402.16,-710 577.16,-710 577.16,-688 402.16,-688"/>
+<text text-anchor="start" x="435.03" y="-695.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="507.74" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="402.16,-666 402.16,-688 577.16,-688 577.16,-666 402.16,-666"/>
+<text text-anchor="start" x="405.1" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="514.35" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-644 402.16,-666 577.16,-666 577.16,-644 402.16,-644"/>
+<text text-anchor="start" x="408.59" y="-651.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="534.96" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="402.16,-622 402.16,-644 577.16,-644 577.16,-622 402.16,-622"/>
+<polygon fill="none" stroke="black" points="402.16,-622 402.16,-644 577.16,-644 577.16,-622 402.16,-622"/>
+<text text-anchor="start" x="469.45" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="402.16,-600 402.16,-622 577.16,-622 577.16,-600 402.16,-600"/>
+<text text-anchor="start" x="421.23" y="-606.4" font-family="Times,serif" font-size="14.00">index_episodes_trakt_id</text>
+<polygon fill="none" stroke="black" points="402.16,-578 402.16,-600 577.16,-600 577.16,-578 402.16,-578"/>
+<text text-anchor="start" x="415.4" y="-584.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M576.66,-853C655.21,-853 677.37,-853 751.07,-853"/>
+<polygon fill="black" stroke="black" points="751.32,-856.5 761.32,-853 751.32,-849.5 751.32,-856.5"/>
+<text text-anchor="middle" x="657.99" y="-857.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node10" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="739.32,-410 739.32,-432 953.32,-432 953.32,-410 739.32,-410"/>
+<polygon fill="none" stroke="black" points="739.32,-410 739.32,-432 953.32,-432 953.32,-410 739.32,-410"/>
+<text text-anchor="start" x="806.28" y="-417.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="739.32,-388 739.32,-410 953.32,-410 953.32,-388 739.32,-388"/>
+<text text-anchor="start" x="807.25" y="-395.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-395.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-366 739.32,-388 953.32,-388 953.32,-366 739.32,-366"/>
+<text text-anchor="start" x="788.97" y="-373.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-344 739.32,-366 953.32,-366 953.32,-344 739.32,-344"/>
+<text text-anchor="start" x="771.09" y="-351.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="861.69" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-322 739.32,-344 953.32,-344 953.32,-322 739.32,-322"/>
+<text text-anchor="start" x="778.87" y="-329.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="853.9" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="739.32,-300 739.32,-322 953.32,-322 953.32,-300 739.32,-300"/>
+<polygon fill="none" stroke="black" points="739.32,-300 739.32,-322 953.32,-322 953.32,-300 739.32,-300"/>
+<text text-anchor="start" x="826.11" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="739.32,-278 739.32,-300 953.32,-300 953.32,-278 739.32,-278"/>
+<text text-anchor="start" x="760.01" y="-284.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="739.32,-256 739.32,-278 953.32,-278 953.32,-256 739.32,-256"/>
+<text text-anchor="start" x="742.12" y="-262.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-355C1100.8,-355 1007.43,-531.32 1043.98,-674.2 1060.95,-740.53 1045.66,-966.39 1106.07,-988.29"/>
+<polygon fill="black" stroke="black" points="1105.53,-991.75 1115.98,-990 1106.72,-984.85 1105.53,-991.75"/>
+<text text-anchor="middle" x="1034.65" y="-678.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-377C1025.99,-377 1006.6,-625.78 1025.32,-696 1042.04,-758.71 1047.1,-967.27 1106.05,-988.29"/>
+<polygon fill="black" stroke="black" points="1105.53,-991.75 1115.98,-990 1106.72,-984.85 1105.53,-991.75"/>
+<text text-anchor="middle" x="1034.65" y="-816.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node11" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-908 0.5,-930 239.5,-930 239.5,-908 0.5,-908"/>
+<polygon fill="none" stroke="black" points="0.5,-908 0.5,-930 239.5,-930 239.5,-908 0.5,-908"/>
+<text text-anchor="start" x="56.25" y="-915.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-886 0.5,-908 239.5,-908 239.5,-886 0.5,-886"/>
+<text text-anchor="start" x="80.93" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-893.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-864 0.5,-886 239.5,-886 239.5,-864 0.5,-864"/>
+<text text-anchor="start" x="56.04" y="-871.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-871.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-842 0.5,-864 239.5,-864 239.5,-842 0.5,-842"/>
+<text text-anchor="start" x="64.6" y="-849.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-820 0.5,-842 239.5,-842 239.5,-820 0.5,-820"/>
+<text text-anchor="start" x="66.55" y="-827.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-798 0.5,-820 239.5,-820 239.5,-798 0.5,-798"/>
+<text text-anchor="start" x="55.26" y="-805.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-776 0.5,-798 239.5,-798 239.5,-776 0.5,-776"/>
+<polygon fill="none" stroke="black" points="0.5,-776 0.5,-798 239.5,-798 239.5,-776 0.5,-776"/>
+<text text-anchor="start" x="99.79" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-754 0.5,-776 239.5,-776 239.5,-754 0.5,-754"/>
+<text text-anchor="start" x="3.37" y="-760.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-732 0.5,-754 239.5,-754 239.5,-732 0.5,-732"/>
+<text text-anchor="start" x="11.92" y="-738.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-875C307.76,-875 327.47,-875 391.45,-875"/>
+<polygon fill="black" stroke="black" points="391.66,-878.5 401.66,-875 391.66,-871.5 391.66,-878.5"/>
+<text text-anchor="middle" x="320.33" y="-879.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node12" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1500 9.5,-1522 229.5,-1522 229.5,-1500 9.5,-1500"/>
+<polygon fill="none" stroke="black" points="9.5,-1500 9.5,-1522 229.5,-1522 229.5,-1500 9.5,-1500"/>
+<text text-anchor="start" x="83.34" y="-1507.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1478 9.5,-1500 229.5,-1500 229.5,-1478 9.5,-1478"/>
+<text text-anchor="start" x="80.43" y="-1485.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1485.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1456 9.5,-1478 229.5,-1478 229.5,-1456 9.5,-1456"/>
+<text text-anchor="start" x="77.71" y="-1463.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1463.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1434 9.5,-1456 229.5,-1456 229.5,-1434 9.5,-1434"/>
+<text text-anchor="start" x="60.98" y="-1441.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1441.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1412 9.5,-1434 229.5,-1434 229.5,-1412 9.5,-1412"/>
+<text text-anchor="start" x="56.71" y="-1419.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1419.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-1390 9.5,-1412 229.5,-1412 229.5,-1390 9.5,-1390"/>
+<polygon fill="none" stroke="black" points="9.5,-1390 9.5,-1412 229.5,-1412 229.5,-1390 9.5,-1390"/>
+<text text-anchor="start" x="99.29" y="-1397.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-1368 9.5,-1390 229.5,-1390 229.5,-1368 9.5,-1368"/>
+<text text-anchor="start" x="12.19" y="-1374.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+<!-- show_images -->
+<g id="node13" class="node">
+<title>show_images</title>
+<polygon fill="#caff70" stroke="transparent" points="759.32,-198 759.32,-220 933.32,-220 933.32,-198 759.32,-198"/>
+<polygon fill="none" stroke="black" points="759.32,-198 759.32,-220 933.32,-220 933.32,-198 759.32,-198"/>
+<text text-anchor="start" x="808.22" y="-205.4" font-family="Times,serif" font-weight="bold" font-size="14.00">show_images</text>
+<polygon fill="none" stroke="black" points="759.32,-176 759.32,-198 933.32,-198 933.32,-176 759.32,-176"/>
+<text text-anchor="start" x="807.25" y="-183.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-183.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-154 759.32,-176 933.32,-176 933.32,-154 759.32,-154"/>
+<text text-anchor="start" x="788.97" y="-161.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-161.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-132 759.32,-154 933.32,-154 933.32,-132 759.32,-132"/>
+<text text-anchor="start" x="812.69" y="-139.4" font-family="Times,serif" font-size="14.00">path: </text>
+<text text-anchor="start" x="844.19" y="-139.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-110 759.32,-132 933.32,-132 933.32,-110 759.32,-110"/>
+<text text-anchor="start" x="812.69" y="-117.4" font-family="Times,serif" font-size="14.00">type: </text>
+<text text-anchor="start" x="844.19" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-88 759.32,-110 933.32,-110 933.32,-88 759.32,-88"/>
+<text text-anchor="start" x="812.69" y="-95.4" font-family="Times,serif" font-size="14.00">lang: </text>
+<text text-anchor="start" x="844.19" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-66 759.32,-88 933.32,-88 933.32,-66 759.32,-66"/>
+<text text-anchor="start" x="808.02" y="-73.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="848.07" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="759.32,-44 759.32,-66 933.32,-66 933.32,-44 759.32,-44"/>
+<text text-anchor="start" x="782.37" y="-51.4" font-family="Times,serif" font-size="14.00">is_primary: </text>
+<text text-anchor="start" x="850.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="759.32,-22 759.32,-44 933.32,-44 933.32,-22 759.32,-22"/>
+<polygon fill="none" stroke="black" points="759.32,-22 759.32,-44 933.32,-44 933.32,-22 759.32,-22"/>
+<text text-anchor="start" x="826.11" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="759.32,0 759.32,-22 933.32,-22 933.32,0 759.32,0"/>
+<text text-anchor="start" x="761.94" y="-6.4" font-family="Times,serif" font-size="14.00">index_show_images_show_id</text>
+</g>
+<!-- show_images&#45;&gt;shows -->
+<g id="edge10" class="edge">
+<title>show_images:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M934.32,-165C1034.22,-165 1013.33,-266.12 1043.98,-361.2 1064.5,-424.86 1047.5,-936.31 1106.31,-986.1"/>
+<polygon fill="black" stroke="black" points="1105.4,-989.51 1115.98,-990 1108.01,-983.02 1105.4,-989.51"/>
+<text text-anchor="middle" x="1034.65" y="-365.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviRoomDatabase/24.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviRoomDatabase/24.svg
@@ -1,0 +1,507 @@
+<svg width="1363px" height="1718px"
+ viewBox="0.00 0.00 1362.98 1718.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1682)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1682 1326.98,-1682 1326.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1116.48,-1001 1116.48,-1023 1291.48,-1023 1291.48,-1001 1116.48,-1001"/>
+<polygon fill="none" stroke="black" points="1116.48,-1001 1116.48,-1023 1291.48,-1023 1291.48,-1001 1116.48,-1001"/>
+<text text-anchor="start" x="1186.48" y="-1008.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1116.48,-979 1116.48,-1001 1291.48,-1001 1291.48,-979 1116.48,-979"/>
+<text text-anchor="start" x="1164.91" y="-986.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1183.19" y="-986.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-957 1116.48,-979 1291.48,-979 1291.48,-957 1116.48,-957"/>
+<text text-anchor="start" x="1171.52" y="-964.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1200.68" y="-964.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-935 1116.48,-957 1291.48,-957 1291.48,-935 1116.48,-935"/>
+<text text-anchor="start" x="1146.24" y="-942.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1225.96" y="-942.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-913 1116.48,-935 1291.48,-935 1291.48,-913 1116.48,-913"/>
+<text text-anchor="start" x="1148.58" y="-920.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1199.52" y="-920.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-891 1116.48,-913 1291.48,-913 1291.48,-891 1116.48,-891"/>
+<text text-anchor="start" x="1147.02" y="-898.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1201.08" y="-898.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-869 1116.48,-891 1291.48,-891 1291.48,-869 1116.48,-869"/>
+<text text-anchor="start" x="1159.07" y="-876.4" font-family="Times,serif" font-size="14.00">imdb_id: </text>
+<text text-anchor="start" x="1213.13" y="-876.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-847 1116.48,-869 1291.48,-869 1291.48,-847 1116.48,-847"/>
+<text text-anchor="start" x="1156.36" y="-854.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1215.84" y="-854.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-825 1116.48,-847 1291.48,-847 1291.48,-825 1116.48,-825"/>
+<text text-anchor="start" x="1153.64" y="-832.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1218.56" y="-832.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-803 1116.48,-825 1291.48,-825 1291.48,-803 1116.48,-803"/>
+<text text-anchor="start" x="1149.36" y="-810.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1222.06" y="-810.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1116.48,-781 1116.48,-803 1291.48,-803 1291.48,-781 1116.48,-781"/>
+<text text-anchor="start" x="1148.59" y="-788.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1223.61" y="-788.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-759 1116.48,-781 1291.48,-781 1291.48,-759 1116.48,-759"/>
+<text text-anchor="start" x="1153.64" y="-766.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1218.56" y="-766.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-737 1116.48,-759 1291.48,-759 1291.48,-737 1116.48,-737"/>
+<text text-anchor="start" x="1161.02" y="-744.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1211.18" y="-744.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-715 1116.48,-737 1291.48,-737 1291.48,-715 1116.48,-715"/>
+<text text-anchor="start" x="1159.47" y="-722.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1212.73" y="-722.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-693 1116.48,-715 1291.48,-715 1291.48,-693 1116.48,-693"/>
+<text text-anchor="start" x="1148.58" y="-700.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1199.52" y="-700.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1116.48,-671 1116.48,-693 1291.48,-693 1291.48,-671 1116.48,-671"/>
+<text text-anchor="start" x="1164.14" y="-678.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1208.06" y="-678.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-649 1116.48,-671 1291.48,-671 1291.48,-649 1116.48,-649"/>
+<text text-anchor="start" x="1119.04" y="-656.4" font-family="Times,serif" font-size="14.00">last_trakt_data_update: </text>
+<text text-anchor="start" x="1253.16" y="-656.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1116.48,-627 1116.48,-649 1291.48,-649 1291.48,-627 1116.48,-627"/>
+<text text-anchor="start" x="1166.46" y="-634.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="1205.74" y="-634.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1116.48,-605 1116.48,-627 1291.48,-627 1291.48,-605 1116.48,-605"/>
+<polygon fill="none" stroke="black" points="1116.48,-605 1116.48,-627 1291.48,-627 1291.48,-605 1116.48,-605"/>
+<text text-anchor="start" x="1183.77" y="-612.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1116.48,-583 1116.48,-605 1291.48,-605 1291.48,-583 1116.48,-583"/>
+<text text-anchor="start" x="1142.16" y="-589.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1116.48,-561 1116.48,-583 1291.48,-583 1291.48,-561 1116.48,-561"/>
+<text text-anchor="start" x="1140.6" y="-567.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- shows_fts -->
+<g id="node2" class="node">
+<title>shows_fts</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-1010 59.5,-1032 180.5,-1032 180.5,-1010 59.5,-1010"/>
+<polygon fill="none" stroke="black" points="59.5,-1010 59.5,-1032 180.5,-1032 180.5,-1010 59.5,-1010"/>
+<text text-anchor="start" x="92" y="-1017.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows_fts</text>
+<polygon fill="none" stroke="black" points="59.5,-988 59.5,-1010 180.5,-1010 180.5,-988 59.5,-988"/>
+<text text-anchor="start" x="87.53" y="-995.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="116.7" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-966 59.5,-988 180.5,-988 180.5,-966 59.5,-966"/>
+<text text-anchor="start" x="62.26" y="-973.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="141.98" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- trending_shows -->
+<g id="node3" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="753.32,-1624 753.32,-1646 940.32,-1646 940.32,-1624 753.32,-1624"/>
+<polygon fill="none" stroke="black" points="753.32,-1624 753.32,-1646 940.32,-1646 940.32,-1624 753.32,-1624"/>
+<text text-anchor="start" x="802.5" y="-1631.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="753.32,-1602 753.32,-1624 940.32,-1624 940.32,-1602 753.32,-1602"/>
+<text text-anchor="start" x="807.75" y="-1609.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1609.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1580 753.32,-1602 940.32,-1602 940.32,-1580 753.32,-1580"/>
+<text text-anchor="start" x="789.47" y="-1587.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1587.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1558 753.32,-1580 940.32,-1580 940.32,-1558 753.32,-1558"/>
+<text text-anchor="start" x="799.98" y="-1565.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1565.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1536 753.32,-1558 940.32,-1558 940.32,-1536 753.32,-1536"/>
+<text text-anchor="start" x="788.32" y="-1543.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="845.46" y="-1543.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="753.32,-1514 753.32,-1536 940.32,-1536 940.32,-1514 753.32,-1514"/>
+<polygon fill="none" stroke="black" points="753.32,-1514 753.32,-1536 940.32,-1536 940.32,-1514 753.32,-1514"/>
+<text text-anchor="start" x="826.61" y="-1521.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="753.32,-1492 753.32,-1514 940.32,-1514 940.32,-1492 753.32,-1492"/>
+<text text-anchor="start" x="756.22" y="-1498.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M941.32,-1591C973.85,-1591 1067.95,-1064.98 1108.42,-997.17"/>
+<polygon fill="black" stroke="black" points="1111.13,-999.42 1115.98,-990 1106.32,-994.34 1111.13,-999.42"/>
+<text text-anchor="middle" x="1034.65" y="-1294.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node4" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="755.32,-1434 755.32,-1456 938.32,-1456 938.32,-1434 755.32,-1434"/>
+<polygon fill="none" stroke="black" points="755.32,-1434 755.32,-1456 938.32,-1456 938.32,-1434 755.32,-1434"/>
+<text text-anchor="start" x="804.44" y="-1441.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="755.32,-1412 755.32,-1434 938.32,-1434 938.32,-1412 755.32,-1412"/>
+<text text-anchor="start" x="807.75" y="-1419.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1419.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1390 755.32,-1412 938.32,-1412 938.32,-1390 755.32,-1390"/>
+<text text-anchor="start" x="789.47" y="-1397.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1397.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1368 755.32,-1390 938.32,-1390 938.32,-1368 755.32,-1368"/>
+<text text-anchor="start" x="799.98" y="-1375.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="833.8" y="-1375.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="755.32,-1346 755.32,-1368 938.32,-1368 938.32,-1346 755.32,-1346"/>
+<text text-anchor="start" x="781.71" y="-1353.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="852.06" y="-1353.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="755.32,-1324 755.32,-1346 938.32,-1346 938.32,-1324 755.32,-1324"/>
+<polygon fill="none" stroke="black" points="755.32,-1324 755.32,-1346 938.32,-1346 938.32,-1324 755.32,-1324"/>
+<text text-anchor="start" x="826.61" y="-1331.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="755.32,-1302 755.32,-1324 938.32,-1324 938.32,-1302 755.32,-1302"/>
+<text text-anchor="start" x="758.17" y="-1308.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M939.32,-1401C986.02,-1401 1057.02,-1038.26 1106.66,-994.34"/>
+<polygon fill="black" stroke="black" points="1108.39,-997.39 1115.98,-990 1105.44,-991.05 1108.39,-997.39"/>
+<text text-anchor="middle" x="1034.65" y="-1199.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node5" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-1310 53.5,-1332 186.5,-1332 186.5,-1310 53.5,-1310"/>
+<polygon fill="none" stroke="black" points="53.5,-1310 53.5,-1332 186.5,-1332 186.5,-1310 53.5,-1310"/>
+<text text-anchor="start" x="105.62" y="-1317.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-1288 53.5,-1310 186.5,-1310 186.5,-1288 53.5,-1288"/>
+<text text-anchor="start" x="80.93" y="-1295.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-1295.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-1266 53.5,-1288 186.5,-1288 186.5,-1266 53.5,-1266"/>
+<text text-anchor="start" x="71.6" y="-1273.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-1273.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1244 53.5,-1266 186.5,-1266 186.5,-1244 53.5,-1244"/>
+<text text-anchor="start" x="83.26" y="-1251.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-1251.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1222 53.5,-1244 186.5,-1244 186.5,-1222 53.5,-1222"/>
+<text text-anchor="start" x="65.76" y="-1229.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-1229.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1200 53.5,-1222 186.5,-1222 186.5,-1200 53.5,-1200"/>
+<text text-anchor="start" x="75.87" y="-1207.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-1207.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1178 53.5,-1200 186.5,-1200 186.5,-1178 53.5,-1178"/>
+<text text-anchor="start" x="82.87" y="-1185.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-1185.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1156 53.5,-1178 186.5,-1178 186.5,-1156 53.5,-1156"/>
+<text text-anchor="start" x="70.05" y="-1163.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1134 53.5,-1156 186.5,-1156 186.5,-1134 53.5,-1134"/>
+<text text-anchor="start" x="77.43" y="-1141.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-1112 53.5,-1134 186.5,-1134 186.5,-1112 53.5,-1112"/>
+<text text-anchor="start" x="69.65" y="-1119.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-1119.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-1090 53.5,-1112 186.5,-1112 186.5,-1090 53.5,-1090"/>
+<polygon fill="none" stroke="black" points="53.5,-1090 53.5,-1112 186.5,-1112 186.5,-1090 53.5,-1090"/>
+<text text-anchor="start" x="99.79" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-1068 53.5,-1090 186.5,-1090 186.5,-1068 53.5,-1068"/>
+<text text-anchor="start" x="56.25" y="-1074.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node6" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="752.32,-1244 752.32,-1266 941.32,-1266 941.32,-1244 752.32,-1244"/>
+<polygon fill="none" stroke="black" points="752.32,-1244 752.32,-1266 941.32,-1266 941.32,-1244 752.32,-1244"/>
+<text text-anchor="start" x="801.34" y="-1251.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="752.32,-1222 752.32,-1244 941.32,-1244 941.32,-1222 752.32,-1222"/>
+<text text-anchor="start" x="807.75" y="-1229.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1229.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-1200 752.32,-1222 941.32,-1222 941.32,-1200 752.32,-1200"/>
+<text text-anchor="start" x="789.47" y="-1207.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1207.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="752.32,-1178 752.32,-1200 941.32,-1200 941.32,-1178 752.32,-1178"/>
+<text text-anchor="start" x="788.7" y="-1185.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="869.17" y="-1185.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="752.32,-1156 752.32,-1178 941.32,-1178 941.32,-1156 752.32,-1156"/>
+<polygon fill="none" stroke="black" points="752.32,-1156 752.32,-1178 941.32,-1178 941.32,-1156 752.32,-1156"/>
+<text text-anchor="start" x="826.61" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="752.32,-1134 752.32,-1156 941.32,-1156 941.32,-1134 752.32,-1134"/>
+<text text-anchor="start" x="755.07" y="-1140.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M942.32,-1211C1063.7,-1211 995.22,-1002.34 1105.84,-990.52"/>
+<polygon fill="black" stroke="black" points="1106.17,-994.01 1115.98,-990 1105.82,-987.02 1106.17,-994.01"/>
+<text text-anchor="middle" x="1034.65" y="-1117.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node7" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="749.32,-1076 749.32,-1098 944.32,-1098 944.32,-1076 749.32,-1076"/>
+<polygon fill="none" stroke="black" points="749.32,-1076 749.32,-1098 944.32,-1098 944.32,-1076 749.32,-1076"/>
+<text text-anchor="start" x="798.22" y="-1083.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="749.32,-1054 749.32,-1076 944.32,-1076 944.32,-1054 749.32,-1054"/>
+<text text-anchor="start" x="807.75" y="-1061.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="826.03" y="-1061.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-1032 749.32,-1054 944.32,-1054 944.32,-1032 749.32,-1032"/>
+<text text-anchor="start" x="789.47" y="-1039.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="844.3" y="-1039.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="749.32,-1010 749.32,-1032 944.32,-1032 944.32,-1010 749.32,-1010"/>
+<text text-anchor="start" x="791.81" y="-1017.4" font-family="Times,serif" font-size="14.00">followed_at: </text>
+<text text-anchor="start" x="866.07" y="-1017.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="749.32,-988 749.32,-1010 944.32,-1010 944.32,-988 749.32,-988"/>
+<text text-anchor="start" x="782.09" y="-995.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="875.79" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="749.32,-966 749.32,-988 944.32,-988 944.32,-966 749.32,-966"/>
+<text text-anchor="start" x="791.42" y="-973.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="842.36" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="749.32,-944 749.32,-966 944.32,-966 944.32,-944 749.32,-944"/>
+<polygon fill="none" stroke="black" points="749.32,-944 749.32,-966 944.32,-966 944.32,-944 749.32,-944"/>
+<text text-anchor="start" x="826.61" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="749.32,-922 749.32,-944 944.32,-944 944.32,-922 749.32,-922"/>
+<text text-anchor="start" x="751.95" y="-928.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M945.32,-1043C1021.18,-1043 1035.36,-994.65 1105.68,-990.31"/>
+<polygon fill="black" stroke="black" points="1106.09,-993.8 1115.98,-990 1105.88,-986.8 1106.09,-993.8"/>
+<text text-anchor="middle" x="1034.65" y="-1022.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node8" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="762.32,-864 762.32,-886 930.32,-886 930.32,-864 762.32,-864"/>
+<polygon fill="none" stroke="black" points="762.32,-864 762.32,-886 930.32,-886 930.32,-864 762.32,-864"/>
+<text text-anchor="start" x="824.94" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="762.32,-842 762.32,-864 930.32,-864 930.32,-842 762.32,-842"/>
+<text text-anchor="start" x="807.25" y="-849.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-849.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-820 762.32,-842 930.32,-842 930.32,-820 762.32,-820"/>
+<text text-anchor="start" x="788.97" y="-827.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-798 762.32,-820 930.32,-820 930.32,-798 762.32,-798"/>
+<text text-anchor="start" x="790.92" y="-805.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="841.86" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-776 762.32,-798 930.32,-798 930.32,-776 762.32,-776"/>
+<text text-anchor="start" x="789.36" y="-783.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="843.42" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-754 762.32,-776 930.32,-776 930.32,-754 762.32,-754"/>
+<text text-anchor="start" x="813.86" y="-761.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="843.02" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-732 762.32,-754 930.32,-754 930.32,-732 762.32,-732"/>
+<text text-anchor="start" x="798.7" y="-739.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="858.18" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-710 762.32,-732 930.32,-732 930.32,-710 762.32,-710"/>
+<text text-anchor="start" x="791.31" y="-717.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="841.47" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-688 762.32,-710 930.32,-710 930.32,-688 762.32,-688"/>
+<text text-anchor="start" x="801.81" y="-695.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="855.07" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-666 762.32,-688 930.32,-688 930.32,-666 762.32,-666"/>
+<text text-anchor="start" x="787.03" y="-673.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="845.74" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-644 762.32,-666 930.32,-666 930.32,-644 762.32,-644"/>
+<text text-anchor="start" x="788.59" y="-651.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="844.18" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-622 762.32,-644 930.32,-644 930.32,-622 762.32,-622"/>
+<text text-anchor="start" x="791.7" y="-629.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="864.4" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="762.32,-600 762.32,-622 930.32,-622 930.32,-600 762.32,-600"/>
+<text text-anchor="start" x="781.59" y="-607.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="851.19" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="762.32,-578 762.32,-600 930.32,-600 930.32,-578 762.32,-578"/>
+<text text-anchor="start" x="774.2" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="882.68" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-556 762.32,-578 930.32,-578 930.32,-556 762.32,-556"/>
+<text text-anchor="start" x="765.26" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="891.62" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="762.32,-534 762.32,-556 930.32,-556 930.32,-534 762.32,-534"/>
+<text text-anchor="start" x="791.31" y="-541.4" font-family="Times,serif" font-size="14.00">ignored: </text>
+<text text-anchor="start" x="841.47" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="762.32,-512 762.32,-534 930.32,-534 930.32,-512 762.32,-512"/>
+<polygon fill="none" stroke="black" points="762.32,-512 762.32,-534 930.32,-534 930.32,-512 762.32,-512"/>
+<text text-anchor="start" x="826.11" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="762.32,-490 762.32,-512 930.32,-512 930.32,-490 762.32,-490"/>
+<text text-anchor="start" x="780.61" y="-496.4" font-family="Times,serif" font-size="14.00">index_seasons_trakt_id</text>
+<polygon fill="none" stroke="black" points="762.32,-468 762.32,-490 930.32,-490 930.32,-468 762.32,-468"/>
+<text text-anchor="start" x="778.67" y="-474.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M931.32,-831C1036.13,-831 1009.59,-979.92 1105.94,-989.52"/>
+<polygon fill="black" stroke="black" points="1105.82,-993.01 1115.98,-990 1106.16,-986.02 1105.82,-993.01"/>
+<text text-anchor="middle" x="1034.65" y="-951.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node9" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="402.16,-886 402.16,-908 577.16,-908 577.16,-886 402.16,-886"/>
+<polygon fill="none" stroke="black" points="402.16,-886 402.16,-908 577.16,-908 577.16,-886 402.16,-886"/>
+<text text-anchor="start" x="465.56" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="402.16,-864 402.16,-886 577.16,-886 577.16,-864 402.16,-864"/>
+<text text-anchor="start" x="450.59" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="468.87" y="-871.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-842 402.16,-864 577.16,-864 577.16,-842 402.16,-842"/>
+<text text-anchor="start" x="428.43" y="-849.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="491.03" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-820 402.16,-842 577.16,-842 577.16,-820 402.16,-820"/>
+<text text-anchor="start" x="434.26" y="-827.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="485.2" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-798 402.16,-820 577.16,-820 577.16,-798 402.16,-798"/>
+<text text-anchor="start" x="432.7" y="-805.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="486.76" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-776 402.16,-798 577.16,-798 577.16,-776 402.16,-776"/>
+<text text-anchor="start" x="457.19" y="-783.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="486.36" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-754 402.16,-776 577.16,-776 577.16,-754 402.16,-754"/>
+<text text-anchor="start" x="442.04" y="-761.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="501.52" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-732 402.16,-754 577.16,-754 577.16,-732 402.16,-732"/>
+<text text-anchor="start" x="434.65" y="-739.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="484.8" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-710 402.16,-732 577.16,-732 577.16,-710 402.16,-710"/>
+<text text-anchor="start" x="439.32" y="-717.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="504.24" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-688 402.16,-710 577.16,-710 577.16,-688 402.16,-688"/>
+<text text-anchor="start" x="435.03" y="-695.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="507.74" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="402.16,-666 402.16,-688 577.16,-688 577.16,-666 402.16,-666"/>
+<text text-anchor="start" x="405.1" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="514.35" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-644 402.16,-666 577.16,-666 577.16,-644 402.16,-644"/>
+<text text-anchor="start" x="408.59" y="-651.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="534.96" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="402.16,-622 402.16,-644 577.16,-644 577.16,-622 402.16,-622"/>
+<polygon fill="none" stroke="black" points="402.16,-622 402.16,-644 577.16,-644 577.16,-622 402.16,-622"/>
+<text text-anchor="start" x="469.45" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="402.16,-600 402.16,-622 577.16,-622 577.16,-600 402.16,-600"/>
+<text text-anchor="start" x="421.23" y="-606.4" font-family="Times,serif" font-size="14.00">index_episodes_trakt_id</text>
+<polygon fill="none" stroke="black" points="402.16,-578 402.16,-600 577.16,-600 577.16,-578 402.16,-578"/>
+<text text-anchor="start" x="415.4" y="-584.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M576.66,-853C655.21,-853 677.37,-853 751.07,-853"/>
+<polygon fill="black" stroke="black" points="751.32,-856.5 761.32,-853 751.32,-849.5 751.32,-856.5"/>
+<text text-anchor="middle" x="657.99" y="-857.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node10" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="739.32,-410 739.32,-432 953.32,-432 953.32,-410 739.32,-410"/>
+<polygon fill="none" stroke="black" points="739.32,-410 739.32,-432 953.32,-432 953.32,-410 739.32,-410"/>
+<text text-anchor="start" x="806.28" y="-417.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="739.32,-388 739.32,-410 953.32,-410 953.32,-388 739.32,-388"/>
+<text text-anchor="start" x="807.25" y="-395.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-395.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-366 739.32,-388 953.32,-388 953.32,-366 739.32,-366"/>
+<text text-anchor="start" x="788.97" y="-373.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-344 739.32,-366 953.32,-366 953.32,-344 739.32,-344"/>
+<text text-anchor="start" x="771.09" y="-351.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="861.69" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-322 739.32,-344 953.32,-344 953.32,-322 739.32,-322"/>
+<text text-anchor="start" x="778.87" y="-329.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="853.9" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="739.32,-300 739.32,-322 953.32,-322 953.32,-300 739.32,-300"/>
+<polygon fill="none" stroke="black" points="739.32,-300 739.32,-322 953.32,-322 953.32,-300 739.32,-300"/>
+<text text-anchor="start" x="826.11" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="739.32,-278 739.32,-300 953.32,-300 953.32,-278 739.32,-278"/>
+<text text-anchor="start" x="760.01" y="-284.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="739.32,-256 739.32,-278 953.32,-278 953.32,-256 739.32,-256"/>
+<text text-anchor="start" x="742.12" y="-262.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-355C1100.8,-355 1007.43,-531.32 1043.98,-674.2 1060.95,-740.53 1045.66,-966.39 1106.07,-988.29"/>
+<polygon fill="black" stroke="black" points="1105.53,-991.75 1115.98,-990 1106.72,-984.85 1105.53,-991.75"/>
+<text text-anchor="middle" x="1034.65" y="-678.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M953.32,-377C1025.99,-377 1006.6,-625.78 1025.32,-696 1042.04,-758.71 1047.1,-967.27 1106.05,-988.29"/>
+<polygon fill="black" stroke="black" points="1105.53,-991.75 1115.98,-990 1106.72,-984.85 1105.53,-991.75"/>
+<text text-anchor="middle" x="1034.65" y="-816.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node11" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-908 0.5,-930 239.5,-930 239.5,-908 0.5,-908"/>
+<polygon fill="none" stroke="black" points="0.5,-908 0.5,-930 239.5,-930 239.5,-908 0.5,-908"/>
+<text text-anchor="start" x="56.25" y="-915.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-886 0.5,-908 239.5,-908 239.5,-886 0.5,-886"/>
+<text text-anchor="start" x="80.93" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-893.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-864 0.5,-886 239.5,-886 239.5,-864 0.5,-864"/>
+<text text-anchor="start" x="56.04" y="-871.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-871.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-842 0.5,-864 239.5,-864 239.5,-842 0.5,-842"/>
+<text text-anchor="start" x="64.6" y="-849.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-820 0.5,-842 239.5,-842 239.5,-820 0.5,-820"/>
+<text text-anchor="start" x="66.55" y="-827.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-798 0.5,-820 239.5,-820 239.5,-798 0.5,-798"/>
+<text text-anchor="start" x="55.26" y="-805.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-776 0.5,-798 239.5,-798 239.5,-776 0.5,-776"/>
+<polygon fill="none" stroke="black" points="0.5,-776 0.5,-798 239.5,-798 239.5,-776 0.5,-776"/>
+<text text-anchor="start" x="99.79" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-754 0.5,-776 239.5,-776 239.5,-754 0.5,-754"/>
+<text text-anchor="start" x="3.37" y="-760.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-732 0.5,-754 239.5,-754 239.5,-732 0.5,-732"/>
+<text text-anchor="start" x="11.92" y="-738.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-875C307.76,-875 327.47,-875 391.45,-875"/>
+<polygon fill="black" stroke="black" points="391.66,-878.5 401.66,-875 391.66,-871.5 391.66,-878.5"/>
+<text text-anchor="middle" x="320.33" y="-879.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node12" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1500 9.5,-1522 229.5,-1522 229.5,-1500 9.5,-1500"/>
+<polygon fill="none" stroke="black" points="9.5,-1500 9.5,-1522 229.5,-1522 229.5,-1500 9.5,-1500"/>
+<text text-anchor="start" x="83.34" y="-1507.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1478 9.5,-1500 229.5,-1500 229.5,-1478 9.5,-1478"/>
+<text text-anchor="start" x="80.43" y="-1485.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1485.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1456 9.5,-1478 229.5,-1478 229.5,-1456 9.5,-1456"/>
+<text text-anchor="start" x="77.71" y="-1463.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1463.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1434 9.5,-1456 229.5,-1456 229.5,-1434 9.5,-1434"/>
+<text text-anchor="start" x="60.98" y="-1441.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1441.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1412 9.5,-1434 229.5,-1434 229.5,-1412 9.5,-1412"/>
+<text text-anchor="start" x="56.71" y="-1419.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1419.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-1390 9.5,-1412 229.5,-1412 229.5,-1390 9.5,-1390"/>
+<polygon fill="none" stroke="black" points="9.5,-1390 9.5,-1412 229.5,-1412 229.5,-1390 9.5,-1390"/>
+<text text-anchor="start" x="99.29" y="-1397.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-1368 9.5,-1390 229.5,-1390 229.5,-1368 9.5,-1368"/>
+<text text-anchor="start" x="12.19" y="-1374.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+<!-- show_images -->
+<g id="node13" class="node">
+<title>show_images</title>
+<polygon fill="#caff70" stroke="transparent" points="759.32,-198 759.32,-220 933.32,-220 933.32,-198 759.32,-198"/>
+<polygon fill="none" stroke="black" points="759.32,-198 759.32,-220 933.32,-220 933.32,-198 759.32,-198"/>
+<text text-anchor="start" x="808.22" y="-205.4" font-family="Times,serif" font-weight="bold" font-size="14.00">show_images</text>
+<polygon fill="none" stroke="black" points="759.32,-176 759.32,-198 933.32,-198 933.32,-176 759.32,-176"/>
+<text text-anchor="start" x="807.25" y="-183.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="825.53" y="-183.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-154 759.32,-176 933.32,-176 933.32,-154 759.32,-154"/>
+<text text-anchor="start" x="788.97" y="-161.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="843.8" y="-161.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-132 759.32,-154 933.32,-154 933.32,-132 759.32,-132"/>
+<text text-anchor="start" x="812.69" y="-139.4" font-family="Times,serif" font-size="14.00">path: </text>
+<text text-anchor="start" x="844.19" y="-139.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-110 759.32,-132 933.32,-132 933.32,-110 759.32,-110"/>
+<text text-anchor="start" x="812.69" y="-117.4" font-family="Times,serif" font-size="14.00">type: </text>
+<text text-anchor="start" x="844.19" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-88 759.32,-110 933.32,-110 933.32,-88 759.32,-88"/>
+<text text-anchor="start" x="812.69" y="-95.4" font-family="Times,serif" font-size="14.00">lang: </text>
+<text text-anchor="start" x="844.19" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="759.32,-66 759.32,-88 933.32,-88 933.32,-66 759.32,-66"/>
+<text text-anchor="start" x="808.02" y="-73.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="848.07" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="759.32,-44 759.32,-66 933.32,-66 933.32,-44 759.32,-44"/>
+<text text-anchor="start" x="782.37" y="-51.4" font-family="Times,serif" font-size="14.00">is_primary: </text>
+<text text-anchor="start" x="850.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="759.32,-22 759.32,-44 933.32,-44 933.32,-22 759.32,-22"/>
+<polygon fill="none" stroke="black" points="759.32,-22 759.32,-44 933.32,-44 933.32,-22 759.32,-22"/>
+<text text-anchor="start" x="826.11" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="759.32,0 759.32,-22 933.32,-22 933.32,0 759.32,0"/>
+<text text-anchor="start" x="761.94" y="-6.4" font-family="Times,serif" font-size="14.00">index_show_images_show_id</text>
+</g>
+<!-- show_images&#45;&gt;shows -->
+<g id="edge10" class="edge">
+<title>show_images:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M934.32,-165C1034.22,-165 1013.33,-266.12 1043.98,-361.2 1064.5,-424.86 1047.5,-936.31 1106.31,-986.1"/>
+<polygon fill="black" stroke="black" points="1105.4,-989.51 1115.98,-990 1108.01,-983.02 1105.4,-989.51"/>
+<text text-anchor="middle" x="1034.65" y="-365.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviRoomDatabase/25.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviRoomDatabase/25.svg
@@ -1,0 +1,535 @@
+<svg width="1371px" height="1886px"
+ viewBox="0.00 0.00 1370.98 1886.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1850)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1850 1334.98,-1850 1334.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1124.48,-1010 1124.48,-1032 1299.48,-1032 1299.48,-1010 1124.48,-1010"/>
+<polygon fill="none" stroke="black" points="1124.48,-1010 1124.48,-1032 1299.48,-1032 1299.48,-1010 1124.48,-1010"/>
+<text text-anchor="start" x="1194.48" y="-1017.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1124.48,-988 1124.48,-1010 1299.48,-1010 1299.48,-988 1124.48,-988"/>
+<text text-anchor="start" x="1172.91" y="-995.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1191.19" y="-995.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1124.48,-966 1124.48,-988 1299.48,-988 1299.48,-966 1124.48,-966"/>
+<text text-anchor="start" x="1179.52" y="-973.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1208.68" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-944 1124.48,-966 1299.48,-966 1299.48,-944 1124.48,-944"/>
+<text text-anchor="start" x="1154.24" y="-951.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1233.96" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-922 1124.48,-944 1299.48,-944 1299.48,-922 1124.48,-922"/>
+<text text-anchor="start" x="1156.58" y="-929.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1207.52" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1124.48,-900 1124.48,-922 1299.48,-922 1299.48,-900 1124.48,-900"/>
+<text text-anchor="start" x="1155.02" y="-907.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1209.08" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1124.48,-878 1124.48,-900 1299.48,-900 1299.48,-878 1124.48,-878"/>
+<text text-anchor="start" x="1167.07" y="-885.4" font-family="Times,serif" font-size="14.00">imdb_id: </text>
+<text text-anchor="start" x="1221.13" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-856 1124.48,-878 1299.48,-878 1299.48,-856 1124.48,-856"/>
+<text text-anchor="start" x="1164.36" y="-863.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1223.84" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-834 1124.48,-856 1299.48,-856 1299.48,-834 1124.48,-834"/>
+<text text-anchor="start" x="1161.64" y="-841.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1226.56" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-812 1124.48,-834 1299.48,-834 1299.48,-812 1124.48,-812"/>
+<text text-anchor="start" x="1157.36" y="-819.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1230.06" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1124.48,-790 1124.48,-812 1299.48,-812 1299.48,-790 1124.48,-790"/>
+<text text-anchor="start" x="1156.59" y="-797.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1231.61" y="-797.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-768 1124.48,-790 1299.48,-790 1299.48,-768 1124.48,-768"/>
+<text text-anchor="start" x="1161.64" y="-775.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1226.56" y="-775.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-746 1124.48,-768 1299.48,-768 1299.48,-746 1124.48,-746"/>
+<text text-anchor="start" x="1169.02" y="-753.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1219.18" y="-753.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-724 1124.48,-746 1299.48,-746 1299.48,-724 1124.48,-724"/>
+<text text-anchor="start" x="1167.47" y="-731.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1220.73" y="-731.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-702 1124.48,-724 1299.48,-724 1299.48,-702 1124.48,-702"/>
+<text text-anchor="start" x="1156.58" y="-709.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1207.52" y="-709.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1124.48,-680 1124.48,-702 1299.48,-702 1299.48,-680 1124.48,-680"/>
+<text text-anchor="start" x="1172.14" y="-687.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1216.06" y="-687.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-658 1124.48,-680 1299.48,-680 1299.48,-658 1124.48,-658"/>
+<text text-anchor="start" x="1127.04" y="-665.4" font-family="Times,serif" font-size="14.00">last_trakt_data_update: </text>
+<text text-anchor="start" x="1261.16" y="-665.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-636 1124.48,-658 1299.48,-658 1299.48,-636 1124.48,-636"/>
+<text text-anchor="start" x="1174.46" y="-643.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="1213.74" y="-643.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1124.48,-614 1124.48,-636 1299.48,-636 1299.48,-614 1124.48,-614"/>
+<polygon fill="none" stroke="black" points="1124.48,-614 1124.48,-636 1299.48,-636 1299.48,-614 1124.48,-614"/>
+<text text-anchor="start" x="1191.77" y="-621.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1124.48,-592 1124.48,-614 1299.48,-614 1299.48,-592 1124.48,-592"/>
+<text text-anchor="start" x="1150.16" y="-598.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1124.48,-570 1124.48,-592 1299.48,-592 1299.48,-570 1124.48,-570"/>
+<text text-anchor="start" x="1148.6" y="-576.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- shows_fts -->
+<g id="node2" class="node">
+<title>shows_fts</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-1178 59.5,-1200 180.5,-1200 180.5,-1178 59.5,-1178"/>
+<polygon fill="none" stroke="black" points="59.5,-1178 59.5,-1200 180.5,-1200 180.5,-1178 59.5,-1178"/>
+<text text-anchor="start" x="92" y="-1185.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows_fts</text>
+<polygon fill="none" stroke="black" points="59.5,-1156 59.5,-1178 180.5,-1178 180.5,-1156 59.5,-1156"/>
+<text text-anchor="start" x="87.53" y="-1163.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="116.7" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-1134 59.5,-1156 180.5,-1156 180.5,-1134 59.5,-1134"/>
+<text text-anchor="start" x="62.26" y="-1141.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="141.98" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- trending_shows -->
+<g id="node3" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="757.32,-1792 757.32,-1814 944.32,-1814 944.32,-1792 757.32,-1792"/>
+<polygon fill="none" stroke="black" points="757.32,-1792 757.32,-1814 944.32,-1814 944.32,-1792 757.32,-1792"/>
+<text text-anchor="start" x="806.5" y="-1799.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="757.32,-1770 757.32,-1792 944.32,-1792 944.32,-1770 757.32,-1770"/>
+<text text-anchor="start" x="811.75" y="-1777.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="830.03" y="-1777.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="757.32,-1748 757.32,-1770 944.32,-1770 944.32,-1748 757.32,-1748"/>
+<text text-anchor="start" x="793.47" y="-1755.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="848.3" y="-1755.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="757.32,-1726 757.32,-1748 944.32,-1748 944.32,-1726 757.32,-1726"/>
+<text text-anchor="start" x="803.98" y="-1733.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="837.8" y="-1733.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="757.32,-1704 757.32,-1726 944.32,-1726 944.32,-1704 757.32,-1704"/>
+<text text-anchor="start" x="792.32" y="-1711.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="849.46" y="-1711.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="757.32,-1682 757.32,-1704 944.32,-1704 944.32,-1682 757.32,-1682"/>
+<polygon fill="none" stroke="black" points="757.32,-1682 757.32,-1704 944.32,-1704 944.32,-1682 757.32,-1682"/>
+<text text-anchor="start" x="830.61" y="-1689.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="757.32,-1660 757.32,-1682 944.32,-1682 944.32,-1660 757.32,-1660"/>
+<text text-anchor="start" x="760.22" y="-1666.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M945.32,-1759C1150.43,-1759 1005.15,-1509.69 1051.98,-1310 1067.36,-1244.44 1054.5,-1023.13 1113.83,-1000.82"/>
+<polygon fill="black" stroke="black" points="1114.75,-1004.21 1123.98,-999 1113.52,-997.32 1114.75,-1004.21"/>
+<text text-anchor="middle" x="1042.65" y="-1729.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node4" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="759.32,-1602 759.32,-1624 942.32,-1624 942.32,-1602 759.32,-1602"/>
+<polygon fill="none" stroke="black" points="759.32,-1602 759.32,-1624 942.32,-1624 942.32,-1602 759.32,-1602"/>
+<text text-anchor="start" x="808.44" y="-1609.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="759.32,-1580 759.32,-1602 942.32,-1602 942.32,-1580 759.32,-1580"/>
+<text text-anchor="start" x="811.75" y="-1587.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="830.03" y="-1587.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-1558 759.32,-1580 942.32,-1580 942.32,-1558 759.32,-1558"/>
+<text text-anchor="start" x="793.47" y="-1565.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="848.3" y="-1565.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-1536 759.32,-1558 942.32,-1558 942.32,-1536 759.32,-1536"/>
+<text text-anchor="start" x="803.98" y="-1543.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="837.8" y="-1543.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-1514 759.32,-1536 942.32,-1536 942.32,-1514 759.32,-1514"/>
+<text text-anchor="start" x="785.71" y="-1521.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="856.06" y="-1521.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="759.32,-1492 759.32,-1514 942.32,-1514 942.32,-1492 759.32,-1492"/>
+<polygon fill="none" stroke="black" points="759.32,-1492 759.32,-1514 942.32,-1514 942.32,-1492 759.32,-1492"/>
+<text text-anchor="start" x="830.61" y="-1499.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="759.32,-1470 759.32,-1492 942.32,-1492 942.32,-1470 759.32,-1470"/>
+<text text-anchor="start" x="762.17" y="-1476.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M943.32,-1569C958.73,-1569 1086.75,-1078.41 1118.43,-1007.5"/>
+<polygon fill="black" stroke="black" points="1121.44,-1009.29 1123.98,-999 1115.58,-1005.46 1121.44,-1009.29"/>
+<text text-anchor="middle" x="1042.65" y="-1288.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node5" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-1478 53.5,-1500 186.5,-1500 186.5,-1478 53.5,-1478"/>
+<polygon fill="none" stroke="black" points="53.5,-1478 53.5,-1500 186.5,-1500 186.5,-1478 53.5,-1478"/>
+<text text-anchor="start" x="105.62" y="-1485.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-1456 53.5,-1478 186.5,-1478 186.5,-1456 53.5,-1456"/>
+<text text-anchor="start" x="80.93" y="-1463.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-1463.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-1434 53.5,-1456 186.5,-1456 186.5,-1434 53.5,-1434"/>
+<text text-anchor="start" x="71.6" y="-1441.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-1441.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1412 53.5,-1434 186.5,-1434 186.5,-1412 53.5,-1412"/>
+<text text-anchor="start" x="83.26" y="-1419.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-1419.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1390 53.5,-1412 186.5,-1412 186.5,-1390 53.5,-1390"/>
+<text text-anchor="start" x="65.76" y="-1397.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-1397.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1368 53.5,-1390 186.5,-1390 186.5,-1368 53.5,-1368"/>
+<text text-anchor="start" x="75.87" y="-1375.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-1375.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1346 53.5,-1368 186.5,-1368 186.5,-1346 53.5,-1346"/>
+<text text-anchor="start" x="82.87" y="-1353.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-1353.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1324 53.5,-1346 186.5,-1346 186.5,-1324 53.5,-1324"/>
+<text text-anchor="start" x="70.05" y="-1331.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-1331.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1302 53.5,-1324 186.5,-1324 186.5,-1302 53.5,-1302"/>
+<text text-anchor="start" x="77.43" y="-1309.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-1309.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-1280 53.5,-1302 186.5,-1302 186.5,-1280 53.5,-1280"/>
+<text text-anchor="start" x="69.65" y="-1287.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-1258 53.5,-1280 186.5,-1280 186.5,-1258 53.5,-1258"/>
+<polygon fill="none" stroke="black" points="53.5,-1258 53.5,-1280 186.5,-1280 186.5,-1258 53.5,-1258"/>
+<text text-anchor="start" x="99.79" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-1236 53.5,-1258 186.5,-1258 186.5,-1236 53.5,-1236"/>
+<text text-anchor="start" x="56.25" y="-1242.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node6" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="756.32,-1412 756.32,-1434 945.32,-1434 945.32,-1412 756.32,-1412"/>
+<polygon fill="none" stroke="black" points="756.32,-1412 756.32,-1434 945.32,-1434 945.32,-1412 756.32,-1412"/>
+<text text-anchor="start" x="805.34" y="-1419.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="756.32,-1390 756.32,-1412 945.32,-1412 945.32,-1390 756.32,-1390"/>
+<text text-anchor="start" x="811.75" y="-1397.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="830.03" y="-1397.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="756.32,-1368 756.32,-1390 945.32,-1390 945.32,-1368 756.32,-1368"/>
+<text text-anchor="start" x="793.47" y="-1375.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="848.3" y="-1375.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="756.32,-1346 756.32,-1368 945.32,-1368 945.32,-1346 756.32,-1346"/>
+<text text-anchor="start" x="792.7" y="-1353.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="873.17" y="-1353.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="756.32,-1324 756.32,-1346 945.32,-1346 945.32,-1324 756.32,-1324"/>
+<polygon fill="none" stroke="black" points="756.32,-1324 756.32,-1346 945.32,-1346 945.32,-1324 756.32,-1324"/>
+<text text-anchor="start" x="830.61" y="-1331.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="756.32,-1302 756.32,-1324 945.32,-1324 945.32,-1302 756.32,-1302"/>
+<text text-anchor="start" x="759.07" y="-1308.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M946.32,-1379C967.76,-1379 1080.38,-1057.42 1116.42,-1005.92"/>
+<polygon fill="black" stroke="black" points="1118.97,-1008.33 1123.98,-999 1114.24,-1003.17 1118.97,-1008.33"/>
+<text text-anchor="middle" x="1042.65" y="-1193.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node7" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="753.32,-1244 753.32,-1266 948.32,-1266 948.32,-1244 753.32,-1244"/>
+<polygon fill="none" stroke="black" points="753.32,-1244 753.32,-1266 948.32,-1266 948.32,-1244 753.32,-1244"/>
+<text text-anchor="start" x="802.22" y="-1251.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="753.32,-1222 753.32,-1244 948.32,-1244 948.32,-1222 753.32,-1222"/>
+<text text-anchor="start" x="811.75" y="-1229.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="830.03" y="-1229.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1200 753.32,-1222 948.32,-1222 948.32,-1200 753.32,-1200"/>
+<text text-anchor="start" x="793.47" y="-1207.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="848.3" y="-1207.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1178 753.32,-1200 948.32,-1200 948.32,-1178 753.32,-1178"/>
+<text text-anchor="start" x="795.81" y="-1185.4" font-family="Times,serif" font-size="14.00">followed_at: </text>
+<text text-anchor="start" x="870.07" y="-1185.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="753.32,-1156 753.32,-1178 948.32,-1178 948.32,-1156 753.32,-1156"/>
+<text text-anchor="start" x="786.09" y="-1163.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="879.79" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="753.32,-1134 753.32,-1156 948.32,-1156 948.32,-1134 753.32,-1134"/>
+<text text-anchor="start" x="795.42" y="-1141.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="846.36" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="753.32,-1112 753.32,-1134 948.32,-1134 948.32,-1112 753.32,-1112"/>
+<polygon fill="none" stroke="black" points="753.32,-1112 753.32,-1134 948.32,-1134 948.32,-1112 753.32,-1112"/>
+<text text-anchor="start" x="830.61" y="-1119.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="753.32,-1090 753.32,-1112 948.32,-1112 948.32,-1090 753.32,-1090"/>
+<text text-anchor="start" x="755.95" y="-1096.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M949.32,-1211C1067.83,-1211 1005.81,-1011.24 1113.74,-999.54"/>
+<polygon fill="black" stroke="black" points="1114.18,-1003.02 1123.98,-999 1113.81,-996.03 1114.18,-1003.02"/>
+<text text-anchor="middle" x="1042.65" y="-1121.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node8" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="766.32,-1032 766.32,-1054 934.32,-1054 934.32,-1032 766.32,-1032"/>
+<polygon fill="none" stroke="black" points="766.32,-1032 766.32,-1054 934.32,-1054 934.32,-1032 766.32,-1032"/>
+<text text-anchor="start" x="828.94" y="-1039.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="766.32,-1010 766.32,-1032 934.32,-1032 934.32,-1010 766.32,-1010"/>
+<text text-anchor="start" x="811.25" y="-1017.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="829.53" y="-1017.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="766.32,-988 766.32,-1010 934.32,-1010 934.32,-988 766.32,-988"/>
+<text text-anchor="start" x="792.97" y="-995.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="847.8" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="766.32,-966 766.32,-988 934.32,-988 934.32,-966 766.32,-966"/>
+<text text-anchor="start" x="794.92" y="-973.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="845.86" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="766.32,-944 766.32,-966 934.32,-966 934.32,-944 766.32,-944"/>
+<text text-anchor="start" x="793.36" y="-951.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="847.42" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="766.32,-922 766.32,-944 934.32,-944 934.32,-922 766.32,-922"/>
+<text text-anchor="start" x="817.86" y="-929.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="847.02" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="766.32,-900 766.32,-922 934.32,-922 934.32,-900 766.32,-900"/>
+<text text-anchor="start" x="802.7" y="-907.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="862.18" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="766.32,-878 766.32,-900 934.32,-900 934.32,-878 766.32,-878"/>
+<text text-anchor="start" x="795.31" y="-885.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="845.47" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="766.32,-856 766.32,-878 934.32,-878 934.32,-856 766.32,-856"/>
+<text text-anchor="start" x="805.81" y="-863.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="859.07" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="766.32,-834 766.32,-856 934.32,-856 934.32,-834 766.32,-834"/>
+<text text-anchor="start" x="791.03" y="-841.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="849.74" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="766.32,-812 766.32,-834 934.32,-834 934.32,-812 766.32,-812"/>
+<text text-anchor="start" x="792.59" y="-819.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="848.18" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="766.32,-790 766.32,-812 934.32,-812 934.32,-790 766.32,-790"/>
+<text text-anchor="start" x="795.7" y="-797.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="868.4" y="-797.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="766.32,-768 766.32,-790 934.32,-790 934.32,-768 766.32,-768"/>
+<text text-anchor="start" x="785.59" y="-775.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="855.19" y="-775.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="766.32,-746 766.32,-768 934.32,-768 934.32,-746 766.32,-746"/>
+<text text-anchor="start" x="778.2" y="-753.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="886.68" y="-753.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="766.32,-724 766.32,-746 934.32,-746 934.32,-724 766.32,-724"/>
+<text text-anchor="start" x="769.26" y="-731.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="895.62" y="-731.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="766.32,-702 766.32,-724 934.32,-724 934.32,-702 766.32,-702"/>
+<text text-anchor="start" x="795.31" y="-709.4" font-family="Times,serif" font-size="14.00">ignored: </text>
+<text text-anchor="start" x="845.47" y="-709.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="766.32,-680 766.32,-702 934.32,-702 934.32,-680 766.32,-680"/>
+<polygon fill="none" stroke="black" points="766.32,-680 766.32,-702 934.32,-702 934.32,-680 766.32,-680"/>
+<text text-anchor="start" x="830.11" y="-687.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="766.32,-658 766.32,-680 934.32,-680 934.32,-658 766.32,-658"/>
+<text text-anchor="start" x="784.61" y="-664.4" font-family="Times,serif" font-size="14.00">index_seasons_trakt_id</text>
+<polygon fill="none" stroke="black" points="766.32,-636 766.32,-658 934.32,-658 934.32,-636 766.32,-636"/>
+<text text-anchor="start" x="782.67" y="-642.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M935.32,-999C1015.73,-999 1038.31,-999 1113.97,-999"/>
+<polygon fill="black" stroke="black" points="1113.98,-1002.5 1123.98,-999 1113.98,-995.5 1113.98,-1002.5"/>
+<text text-anchor="middle" x="1042.65" y="-1003.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node9" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="402.16,-1054 402.16,-1076 577.16,-1076 577.16,-1054 402.16,-1054"/>
+<polygon fill="none" stroke="black" points="402.16,-1054 402.16,-1076 577.16,-1076 577.16,-1054 402.16,-1054"/>
+<text text-anchor="start" x="465.56" y="-1061.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="402.16,-1032 402.16,-1054 577.16,-1054 577.16,-1032 402.16,-1032"/>
+<text text-anchor="start" x="450.59" y="-1039.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="468.87" y="-1039.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-1010 402.16,-1032 577.16,-1032 577.16,-1010 402.16,-1010"/>
+<text text-anchor="start" x="428.43" y="-1017.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="491.03" y="-1017.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-988 402.16,-1010 577.16,-1010 577.16,-988 402.16,-988"/>
+<text text-anchor="start" x="434.26" y="-995.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="485.2" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-966 402.16,-988 577.16,-988 577.16,-966 402.16,-966"/>
+<text text-anchor="start" x="432.7" y="-973.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="486.76" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-944 402.16,-966 577.16,-966 577.16,-944 402.16,-944"/>
+<text text-anchor="start" x="457.19" y="-951.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="486.36" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-922 402.16,-944 577.16,-944 577.16,-922 402.16,-922"/>
+<text text-anchor="start" x="442.04" y="-929.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="501.52" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-900 402.16,-922 577.16,-922 577.16,-900 402.16,-900"/>
+<text text-anchor="start" x="434.65" y="-907.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="484.8" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-878 402.16,-900 577.16,-900 577.16,-878 402.16,-878"/>
+<text text-anchor="start" x="439.32" y="-885.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="504.24" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-856 402.16,-878 577.16,-878 577.16,-856 402.16,-856"/>
+<text text-anchor="start" x="435.03" y="-863.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="507.74" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="402.16,-834 402.16,-856 577.16,-856 577.16,-834 402.16,-834"/>
+<text text-anchor="start" x="405.1" y="-841.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="514.35" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-812 402.16,-834 577.16,-834 577.16,-812 402.16,-812"/>
+<text text-anchor="start" x="408.59" y="-819.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="534.96" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="402.16,-790 402.16,-812 577.16,-812 577.16,-790 402.16,-790"/>
+<polygon fill="none" stroke="black" points="402.16,-790 402.16,-812 577.16,-812 577.16,-790 402.16,-790"/>
+<text text-anchor="start" x="469.45" y="-797.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="402.16,-768 402.16,-790 577.16,-790 577.16,-768 402.16,-768"/>
+<text text-anchor="start" x="421.23" y="-774.4" font-family="Times,serif" font-size="14.00">index_episodes_trakt_id</text>
+<polygon fill="none" stroke="black" points="402.16,-746 402.16,-768 577.16,-768 577.16,-746 402.16,-746"/>
+<text text-anchor="start" x="415.4" y="-752.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M576.66,-1021C657.07,-1021 679.65,-1021 755.31,-1021"/>
+<polygon fill="black" stroke="black" points="755.32,-1024.5 765.32,-1021 755.32,-1017.5 755.32,-1024.5"/>
+<text text-anchor="middle" x="657.99" y="-1025.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node10" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="743.32,-578 743.32,-600 957.32,-600 957.32,-578 743.32,-578"/>
+<polygon fill="none" stroke="black" points="743.32,-578 743.32,-600 957.32,-600 957.32,-578 743.32,-578"/>
+<text text-anchor="start" x="810.28" y="-585.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="743.32,-556 743.32,-578 957.32,-578 957.32,-556 743.32,-556"/>
+<text text-anchor="start" x="811.25" y="-563.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="829.53" y="-563.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="743.32,-534 743.32,-556 957.32,-556 957.32,-534 743.32,-534"/>
+<text text-anchor="start" x="792.97" y="-541.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="847.8" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="743.32,-512 743.32,-534 957.32,-534 957.32,-512 743.32,-512"/>
+<text text-anchor="start" x="775.09" y="-519.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="865.69" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="743.32,-490 743.32,-512 957.32,-512 957.32,-490 743.32,-490"/>
+<text text-anchor="start" x="782.87" y="-497.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="857.9" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="743.32,-468 743.32,-490 957.32,-490 957.32,-468 743.32,-468"/>
+<polygon fill="none" stroke="black" points="743.32,-468 743.32,-490 957.32,-490 957.32,-468 743.32,-468"/>
+<text text-anchor="start" x="830.11" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="743.32,-446 743.32,-468 957.32,-468 957.32,-446 743.32,-446"/>
+<text text-anchor="start" x="764.01" y="-452.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="743.32,-424 743.32,-446 957.32,-446 957.32,-424 743.32,-424"/>
+<text text-anchor="start" x="746.12" y="-430.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M958.32,-523C1047.01,-523 1020.56,-616.26 1051.98,-699.2 1099.25,-823.97 992.83,-989.98 1113.66,-998.65"/>
+<polygon fill="black" stroke="black" points="1113.87,-1002.16 1123.98,-999 1114.11,-995.16 1113.87,-1002.16"/>
+<text text-anchor="middle" x="1042.65" y="-703.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M958.32,-545C1008.98,-545 1063.7,-949.03 1114.82,-994.8"/>
+<polygon fill="black" stroke="black" points="1113.43,-998.01 1123.98,-999 1116.35,-991.65 1113.43,-998.01"/>
+<text text-anchor="middle" x="1042.65" y="-816.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node11" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-1076 0.5,-1098 239.5,-1098 239.5,-1076 0.5,-1076"/>
+<polygon fill="none" stroke="black" points="0.5,-1076 0.5,-1098 239.5,-1098 239.5,-1076 0.5,-1076"/>
+<text text-anchor="start" x="56.25" y="-1083.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-1054 0.5,-1076 239.5,-1076 239.5,-1054 0.5,-1054"/>
+<text text-anchor="start" x="80.93" y="-1061.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-1061.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-1032 0.5,-1054 239.5,-1054 239.5,-1032 0.5,-1032"/>
+<text text-anchor="start" x="56.04" y="-1039.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-1039.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-1010 0.5,-1032 239.5,-1032 239.5,-1010 0.5,-1010"/>
+<text text-anchor="start" x="64.6" y="-1017.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-1017.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-988 0.5,-1010 239.5,-1010 239.5,-988 0.5,-988"/>
+<text text-anchor="start" x="66.55" y="-995.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-966 0.5,-988 239.5,-988 239.5,-966 0.5,-966"/>
+<text text-anchor="start" x="55.26" y="-973.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-944 0.5,-966 239.5,-966 239.5,-944 0.5,-944"/>
+<polygon fill="none" stroke="black" points="0.5,-944 0.5,-966 239.5,-966 239.5,-944 0.5,-944"/>
+<text text-anchor="start" x="99.79" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-922 0.5,-944 239.5,-944 239.5,-922 0.5,-922"/>
+<text text-anchor="start" x="3.37" y="-928.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-900 0.5,-922 239.5,-922 239.5,-900 0.5,-900"/>
+<text text-anchor="start" x="11.92" y="-906.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-1043C307.76,-1043 327.47,-1043 391.45,-1043"/>
+<polygon fill="black" stroke="black" points="391.66,-1046.5 401.66,-1043 391.66,-1039.5 391.66,-1046.5"/>
+<text text-anchor="middle" x="320.33" y="-1047.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node12" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1668 9.5,-1690 229.5,-1690 229.5,-1668 9.5,-1668"/>
+<polygon fill="none" stroke="black" points="9.5,-1668 9.5,-1690 229.5,-1690 229.5,-1668 9.5,-1668"/>
+<text text-anchor="start" x="83.34" y="-1675.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1646 9.5,-1668 229.5,-1668 229.5,-1646 9.5,-1646"/>
+<text text-anchor="start" x="80.43" y="-1653.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1653.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1624 9.5,-1646 229.5,-1646 229.5,-1624 9.5,-1624"/>
+<text text-anchor="start" x="77.71" y="-1631.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1631.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1602 9.5,-1624 229.5,-1624 229.5,-1602 9.5,-1602"/>
+<text text-anchor="start" x="60.98" y="-1609.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1609.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1580 9.5,-1602 229.5,-1602 229.5,-1580 9.5,-1580"/>
+<text text-anchor="start" x="56.71" y="-1587.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1587.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-1558 9.5,-1580 229.5,-1580 229.5,-1558 9.5,-1558"/>
+<polygon fill="none" stroke="black" points="9.5,-1558 9.5,-1580 229.5,-1580 229.5,-1558 9.5,-1558"/>
+<text text-anchor="start" x="99.29" y="-1565.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-1536 9.5,-1558 229.5,-1558 229.5,-1536 9.5,-1536"/>
+<text text-anchor="start" x="12.19" y="-1542.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+<!-- show_images -->
+<g id="node13" class="node">
+<title>show_images</title>
+<polygon fill="#caff70" stroke="transparent" points="763.32,-366 763.32,-388 937.32,-388 937.32,-366 763.32,-366"/>
+<polygon fill="none" stroke="black" points="763.32,-366 763.32,-388 937.32,-388 937.32,-366 763.32,-366"/>
+<text text-anchor="start" x="812.22" y="-373.4" font-family="Times,serif" font-weight="bold" font-size="14.00">show_images</text>
+<polygon fill="none" stroke="black" points="763.32,-344 763.32,-366 937.32,-366 937.32,-344 763.32,-344"/>
+<text text-anchor="start" x="811.25" y="-351.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="829.53" y="-351.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="763.32,-322 763.32,-344 937.32,-344 937.32,-322 763.32,-322"/>
+<text text-anchor="start" x="792.97" y="-329.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="847.8" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="763.32,-300 763.32,-322 937.32,-322 937.32,-300 763.32,-300"/>
+<text text-anchor="start" x="816.69" y="-307.4" font-family="Times,serif" font-size="14.00">path: </text>
+<text text-anchor="start" x="848.19" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="763.32,-278 763.32,-300 937.32,-300 937.32,-278 763.32,-278"/>
+<text text-anchor="start" x="816.69" y="-285.4" font-family="Times,serif" font-size="14.00">type: </text>
+<text text-anchor="start" x="848.19" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="763.32,-256 763.32,-278 937.32,-278 937.32,-256 763.32,-256"/>
+<text text-anchor="start" x="816.69" y="-263.4" font-family="Times,serif" font-size="14.00">lang: </text>
+<text text-anchor="start" x="848.19" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="763.32,-234 763.32,-256 937.32,-256 937.32,-234 763.32,-234"/>
+<text text-anchor="start" x="812.02" y="-241.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="852.07" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="763.32,-212 763.32,-234 937.32,-234 937.32,-212 763.32,-212"/>
+<text text-anchor="start" x="786.37" y="-219.4" font-family="Times,serif" font-size="14.00">is_primary: </text>
+<text text-anchor="start" x="854.41" y="-219.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="763.32,-190 763.32,-212 937.32,-212 937.32,-190 763.32,-190"/>
+<polygon fill="none" stroke="black" points="763.32,-190 763.32,-212 937.32,-212 937.32,-190 763.32,-190"/>
+<text text-anchor="start" x="830.11" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="763.32,-168 763.32,-190 937.32,-190 937.32,-168 763.32,-168"/>
+<text text-anchor="start" x="765.94" y="-174.4" font-family="Times,serif" font-size="14.00">index_show_images_show_id</text>
+</g>
+<!-- show_images&#45;&gt;shows -->
+<g id="edge10" class="edge">
+<title>show_images:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M938.32,-333C1064.52,-333 1015.45,-472.41 1051.98,-593.2 1077.46,-677.44 1035.89,-974.5 1113.87,-997.58"/>
+<polygon fill="black" stroke="black" points="1113.59,-1001.07 1123.98,-999 1114.57,-994.14 1113.59,-1001.07"/>
+<text text-anchor="middle" x="1042.65" y="-597.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- recommended_entries -->
+<g id="node14" class="node">
+<title>recommended_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="739.32,-110 739.32,-132 961.32,-132 961.32,-110 739.32,-110"/>
+<polygon fill="none" stroke="black" points="739.32,-110 739.32,-132 961.32,-132 961.32,-110 739.32,-110"/>
+<text text-anchor="start" x="788.51" y="-117.4" font-family="Times,serif" font-weight="bold" font-size="14.00">recommended_entries</text>
+<polygon fill="none" stroke="black" points="739.32,-88 739.32,-110 961.32,-110 961.32,-88 739.32,-88"/>
+<text text-anchor="start" x="811.25" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="829.53" y="-95.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-66 739.32,-88 961.32,-88 961.32,-66 739.32,-66"/>
+<text text-anchor="start" x="792.97" y="-73.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="847.8" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-44 739.32,-66 961.32,-66 961.32,-44 739.32,-44"/>
+<text text-anchor="start" x="803.48" y="-51.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="837.3" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="739.32,-22 739.32,-44 961.32,-44 961.32,-22 739.32,-22"/>
+<polygon fill="none" stroke="black" points="739.32,-22 739.32,-44 961.32,-44 961.32,-22 739.32,-22"/>
+<text text-anchor="start" x="830.11" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="739.32,0 739.32,-22 961.32,-22 961.32,0 739.32,0"/>
+<text text-anchor="start" x="742.24" y="-6.4" font-family="Times,serif" font-size="14.00">index_recommended_entries_show_id</text>
+</g>
+<!-- recommended_entries&#45;&gt;shows -->
+<g id="edge11" class="edge">
+<title>recommended_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M961.32,-77C1125.97,-77 1021.33,-274.43 1051.98,-436.2 1063.1,-494.87 1061.19,-947.4 1114.55,-994.96"/>
+<polygon fill="black" stroke="black" points="1113.41,-998.28 1123.98,-999 1116.17,-991.85 1113.41,-998.28"/>
+<text text-anchor="middle" x="1042.65" y="-440.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/app.tivi.data.TiviRoomDatabase/26.svg
+++ b/data-android/floorplan-output/app.tivi.data.TiviRoomDatabase/26.svg
@@ -1,0 +1,550 @@
+<svg width="1371px" height="1886px"
+ viewBox="0.00 0.00 1370.98 1886.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1850)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1850 1334.98,-1850 1334.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1124.48,-1010 1124.48,-1032 1299.48,-1032 1299.48,-1010 1124.48,-1010"/>
+<polygon fill="none" stroke="black" points="1124.48,-1010 1124.48,-1032 1299.48,-1032 1299.48,-1010 1124.48,-1010"/>
+<text text-anchor="start" x="1194.48" y="-1017.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1124.48,-988 1124.48,-1010 1299.48,-1010 1299.48,-988 1124.48,-988"/>
+<text text-anchor="start" x="1172.91" y="-995.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1191.19" y="-995.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1124.48,-966 1124.48,-988 1299.48,-988 1299.48,-966 1124.48,-966"/>
+<text text-anchor="start" x="1179.52" y="-973.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1208.68" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-944 1124.48,-966 1299.48,-966 1299.48,-944 1124.48,-944"/>
+<text text-anchor="start" x="1154.24" y="-951.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1233.96" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-922 1124.48,-944 1299.48,-944 1299.48,-922 1124.48,-922"/>
+<text text-anchor="start" x="1156.58" y="-929.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1207.52" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1124.48,-900 1124.48,-922 1299.48,-922 1299.48,-900 1124.48,-900"/>
+<text text-anchor="start" x="1155.02" y="-907.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1209.08" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1124.48,-878 1124.48,-900 1299.48,-900 1299.48,-878 1124.48,-878"/>
+<text text-anchor="start" x="1167.07" y="-885.4" font-family="Times,serif" font-size="14.00">imdb_id: </text>
+<text text-anchor="start" x="1221.13" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-856 1124.48,-878 1299.48,-878 1299.48,-856 1124.48,-856"/>
+<text text-anchor="start" x="1164.36" y="-863.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1223.84" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-834 1124.48,-856 1299.48,-856 1299.48,-834 1124.48,-834"/>
+<text text-anchor="start" x="1161.64" y="-841.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1226.56" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-812 1124.48,-834 1299.48,-834 1299.48,-812 1124.48,-812"/>
+<text text-anchor="start" x="1157.36" y="-819.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="1230.06" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1124.48,-790 1124.48,-812 1299.48,-812 1299.48,-790 1124.48,-790"/>
+<text text-anchor="start" x="1147.25" y="-797.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="1216.85" y="-797.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1124.48,-768 1124.48,-790 1299.48,-790 1299.48,-768 1124.48,-768"/>
+<text text-anchor="start" x="1156.59" y="-775.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1231.61" y="-775.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-746 1124.48,-768 1299.48,-768 1299.48,-746 1124.48,-746"/>
+<text text-anchor="start" x="1161.64" y="-753.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="1226.56" y="-753.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-724 1124.48,-746 1299.48,-746 1299.48,-724 1124.48,-724"/>
+<text text-anchor="start" x="1169.02" y="-731.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1219.18" y="-731.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-702 1124.48,-724 1299.48,-724 1299.48,-702 1124.48,-702"/>
+<text text-anchor="start" x="1167.47" y="-709.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1220.73" y="-709.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-680 1124.48,-702 1299.48,-702 1299.48,-680 1124.48,-680"/>
+<text text-anchor="start" x="1135.97" y="-687.4" font-family="Times,serif" font-size="14.00">network_logo_path: </text>
+<text text-anchor="start" x="1252.23" y="-687.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-658 1124.48,-680 1299.48,-680 1299.48,-658 1124.48,-658"/>
+<text text-anchor="start" x="1156.58" y="-665.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1207.52" y="-665.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1124.48,-636 1124.48,-658 1299.48,-658 1299.48,-636 1124.48,-636"/>
+<text text-anchor="start" x="1172.14" y="-643.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1216.06" y="-643.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-614 1124.48,-636 1299.48,-636 1299.48,-614 1124.48,-614"/>
+<text text-anchor="start" x="1127.04" y="-621.4" font-family="Times,serif" font-size="14.00">last_trakt_data_update: </text>
+<text text-anchor="start" x="1261.16" y="-621.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-592 1124.48,-614 1299.48,-614 1299.48,-592 1124.48,-592"/>
+<text text-anchor="start" x="1174.46" y="-599.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="1213.74" y="-599.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-570 1124.48,-592 1299.48,-592 1299.48,-570 1124.48,-570"/>
+<text text-anchor="start" x="1154.64" y="-577.4" font-family="Times,serif" font-size="14.00">airs_day: </text>
+<text text-anchor="start" x="1209.46" y="-577.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1124.48,-548 1124.48,-570 1299.48,-570 1299.48,-548 1124.48,-548"/>
+<text text-anchor="start" x="1164.36" y="-555.4" font-family="Times,serif" font-size="14.00">airs_time: </text>
+<text text-anchor="start" x="1223.84" y="-555.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1124.48,-526 1124.48,-548 1299.48,-548 1299.48,-526 1124.48,-526"/>
+<text text-anchor="start" x="1171.75" y="-533.4" font-family="Times,serif" font-size="14.00">airs_tz: </text>
+<text text-anchor="start" x="1216.45" y="-533.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1124.48,-504 1124.48,-526 1299.48,-526 1299.48,-504 1124.48,-504"/>
+<polygon fill="none" stroke="black" points="1124.48,-504 1124.48,-526 1299.48,-526 1299.48,-504 1124.48,-504"/>
+<text text-anchor="start" x="1191.77" y="-511.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1124.48,-482 1124.48,-504 1299.48,-504 1299.48,-482 1124.48,-482"/>
+<text text-anchor="start" x="1150.16" y="-488.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1124.48,-460 1124.48,-482 1299.48,-482 1299.48,-460 1124.48,-460"/>
+<text text-anchor="start" x="1148.6" y="-466.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- shows_fts -->
+<g id="node2" class="node">
+<title>shows_fts</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-1178 59.5,-1200 180.5,-1200 180.5,-1178 59.5,-1178"/>
+<polygon fill="none" stroke="black" points="59.5,-1178 59.5,-1200 180.5,-1200 180.5,-1178 59.5,-1178"/>
+<text text-anchor="start" x="92" y="-1185.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows_fts</text>
+<polygon fill="none" stroke="black" points="59.5,-1156 59.5,-1178 180.5,-1178 180.5,-1156 59.5,-1156"/>
+<text text-anchor="start" x="87.53" y="-1163.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="116.7" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-1134 59.5,-1156 180.5,-1156 180.5,-1134 59.5,-1134"/>
+<text text-anchor="start" x="62.26" y="-1141.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="141.98" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- trending_shows -->
+<g id="node3" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="757.32,-1792 757.32,-1814 944.32,-1814 944.32,-1792 757.32,-1792"/>
+<polygon fill="none" stroke="black" points="757.32,-1792 757.32,-1814 944.32,-1814 944.32,-1792 757.32,-1792"/>
+<text text-anchor="start" x="806.5" y="-1799.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="757.32,-1770 757.32,-1792 944.32,-1792 944.32,-1770 757.32,-1770"/>
+<text text-anchor="start" x="811.75" y="-1777.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="830.03" y="-1777.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="757.32,-1748 757.32,-1770 944.32,-1770 944.32,-1748 757.32,-1748"/>
+<text text-anchor="start" x="793.47" y="-1755.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="848.3" y="-1755.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="757.32,-1726 757.32,-1748 944.32,-1748 944.32,-1726 757.32,-1726"/>
+<text text-anchor="start" x="803.98" y="-1733.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="837.8" y="-1733.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="757.32,-1704 757.32,-1726 944.32,-1726 944.32,-1704 757.32,-1704"/>
+<text text-anchor="start" x="792.32" y="-1711.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="849.46" y="-1711.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="757.32,-1682 757.32,-1704 944.32,-1704 944.32,-1682 757.32,-1682"/>
+<polygon fill="none" stroke="black" points="757.32,-1682 757.32,-1704 944.32,-1704 944.32,-1682 757.32,-1682"/>
+<text text-anchor="start" x="830.61" y="-1689.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="757.32,-1660 757.32,-1682 944.32,-1682 944.32,-1660 757.32,-1660"/>
+<text text-anchor="start" x="760.22" y="-1666.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M945.32,-1759C1150.43,-1759 1005.15,-1509.69 1051.98,-1310 1067.36,-1244.44 1054.5,-1023.13 1113.83,-1000.82"/>
+<polygon fill="black" stroke="black" points="1114.75,-1004.21 1123.98,-999 1113.52,-997.32 1114.75,-1004.21"/>
+<text text-anchor="middle" x="1042.65" y="-1729.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node4" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="759.32,-1602 759.32,-1624 942.32,-1624 942.32,-1602 759.32,-1602"/>
+<polygon fill="none" stroke="black" points="759.32,-1602 759.32,-1624 942.32,-1624 942.32,-1602 759.32,-1602"/>
+<text text-anchor="start" x="808.44" y="-1609.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="759.32,-1580 759.32,-1602 942.32,-1602 942.32,-1580 759.32,-1580"/>
+<text text-anchor="start" x="811.75" y="-1587.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="830.03" y="-1587.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-1558 759.32,-1580 942.32,-1580 942.32,-1558 759.32,-1558"/>
+<text text-anchor="start" x="793.47" y="-1565.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="848.3" y="-1565.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-1536 759.32,-1558 942.32,-1558 942.32,-1536 759.32,-1536"/>
+<text text-anchor="start" x="803.98" y="-1543.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="837.8" y="-1543.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="759.32,-1514 759.32,-1536 942.32,-1536 942.32,-1514 759.32,-1514"/>
+<text text-anchor="start" x="785.71" y="-1521.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="856.06" y="-1521.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="759.32,-1492 759.32,-1514 942.32,-1514 942.32,-1492 759.32,-1492"/>
+<polygon fill="none" stroke="black" points="759.32,-1492 759.32,-1514 942.32,-1514 942.32,-1492 759.32,-1492"/>
+<text text-anchor="start" x="830.61" y="-1499.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="759.32,-1470 759.32,-1492 942.32,-1492 942.32,-1470 759.32,-1470"/>
+<text text-anchor="start" x="762.17" y="-1476.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M943.32,-1569C958.73,-1569 1086.75,-1078.41 1118.43,-1007.5"/>
+<polygon fill="black" stroke="black" points="1121.44,-1009.29 1123.98,-999 1115.58,-1005.46 1121.44,-1009.29"/>
+<text text-anchor="middle" x="1042.65" y="-1288.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node5" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="53.5,-1478 53.5,-1500 186.5,-1500 186.5,-1478 53.5,-1478"/>
+<polygon fill="none" stroke="black" points="53.5,-1478 53.5,-1500 186.5,-1500 186.5,-1478 53.5,-1478"/>
+<text text-anchor="start" x="105.62" y="-1485.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="53.5,-1456 53.5,-1478 186.5,-1478 186.5,-1456 53.5,-1456"/>
+<text text-anchor="start" x="80.93" y="-1463.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-1463.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-1434 53.5,-1456 186.5,-1456 186.5,-1434 53.5,-1434"/>
+<text text-anchor="start" x="71.6" y="-1441.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.63" y="-1441.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1412 53.5,-1434 186.5,-1434 186.5,-1412 53.5,-1412"/>
+<text text-anchor="start" x="83.26" y="-1419.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.97" y="-1419.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1390 53.5,-1412 186.5,-1412 186.5,-1390 53.5,-1390"/>
+<text text-anchor="start" x="65.76" y="-1397.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="138.47" y="-1397.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1368 53.5,-1390 186.5,-1390 186.5,-1368 53.5,-1368"/>
+<text text-anchor="start" x="75.87" y="-1375.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="128.36" y="-1375.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1346 53.5,-1368 186.5,-1368 186.5,-1346 53.5,-1346"/>
+<text text-anchor="start" x="82.87" y="-1353.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="121.37" y="-1353.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1324 53.5,-1346 186.5,-1346 186.5,-1324 53.5,-1324"/>
+<text text-anchor="start" x="70.05" y="-1331.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="134.19" y="-1331.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="53.5,-1302 53.5,-1324 186.5,-1324 186.5,-1302 53.5,-1302"/>
+<text text-anchor="start" x="77.43" y="-1309.4" font-family="Times,serif" font-size="14.00">vip: </text>
+<text text-anchor="start" x="102.71" y="-1309.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="53.5,-1280 53.5,-1302 186.5,-1302 186.5,-1280 53.5,-1280"/>
+<text text-anchor="start" x="69.65" y="-1287.4" font-family="Times,serif" font-size="14.00">is_me: </text>
+<text text-anchor="start" x="110.48" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="53.5,-1258 53.5,-1280 186.5,-1280 186.5,-1258 53.5,-1258"/>
+<polygon fill="none" stroke="black" points="53.5,-1258 53.5,-1280 186.5,-1280 186.5,-1258 53.5,-1258"/>
+<text text-anchor="start" x="99.79" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="53.5,-1236 53.5,-1258 186.5,-1258 186.5,-1236 53.5,-1236"/>
+<text text-anchor="start" x="56.25" y="-1242.4" font-family="Times,serif" font-size="14.00">index_users_username</text>
+</g>
+<!-- watched_entries -->
+<g id="node6" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="756.32,-1412 756.32,-1434 945.32,-1434 945.32,-1412 756.32,-1412"/>
+<polygon fill="none" stroke="black" points="756.32,-1412 756.32,-1434 945.32,-1434 945.32,-1412 756.32,-1412"/>
+<text text-anchor="start" x="805.34" y="-1419.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="756.32,-1390 756.32,-1412 945.32,-1412 945.32,-1390 756.32,-1390"/>
+<text text-anchor="start" x="811.75" y="-1397.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="830.03" y="-1397.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="756.32,-1368 756.32,-1390 945.32,-1390 945.32,-1368 756.32,-1368"/>
+<text text-anchor="start" x="793.47" y="-1375.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="848.3" y="-1375.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="756.32,-1346 756.32,-1368 945.32,-1368 945.32,-1346 756.32,-1346"/>
+<text text-anchor="start" x="792.7" y="-1353.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="873.17" y="-1353.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="756.32,-1324 756.32,-1346 945.32,-1346 945.32,-1324 756.32,-1324"/>
+<polygon fill="none" stroke="black" points="756.32,-1324 756.32,-1346 945.32,-1346 945.32,-1324 756.32,-1324"/>
+<text text-anchor="start" x="830.61" y="-1331.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="756.32,-1302 756.32,-1324 945.32,-1324 945.32,-1302 756.32,-1302"/>
+<text text-anchor="start" x="759.07" y="-1308.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M946.32,-1379C967.76,-1379 1080.38,-1057.42 1116.42,-1005.92"/>
+<polygon fill="black" stroke="black" points="1118.97,-1008.33 1123.98,-999 1114.24,-1003.17 1118.97,-1008.33"/>
+<text text-anchor="middle" x="1042.65" y="-1193.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node7" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="753.32,-1244 753.32,-1266 948.32,-1266 948.32,-1244 753.32,-1244"/>
+<polygon fill="none" stroke="black" points="753.32,-1244 753.32,-1266 948.32,-1266 948.32,-1244 753.32,-1244"/>
+<text text-anchor="start" x="802.22" y="-1251.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="753.32,-1222 753.32,-1244 948.32,-1244 948.32,-1222 753.32,-1222"/>
+<text text-anchor="start" x="811.75" y="-1229.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="830.03" y="-1229.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1200 753.32,-1222 948.32,-1222 948.32,-1200 753.32,-1200"/>
+<text text-anchor="start" x="793.47" y="-1207.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="848.3" y="-1207.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="753.32,-1178 753.32,-1200 948.32,-1200 948.32,-1178 753.32,-1178"/>
+<text text-anchor="start" x="795.81" y="-1185.4" font-family="Times,serif" font-size="14.00">followed_at: </text>
+<text text-anchor="start" x="870.07" y="-1185.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="753.32,-1156 753.32,-1178 948.32,-1178 948.32,-1156 753.32,-1156"/>
+<text text-anchor="start" x="786.09" y="-1163.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="879.79" y="-1163.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="753.32,-1134 753.32,-1156 948.32,-1156 948.32,-1134 753.32,-1134"/>
+<text text-anchor="start" x="795.42" y="-1141.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="846.36" y="-1141.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="753.32,-1112 753.32,-1134 948.32,-1134 948.32,-1112 753.32,-1112"/>
+<polygon fill="none" stroke="black" points="753.32,-1112 753.32,-1134 948.32,-1134 948.32,-1112 753.32,-1112"/>
+<text text-anchor="start" x="830.61" y="-1119.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="753.32,-1090 753.32,-1112 948.32,-1112 948.32,-1090 753.32,-1090"/>
+<text text-anchor="start" x="755.95" y="-1096.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M949.32,-1211C1067.83,-1211 1005.81,-1011.24 1113.74,-999.54"/>
+<polygon fill="black" stroke="black" points="1114.18,-1003.02 1123.98,-999 1113.81,-996.03 1114.18,-1003.02"/>
+<text text-anchor="middle" x="1042.65" y="-1121.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node8" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="766.32,-1032 766.32,-1054 934.32,-1054 934.32,-1032 766.32,-1032"/>
+<polygon fill="none" stroke="black" points="766.32,-1032 766.32,-1054 934.32,-1054 934.32,-1032 766.32,-1032"/>
+<text text-anchor="start" x="828.94" y="-1039.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="766.32,-1010 766.32,-1032 934.32,-1032 934.32,-1010 766.32,-1010"/>
+<text text-anchor="start" x="811.25" y="-1017.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="829.53" y="-1017.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="766.32,-988 766.32,-1010 934.32,-1010 934.32,-988 766.32,-988"/>
+<text text-anchor="start" x="792.97" y="-995.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="847.8" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="766.32,-966 766.32,-988 934.32,-988 934.32,-966 766.32,-966"/>
+<text text-anchor="start" x="794.92" y="-973.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="845.86" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="766.32,-944 766.32,-966 934.32,-966 934.32,-944 766.32,-944"/>
+<text text-anchor="start" x="793.36" y="-951.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="847.42" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="766.32,-922 766.32,-944 934.32,-944 934.32,-922 766.32,-922"/>
+<text text-anchor="start" x="817.86" y="-929.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="847.02" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="766.32,-900 766.32,-922 934.32,-922 934.32,-900 766.32,-900"/>
+<text text-anchor="start" x="802.7" y="-907.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="862.18" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="766.32,-878 766.32,-900 934.32,-900 934.32,-878 766.32,-878"/>
+<text text-anchor="start" x="795.31" y="-885.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="845.47" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="766.32,-856 766.32,-878 934.32,-878 934.32,-856 766.32,-856"/>
+<text text-anchor="start" x="805.81" y="-863.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="859.07" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="766.32,-834 766.32,-856 934.32,-856 934.32,-834 766.32,-834"/>
+<text text-anchor="start" x="791.03" y="-841.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="849.74" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="766.32,-812 766.32,-834 934.32,-834 934.32,-812 766.32,-812"/>
+<text text-anchor="start" x="792.59" y="-819.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="848.18" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="766.32,-790 766.32,-812 934.32,-812 934.32,-790 766.32,-790"/>
+<text text-anchor="start" x="795.7" y="-797.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="868.4" y="-797.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="766.32,-768 766.32,-790 934.32,-790 934.32,-768 766.32,-768"/>
+<text text-anchor="start" x="785.59" y="-775.4" font-family="Times,serif" font-size="14.00">trakt_votes: </text>
+<text text-anchor="start" x="855.19" y="-775.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="766.32,-746 766.32,-768 934.32,-768 934.32,-746 766.32,-746"/>
+<text text-anchor="start" x="778.2" y="-753.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="886.68" y="-753.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="766.32,-724 766.32,-746 934.32,-746 934.32,-724 766.32,-724"/>
+<text text-anchor="start" x="769.26" y="-731.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="895.62" y="-731.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="766.32,-702 766.32,-724 934.32,-724 934.32,-702 766.32,-702"/>
+<text text-anchor="start" x="795.31" y="-709.4" font-family="Times,serif" font-size="14.00">ignored: </text>
+<text text-anchor="start" x="845.47" y="-709.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="766.32,-680 766.32,-702 934.32,-702 934.32,-680 766.32,-680"/>
+<polygon fill="none" stroke="black" points="766.32,-680 766.32,-702 934.32,-702 934.32,-680 766.32,-680"/>
+<text text-anchor="start" x="830.11" y="-687.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="766.32,-658 766.32,-680 934.32,-680 934.32,-658 766.32,-658"/>
+<text text-anchor="start" x="784.61" y="-664.4" font-family="Times,serif" font-size="14.00">index_seasons_trakt_id</text>
+<polygon fill="none" stroke="black" points="766.32,-636 766.32,-658 934.32,-658 934.32,-636 766.32,-636"/>
+<text text-anchor="start" x="782.67" y="-642.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M935.32,-999C1015.73,-999 1038.31,-999 1113.97,-999"/>
+<polygon fill="black" stroke="black" points="1113.98,-1002.5 1123.98,-999 1113.98,-995.5 1113.98,-1002.5"/>
+<text text-anchor="middle" x="1042.65" y="-1003.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node9" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="402.16,-1054 402.16,-1076 577.16,-1076 577.16,-1054 402.16,-1054"/>
+<polygon fill="none" stroke="black" points="402.16,-1054 402.16,-1076 577.16,-1076 577.16,-1054 402.16,-1054"/>
+<text text-anchor="start" x="465.56" y="-1061.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="402.16,-1032 402.16,-1054 577.16,-1054 577.16,-1032 402.16,-1032"/>
+<text text-anchor="start" x="450.59" y="-1039.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="468.87" y="-1039.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-1010 402.16,-1032 577.16,-1032 577.16,-1010 402.16,-1010"/>
+<text text-anchor="start" x="428.43" y="-1017.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="491.03" y="-1017.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-988 402.16,-1010 577.16,-1010 577.16,-988 402.16,-988"/>
+<text text-anchor="start" x="434.26" y="-995.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="485.2" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-966 402.16,-988 577.16,-988 577.16,-966 402.16,-966"/>
+<text text-anchor="start" x="432.7" y="-973.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="486.76" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-944 402.16,-966 577.16,-966 577.16,-944 402.16,-944"/>
+<text text-anchor="start" x="457.19" y="-951.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="486.36" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-922 402.16,-944 577.16,-944 577.16,-922 402.16,-922"/>
+<text text-anchor="start" x="442.04" y="-929.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="501.52" y="-929.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-900 402.16,-922 577.16,-922 577.16,-900 402.16,-900"/>
+<text text-anchor="start" x="434.65" y="-907.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="484.8" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-878 402.16,-900 577.16,-900 577.16,-878 402.16,-878"/>
+<text text-anchor="start" x="439.32" y="-885.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="504.24" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="402.16,-856 402.16,-878 577.16,-878 577.16,-856 402.16,-856"/>
+<text text-anchor="start" x="435.03" y="-863.4" font-family="Times,serif" font-size="14.00">trakt_rating: </text>
+<text text-anchor="start" x="507.74" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="402.16,-834 402.16,-856 577.16,-856 577.16,-834 402.16,-834"/>
+<text text-anchor="start" x="405.1" y="-841.4" font-family="Times,serif" font-size="14.00">trakt_rating_votes: </text>
+<text text-anchor="start" x="514.35" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="402.16,-812 402.16,-834 577.16,-834 577.16,-812 402.16,-812"/>
+<text text-anchor="start" x="408.59" y="-819.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="534.96" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="402.16,-790 402.16,-812 577.16,-812 577.16,-790 402.16,-790"/>
+<polygon fill="none" stroke="black" points="402.16,-790 402.16,-812 577.16,-812 577.16,-790 402.16,-790"/>
+<text text-anchor="start" x="469.45" y="-797.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="402.16,-768 402.16,-790 577.16,-790 577.16,-768 402.16,-768"/>
+<text text-anchor="start" x="421.23" y="-774.4" font-family="Times,serif" font-size="14.00">index_episodes_trakt_id</text>
+<polygon fill="none" stroke="black" points="402.16,-746 402.16,-768 577.16,-768 577.16,-746 402.16,-746"/>
+<text text-anchor="start" x="415.4" y="-752.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M576.66,-1021C657.07,-1021 679.65,-1021 755.31,-1021"/>
+<polygon fill="black" stroke="black" points="755.32,-1024.5 765.32,-1021 755.32,-1017.5 755.32,-1024.5"/>
+<text text-anchor="middle" x="657.99" y="-1025.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node10" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="743.32,-578 743.32,-600 957.32,-600 957.32,-578 743.32,-578"/>
+<polygon fill="none" stroke="black" points="743.32,-578 743.32,-600 957.32,-600 957.32,-578 743.32,-578"/>
+<text text-anchor="start" x="810.28" y="-585.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="743.32,-556 743.32,-578 957.32,-578 957.32,-556 743.32,-556"/>
+<text text-anchor="start" x="811.25" y="-563.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="829.53" y="-563.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="743.32,-534 743.32,-556 957.32,-556 957.32,-534 743.32,-534"/>
+<text text-anchor="start" x="792.97" y="-541.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="847.8" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="743.32,-512 743.32,-534 957.32,-534 957.32,-512 743.32,-512"/>
+<text text-anchor="start" x="775.09" y="-519.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="865.69" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="743.32,-490 743.32,-512 957.32,-512 957.32,-490 743.32,-490"/>
+<text text-anchor="start" x="782.87" y="-497.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="857.9" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="743.32,-468 743.32,-490 957.32,-490 957.32,-468 743.32,-468"/>
+<polygon fill="none" stroke="black" points="743.32,-468 743.32,-490 957.32,-490 957.32,-468 743.32,-468"/>
+<text text-anchor="start" x="830.11" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="743.32,-446 743.32,-468 957.32,-468 957.32,-446 743.32,-446"/>
+<text text-anchor="start" x="764.01" y="-452.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="743.32,-424 743.32,-446 957.32,-446 957.32,-424 743.32,-424"/>
+<text text-anchor="start" x="746.12" y="-430.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M958.32,-523C1047.01,-523 1020.56,-616.26 1051.98,-699.2 1099.25,-823.97 992.83,-989.98 1113.66,-998.65"/>
+<polygon fill="black" stroke="black" points="1113.87,-1002.16 1123.98,-999 1114.11,-995.16 1113.87,-1002.16"/>
+<text text-anchor="middle" x="1042.65" y="-703.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M958.32,-545C1008.98,-545 1063.7,-949.03 1114.82,-994.8"/>
+<polygon fill="black" stroke="black" points="1113.43,-998.01 1123.98,-999 1116.35,-991.65 1113.43,-998.01"/>
+<text text-anchor="middle" x="1042.65" y="-816.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node11" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-1076 0.5,-1098 239.5,-1098 239.5,-1076 0.5,-1076"/>
+<polygon fill="none" stroke="black" points="0.5,-1076 0.5,-1098 239.5,-1098 239.5,-1076 0.5,-1076"/>
+<text text-anchor="start" x="56.25" y="-1083.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-1054 0.5,-1076 239.5,-1076 239.5,-1054 0.5,-1054"/>
+<text text-anchor="start" x="80.93" y="-1061.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-1061.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-1032 0.5,-1054 239.5,-1054 239.5,-1032 0.5,-1032"/>
+<text text-anchor="start" x="56.04" y="-1039.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-1039.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-1010 0.5,-1032 239.5,-1032 239.5,-1010 0.5,-1010"/>
+<text text-anchor="start" x="64.6" y="-1017.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-1017.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-988 0.5,-1010 239.5,-1010 239.5,-988 0.5,-988"/>
+<text text-anchor="start" x="66.55" y="-995.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-995.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-966 0.5,-988 239.5,-988 239.5,-966 0.5,-966"/>
+<text text-anchor="start" x="55.26" y="-973.4" font-family="Times,serif" font-size="14.00">pending_action: </text>
+<text text-anchor="start" x="148.97" y="-973.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-944 0.5,-966 239.5,-966 239.5,-944 0.5,-944"/>
+<polygon fill="none" stroke="black" points="0.5,-944 0.5,-966 239.5,-966 239.5,-944 0.5,-944"/>
+<text text-anchor="start" x="99.79" y="-951.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-922 0.5,-944 239.5,-944 239.5,-922 0.5,-922"/>
+<text text-anchor="start" x="3.37" y="-928.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-900 0.5,-922 239.5,-922 239.5,-900 0.5,-900"/>
+<text text-anchor="start" x="11.92" y="-906.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-1043C307.76,-1043 327.47,-1043 391.45,-1043"/>
+<polygon fill="black" stroke="black" points="391.66,-1046.5 401.66,-1043 391.66,-1039.5 391.66,-1046.5"/>
+<text text-anchor="middle" x="320.33" y="-1047.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- last_requests -->
+<g id="node12" class="node">
+<title>last_requests</title>
+<polygon fill="#caff70" stroke="transparent" points="9.5,-1668 9.5,-1690 229.5,-1690 229.5,-1668 9.5,-1668"/>
+<polygon fill="none" stroke="black" points="9.5,-1668 9.5,-1690 229.5,-1690 229.5,-1668 9.5,-1668"/>
+<text text-anchor="start" x="83.34" y="-1675.4" font-family="Times,serif" font-weight="bold" font-size="14.00">last_requests</text>
+<polygon fill="none" stroke="black" points="9.5,-1646 9.5,-1668 229.5,-1668 229.5,-1646 9.5,-1646"/>
+<text text-anchor="start" x="80.43" y="-1653.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-1653.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1624 9.5,-1646 229.5,-1646 229.5,-1624 9.5,-1624"/>
+<text text-anchor="start" x="77.71" y="-1631.4" font-family="Times,serif" font-size="14.00">request: </text>
+<text text-anchor="start" x="125.53" y="-1631.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="9.5,-1602 9.5,-1624 229.5,-1624 229.5,-1602 9.5,-1602"/>
+<text text-anchor="start" x="60.98" y="-1609.4" font-family="Times,serif" font-size="14.00">entity_id: </text>
+<text text-anchor="start" x="118.15" y="-1609.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="9.5,-1580 9.5,-1602 229.5,-1602 229.5,-1580 9.5,-1580"/>
+<text text-anchor="start" x="56.71" y="-1587.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="122.42" y="-1587.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="9.5,-1558 9.5,-1580 229.5,-1580 229.5,-1558 9.5,-1558"/>
+<polygon fill="none" stroke="black" points="9.5,-1558 9.5,-1580 229.5,-1580 229.5,-1558 9.5,-1558"/>
+<text text-anchor="start" x="99.29" y="-1565.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="9.5,-1536 9.5,-1558 229.5,-1558 229.5,-1536 9.5,-1536"/>
+<text text-anchor="start" x="12.19" y="-1542.4" font-family="Times,serif" font-size="14.00">index_last_requests_request_entity_id</text>
+</g>
+<!-- show_images -->
+<g id="node13" class="node">
+<title>show_images</title>
+<polygon fill="#caff70" stroke="transparent" points="763.32,-366 763.32,-388 937.32,-388 937.32,-366 763.32,-366"/>
+<polygon fill="none" stroke="black" points="763.32,-366 763.32,-388 937.32,-388 937.32,-366 763.32,-366"/>
+<text text-anchor="start" x="812.22" y="-373.4" font-family="Times,serif" font-weight="bold" font-size="14.00">show_images</text>
+<polygon fill="none" stroke="black" points="763.32,-344 763.32,-366 937.32,-366 937.32,-344 763.32,-344"/>
+<text text-anchor="start" x="811.25" y="-351.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="829.53" y="-351.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="763.32,-322 763.32,-344 937.32,-344 937.32,-322 763.32,-322"/>
+<text text-anchor="start" x="792.97" y="-329.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="847.8" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="763.32,-300 763.32,-322 937.32,-322 937.32,-300 763.32,-300"/>
+<text text-anchor="start" x="816.69" y="-307.4" font-family="Times,serif" font-size="14.00">path: </text>
+<text text-anchor="start" x="848.19" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="763.32,-278 763.32,-300 937.32,-300 937.32,-278 763.32,-278"/>
+<text text-anchor="start" x="816.69" y="-285.4" font-family="Times,serif" font-size="14.00">type: </text>
+<text text-anchor="start" x="848.19" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="763.32,-256 763.32,-278 937.32,-278 937.32,-256 763.32,-256"/>
+<text text-anchor="start" x="816.69" y="-263.4" font-family="Times,serif" font-size="14.00">lang: </text>
+<text text-anchor="start" x="848.19" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="763.32,-234 763.32,-256 937.32,-256 937.32,-234 763.32,-234"/>
+<text text-anchor="start" x="812.02" y="-241.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="852.07" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="763.32,-212 763.32,-234 937.32,-234 937.32,-212 763.32,-212"/>
+<text text-anchor="start" x="786.37" y="-219.4" font-family="Times,serif" font-size="14.00">is_primary: </text>
+<text text-anchor="start" x="854.41" y="-219.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="763.32,-190 763.32,-212 937.32,-212 937.32,-190 763.32,-190"/>
+<polygon fill="none" stroke="black" points="763.32,-190 763.32,-212 937.32,-212 937.32,-190 763.32,-190"/>
+<text text-anchor="start" x="830.11" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="763.32,-168 763.32,-190 937.32,-190 937.32,-168 763.32,-168"/>
+<text text-anchor="start" x="765.94" y="-174.4" font-family="Times,serif" font-size="14.00">index_show_images_show_id</text>
+</g>
+<!-- show_images&#45;&gt;shows -->
+<g id="edge10" class="edge">
+<title>show_images:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M938.32,-333C1064.52,-333 1015.45,-472.41 1051.98,-593.2 1077.46,-677.44 1035.89,-974.5 1113.87,-997.58"/>
+<polygon fill="black" stroke="black" points="1113.59,-1001.07 1123.98,-999 1114.57,-994.14 1113.59,-1001.07"/>
+<text text-anchor="middle" x="1042.65" y="-597.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- recommended_entries -->
+<g id="node14" class="node">
+<title>recommended_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="739.32,-110 739.32,-132 961.32,-132 961.32,-110 739.32,-110"/>
+<polygon fill="none" stroke="black" points="739.32,-110 739.32,-132 961.32,-132 961.32,-110 739.32,-110"/>
+<text text-anchor="start" x="788.51" y="-117.4" font-family="Times,serif" font-weight="bold" font-size="14.00">recommended_entries</text>
+<polygon fill="none" stroke="black" points="739.32,-88 739.32,-110 961.32,-110 961.32,-88 739.32,-88"/>
+<text text-anchor="start" x="811.25" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="829.53" y="-95.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-66 739.32,-88 961.32,-88 961.32,-66 739.32,-66"/>
+<text text-anchor="start" x="792.97" y="-73.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="847.8" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="739.32,-44 739.32,-66 961.32,-66 961.32,-44 739.32,-44"/>
+<text text-anchor="start" x="803.48" y="-51.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="837.3" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="739.32,-22 739.32,-44 961.32,-44 961.32,-22 739.32,-22"/>
+<polygon fill="none" stroke="black" points="739.32,-22 739.32,-44 961.32,-44 961.32,-22 739.32,-22"/>
+<text text-anchor="start" x="830.11" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="739.32,0 739.32,-22 961.32,-22 961.32,0 739.32,0"/>
+<text text-anchor="start" x="742.24" y="-6.4" font-family="Times,serif" font-size="14.00">index_recommended_entries_show_id</text>
+</g>
+<!-- recommended_entries&#45;&gt;shows -->
+<g id="edge11" class="edge">
+<title>recommended_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M961.32,-77C1125.97,-77 1021.33,-274.43 1051.98,-436.2 1063.1,-494.87 1061.19,-947.4 1114.55,-994.96"/>
+<polygon fill="black" stroke="black" points="1113.41,-998.28 1123.98,-999 1116.17,-991.85 1113.41,-998.28"/>
+<text text-anchor="middle" x="1042.65" y="-440.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/me.banes.chris.tivi.data.TiviDatabase/10.svg
+++ b/data-android/floorplan-output/me.banes.chris.tivi.data.TiviDatabase/10.svg
@@ -1,0 +1,214 @@
+<svg width="598px" height="1053px"
+ viewBox="0.00 0.00 597.66 1053.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1017)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1017 561.66,-1017 561.66,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="357.66,-440 357.66,-462 525.66,-462 525.66,-440 357.66,-440"/>
+<polygon fill="none" stroke="black" points="357.66,-440 357.66,-462 525.66,-462 525.66,-440 357.66,-440"/>
+<text text-anchor="start" x="424.16" y="-447.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="357.66,-418 357.66,-440 525.66,-440 525.66,-418 357.66,-418"/>
+<text text-anchor="start" x="402.59" y="-425.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="420.87" y="-425.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="357.66,-396 357.66,-418 525.66,-418 525.66,-396 357.66,-396"/>
+<text text-anchor="start" x="409.19" y="-403.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="438.36" y="-403.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-374 357.66,-396 525.66,-396 525.66,-374 357.66,-374"/>
+<text text-anchor="start" x="383.92" y="-381.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="463.64" y="-381.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-352 357.66,-374 525.66,-374 525.66,-352 357.66,-352"/>
+<text text-anchor="start" x="386.26" y="-359.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="437.2" y="-359.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="357.66,-330 357.66,-352 525.66,-352 525.66,-330 357.66,-330"/>
+<text text-anchor="start" x="384.7" y="-337.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="438.76" y="-337.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="357.66,-308 357.66,-330 525.66,-330 525.66,-308 357.66,-308"/>
+<text text-anchor="start" x="369.53" y="-315.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="478.02" y="-315.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-286 357.66,-308 525.66,-308 525.66,-286 357.66,-286"/>
+<text text-anchor="start" x="360.59" y="-293.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="486.96" y="-293.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-264 357.66,-286 525.66,-286 525.66,-264 357.66,-264"/>
+<text text-anchor="start" x="381.59" y="-271.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="465.96" y="-271.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-242 357.66,-264 525.66,-264 525.66,-242 357.66,-242"/>
+<text text-anchor="start" x="380.03" y="-249.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="467.52" y="-249.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-220 357.66,-242 525.66,-242 525.66,-220 357.66,-220"/>
+<text text-anchor="start" x="394.04" y="-227.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="453.52" y="-227.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-198 357.66,-220 525.66,-220 525.66,-198 357.66,-198"/>
+<text text-anchor="start" x="391.32" y="-205.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="456.24" y="-205.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-176 357.66,-198 525.66,-198 525.66,-176 357.66,-176"/>
+<text text-anchor="start" x="403.36" y="-183.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="443.41" y="-183.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="357.66,-154 357.66,-176 525.66,-176 525.66,-154 357.66,-154"/>
+<text text-anchor="start" x="386.27" y="-161.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="461.29" y="-161.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-132 357.66,-154 525.66,-154 525.66,-132 357.66,-132"/>
+<text text-anchor="start" x="398.7" y="-139.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="448.86" y="-139.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-110 357.66,-132 525.66,-132 525.66,-110 357.66,-110"/>
+<text text-anchor="start" x="397.15" y="-117.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="450.41" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-88 357.66,-110 525.66,-110 525.66,-88 357.66,-88"/>
+<text text-anchor="start" x="386.26" y="-95.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="437.2" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="357.66,-66 357.66,-88 525.66,-88 525.66,-66 357.66,-66"/>
+<text text-anchor="start" x="401.82" y="-73.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="445.74" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="357.66,-44 357.66,-66 525.66,-66 525.66,-44 357.66,-44"/>
+<polygon fill="none" stroke="black" points="357.66,-44 357.66,-66 525.66,-66 525.66,-44 357.66,-44"/>
+<text text-anchor="start" x="421.45" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="357.66,-22 357.66,-44 525.66,-44 525.66,-22 357.66,-22"/>
+<text text-anchor="start" x="379.84" y="-28.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="357.66,0 357.66,-22 525.66,-22 525.66,0 357.66,0"/>
+<text text-anchor="start" x="378.27" y="-6.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="4.5,-747 4.5,-769 191.5,-769 191.5,-747 4.5,-747"/>
+<polygon fill="none" stroke="black" points="4.5,-747 4.5,-769 191.5,-769 191.5,-747 4.5,-747"/>
+<text text-anchor="start" x="53.67" y="-754.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="4.5,-725 4.5,-747 191.5,-747 191.5,-725 4.5,-725"/>
+<text text-anchor="start" x="58.93" y="-732.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="77.21" y="-732.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="4.5,-703 4.5,-725 191.5,-725 191.5,-703 4.5,-703"/>
+<text text-anchor="start" x="40.65" y="-710.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="95.48" y="-710.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="4.5,-681 4.5,-703 191.5,-703 191.5,-681 4.5,-681"/>
+<text text-anchor="start" x="51.16" y="-688.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="84.98" y="-688.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="4.5,-659 4.5,-681 191.5,-681 191.5,-659 4.5,-659"/>
+<text text-anchor="start" x="39.5" y="-666.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="96.63" y="-666.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="4.5,-637 4.5,-659 191.5,-659 191.5,-637 4.5,-637"/>
+<polygon fill="none" stroke="black" points="4.5,-637 4.5,-659 191.5,-659 191.5,-637 4.5,-637"/>
+<text text-anchor="start" x="77.79" y="-644.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="4.5,-615 4.5,-637 191.5,-637 191.5,-615 4.5,-615"/>
+<text text-anchor="start" x="7.4" y="-621.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M192.5,-714C262.27,-714 282.58,-455.09 347.71,-430.82"/>
+<polygon fill="black" stroke="black" points="348.45,-434.24 357.66,-429 347.19,-427.36 348.45,-434.24"/>
+<text text-anchor="middle" x="276.33" y="-592.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="6.5,-557 6.5,-579 189.5,-579 189.5,-557 6.5,-557"/>
+<polygon fill="none" stroke="black" points="6.5,-557 6.5,-579 189.5,-579 189.5,-557 6.5,-557"/>
+<text text-anchor="start" x="55.62" y="-564.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="6.5,-535 6.5,-557 189.5,-557 189.5,-535 6.5,-535"/>
+<text text-anchor="start" x="58.93" y="-542.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="77.21" y="-542.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="6.5,-513 6.5,-535 189.5,-535 189.5,-513 6.5,-513"/>
+<text text-anchor="start" x="40.65" y="-520.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="95.48" y="-520.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="6.5,-491 6.5,-513 189.5,-513 189.5,-491 6.5,-491"/>
+<text text-anchor="start" x="51.16" y="-498.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="84.98" y="-498.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="6.5,-469 6.5,-491 189.5,-491 189.5,-469 6.5,-469"/>
+<text text-anchor="start" x="32.89" y="-476.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="103.24" y="-476.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="6.5,-447 6.5,-469 189.5,-469 189.5,-447 6.5,-447"/>
+<polygon fill="none" stroke="black" points="6.5,-447 6.5,-469 189.5,-469 189.5,-447 6.5,-447"/>
+<text text-anchor="start" x="77.79" y="-454.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="6.5,-425 6.5,-447 189.5,-447 189.5,-425 6.5,-425"/>
+<text text-anchor="start" x="9.35" y="-431.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M190.5,-524C272.45,-524 272.36,-436.63 347.58,-429.47"/>
+<polygon fill="black" stroke="black" points="347.83,-432.96 357.66,-429 347.51,-425.97 347.83,-432.96"/>
+<text text-anchor="middle" x="276.33" y="-486.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="40.5,-959 40.5,-981 154.5,-981 154.5,-959 40.5,-959"/>
+<polygon fill="none" stroke="black" points="40.5,-959 40.5,-981 154.5,-981 154.5,-959 40.5,-959"/>
+<text text-anchor="start" x="83.12" y="-966.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="40.5,-937 40.5,-959 154.5,-959 154.5,-937 40.5,-937"/>
+<text text-anchor="start" x="58.43" y="-944.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="76.71" y="-944.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="40.5,-915 40.5,-937 154.5,-937 154.5,-915 40.5,-915"/>
+<text text-anchor="start" x="49.1" y="-922.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="110.13" y="-922.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="40.5,-893 40.5,-915 154.5,-915 154.5,-893 40.5,-893"/>
+<text text-anchor="start" x="60.76" y="-900.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="98.47" y="-900.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="40.5,-871 40.5,-893 154.5,-893 154.5,-871 40.5,-871"/>
+<text text-anchor="start" x="43.26" y="-878.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="115.97" y="-878.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="40.5,-849 40.5,-871 154.5,-871 154.5,-849 40.5,-849"/>
+<text text-anchor="start" x="53.37" y="-856.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="105.86" y="-856.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="40.5,-827 40.5,-849 154.5,-849 154.5,-827 40.5,-827"/>
+<text text-anchor="start" x="60.37" y="-834.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="98.87" y="-834.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="40.5,-805 40.5,-827 154.5,-827 154.5,-805 40.5,-805"/>
+<text text-anchor="start" x="47.55" y="-812.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="111.69" y="-812.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="3.5,-367 3.5,-389 192.5,-389 192.5,-367 3.5,-367"/>
+<polygon fill="none" stroke="black" points="3.5,-367 3.5,-389 192.5,-389 192.5,-367 3.5,-367"/>
+<text text-anchor="start" x="52.52" y="-374.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="3.5,-345 3.5,-367 192.5,-367 192.5,-345 3.5,-345"/>
+<text text-anchor="start" x="58.93" y="-352.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="77.21" y="-352.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="3.5,-323 3.5,-345 192.5,-345 192.5,-323 3.5,-323"/>
+<text text-anchor="start" x="40.65" y="-330.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="95.48" y="-330.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="3.5,-301 3.5,-323 192.5,-323 192.5,-301 3.5,-301"/>
+<text text-anchor="start" x="39.88" y="-308.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="120.35" y="-308.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="3.5,-279 3.5,-301 192.5,-301 192.5,-279 3.5,-279"/>
+<polygon fill="none" stroke="black" points="3.5,-279 3.5,-301 192.5,-301 192.5,-279 3.5,-279"/>
+<text text-anchor="start" x="77.79" y="-286.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="3.5,-257 3.5,-279 192.5,-279 192.5,-257 3.5,-257"/>
+<text text-anchor="start" x="6.25" y="-263.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M193.5,-334C274.17,-334 273.58,-421.01 347.27,-428.49"/>
+<polygon fill="black" stroke="black" points="347.5,-432 357.66,-429 347.84,-425.01 347.5,-432"/>
+<text text-anchor="middle" x="276.33" y="-396.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-199 0.5,-221 195.5,-221 195.5,-199 0.5,-199"/>
+<polygon fill="none" stroke="black" points="0.5,-199 0.5,-221 195.5,-221 195.5,-199 0.5,-199"/>
+<text text-anchor="start" x="49.4" y="-206.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-177 0.5,-199 195.5,-199 195.5,-177 0.5,-177"/>
+<text text-anchor="start" x="58.93" y="-184.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="77.21" y="-184.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-155 0.5,-177 195.5,-177 195.5,-155 0.5,-155"/>
+<text text-anchor="start" x="40.65" y="-162.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="95.48" y="-162.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-133 0.5,-155 195.5,-155 195.5,-133 0.5,-133"/>
+<polygon fill="none" stroke="black" points="0.5,-133 0.5,-155 195.5,-155 195.5,-133 0.5,-133"/>
+<text text-anchor="start" x="77.79" y="-140.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-111 0.5,-133 195.5,-133 195.5,-111 0.5,-111"/>
+<text text-anchor="start" x="3.13" y="-117.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M195,-166C257.06,-166 252.25,-219.9 285.66,-272.2 325.01,-333.79 285.09,-420.42 347.66,-428.4"/>
+<polygon fill="black" stroke="black" points="347.47,-431.9 357.66,-429 347.89,-424.91 347.47,-431.9"/>
+<text text-anchor="middle" x="276.33" y="-276.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/me.banes.chris.tivi.data.TiviDatabase/11.svg
+++ b/data-android/floorplan-output/me.banes.chris.tivi.data.TiviDatabase/11.svg
@@ -1,0 +1,350 @@
+<svg width="928px" height="1228px"
+ viewBox="0.00 0.00 928.32 1228.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1192)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1192 892.32,-1192 892.32,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="688.32,-732 688.32,-754 856.32,-754 856.32,-732 688.32,-732"/>
+<polygon fill="none" stroke="black" points="688.32,-732 688.32,-754 856.32,-754 856.32,-732 688.32,-732"/>
+<text text-anchor="start" x="754.82" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="688.32,-710 688.32,-732 856.32,-732 856.32,-710 688.32,-710"/>
+<text text-anchor="start" x="733.25" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="751.53" y="-717.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="688.32,-688 688.32,-710 856.32,-710 856.32,-688 688.32,-688"/>
+<text text-anchor="start" x="739.86" y="-695.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="769.02" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="688.32,-666 688.32,-688 856.32,-688 856.32,-666 688.32,-666"/>
+<text text-anchor="start" x="714.58" y="-673.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="794.3" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="688.32,-644 688.32,-666 856.32,-666 856.32,-644 688.32,-644"/>
+<text text-anchor="start" x="716.92" y="-651.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="767.86" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="688.32,-622 688.32,-644 856.32,-644 856.32,-622 688.32,-622"/>
+<text text-anchor="start" x="715.36" y="-629.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="769.42" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="688.32,-600 688.32,-622 856.32,-622 856.32,-600 688.32,-600"/>
+<text text-anchor="start" x="700.2" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="808.68" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="688.32,-578 688.32,-600 856.32,-600 856.32,-578 688.32,-578"/>
+<text text-anchor="start" x="691.26" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="817.62" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="688.32,-556 688.32,-578 856.32,-578 856.32,-556 688.32,-556"/>
+<text text-anchor="start" x="712.26" y="-563.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="796.62" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="688.32,-534 688.32,-556 856.32,-556 856.32,-534 688.32,-534"/>
+<text text-anchor="start" x="710.69" y="-541.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="798.18" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="688.32,-512 688.32,-534 856.32,-534 856.32,-512 688.32,-512"/>
+<text text-anchor="start" x="724.7" y="-519.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="784.18" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="688.32,-490 688.32,-512 856.32,-512 856.32,-490 688.32,-490"/>
+<text text-anchor="start" x="721.98" y="-497.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="786.9" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="688.32,-468 688.32,-490 856.32,-490 856.32,-468 688.32,-468"/>
+<text text-anchor="start" x="734.02" y="-475.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="774.07" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="688.32,-446 688.32,-468 856.32,-468 856.32,-446 688.32,-446"/>
+<text text-anchor="start" x="716.93" y="-453.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="791.95" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="688.32,-424 688.32,-446 856.32,-446 856.32,-424 688.32,-424"/>
+<text text-anchor="start" x="729.36" y="-431.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="779.52" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="688.32,-402 688.32,-424 856.32,-424 856.32,-402 688.32,-402"/>
+<text text-anchor="start" x="727.81" y="-409.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="781.07" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="688.32,-380 688.32,-402 856.32,-402 856.32,-380 688.32,-380"/>
+<text text-anchor="start" x="716.92" y="-387.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="767.86" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="688.32,-358 688.32,-380 856.32,-380 856.32,-358 688.32,-358"/>
+<text text-anchor="start" x="732.48" y="-365.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="776.4" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="688.32,-336 688.32,-358 856.32,-358 856.32,-336 688.32,-336"/>
+<polygon fill="none" stroke="black" points="688.32,-336 688.32,-358 856.32,-358 856.32,-336 688.32,-336"/>
+<text text-anchor="start" x="752.11" y="-343.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="688.32,-314 688.32,-336 856.32,-336 856.32,-314 688.32,-314"/>
+<text text-anchor="start" x="710.5" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="688.32,-292 688.32,-314 856.32,-314 856.32,-292 688.32,-292"/>
+<text text-anchor="start" x="708.93" y="-298.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="335.16,-1134 335.16,-1156 522.16,-1156 522.16,-1134 335.16,-1134"/>
+<polygon fill="none" stroke="black" points="335.16,-1134 335.16,-1156 522.16,-1156 522.16,-1134 335.16,-1134"/>
+<text text-anchor="start" x="384.33" y="-1141.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="335.16,-1112 335.16,-1134 522.16,-1134 522.16,-1112 335.16,-1112"/>
+<text text-anchor="start" x="389.59" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="407.87" y="-1119.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="335.16,-1090 335.16,-1112 522.16,-1112 522.16,-1090 335.16,-1090"/>
+<text text-anchor="start" x="371.31" y="-1097.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="426.14" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="335.16,-1068 335.16,-1090 522.16,-1090 522.16,-1068 335.16,-1068"/>
+<text text-anchor="start" x="381.82" y="-1075.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="415.64" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="335.16,-1046 335.16,-1068 522.16,-1068 522.16,-1046 335.16,-1046"/>
+<text text-anchor="start" x="370.16" y="-1053.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="427.29" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="335.16,-1024 335.16,-1046 522.16,-1046 522.16,-1024 335.16,-1024"/>
+<polygon fill="none" stroke="black" points="335.16,-1024 335.16,-1046 522.16,-1046 522.16,-1024 335.16,-1024"/>
+<text text-anchor="start" x="408.45" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="335.16,-1002 335.16,-1024 522.16,-1024 522.16,-1002 335.16,-1002"/>
+<text text-anchor="start" x="338.06" y="-1008.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M523.16,-1101C566.23,-1101 632.97,-768.41 679.1,-725.53"/>
+<polygon fill="black" stroke="black" points="680.89,-728.55 688.32,-721 677.8,-722.27 680.89,-728.55"/>
+<text text-anchor="middle" x="606.99" y="-937.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="337.16,-944 337.16,-966 520.16,-966 520.16,-944 337.16,-944"/>
+<polygon fill="none" stroke="black" points="337.16,-944 337.16,-966 520.16,-966 520.16,-944 337.16,-944"/>
+<text text-anchor="start" x="386.28" y="-951.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="337.16,-922 337.16,-944 520.16,-944 520.16,-922 337.16,-922"/>
+<text text-anchor="start" x="389.59" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="407.87" y="-929.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="337.16,-900 337.16,-922 520.16,-922 520.16,-900 337.16,-900"/>
+<text text-anchor="start" x="371.31" y="-907.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="426.14" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="337.16,-878 337.16,-900 520.16,-900 520.16,-878 337.16,-878"/>
+<text text-anchor="start" x="381.82" y="-885.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="415.64" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="337.16,-856 337.16,-878 520.16,-878 520.16,-856 337.16,-856"/>
+<text text-anchor="start" x="363.55" y="-863.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="433.9" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="337.16,-834 337.16,-856 520.16,-856 520.16,-834 337.16,-834"/>
+<polygon fill="none" stroke="black" points="337.16,-834 337.16,-856 520.16,-856 520.16,-834 337.16,-834"/>
+<text text-anchor="start" x="408.45" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="337.16,-812 337.16,-834 520.16,-834 520.16,-812 337.16,-812"/>
+<text text-anchor="start" x="340.01" y="-818.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M521.16,-911C630.12,-911 579.29,-732.69 678.27,-721.55"/>
+<polygon fill="black" stroke="black" points="678.53,-725.04 688.32,-721 678.15,-718.05 678.53,-725.04"/>
+<text text-anchor="middle" x="606.99" y="-842.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="27,-674 27,-696 141,-696 141,-674 27,-674"/>
+<polygon fill="none" stroke="black" points="27,-674 27,-696 141,-696 141,-674 27,-674"/>
+<text text-anchor="start" x="69.62" y="-681.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="27,-652 27,-674 141,-674 141,-652 27,-652"/>
+<text text-anchor="start" x="44.93" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="63.21" y="-659.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27,-630 27,-652 141,-652 141,-630 27,-630"/>
+<text text-anchor="start" x="35.6" y="-637.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="96.63" y="-637.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27,-608 27,-630 141,-630 141,-608 27,-608"/>
+<text text-anchor="start" x="47.26" y="-615.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="84.97" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27,-586 27,-608 141,-608 141,-586 27,-586"/>
+<text text-anchor="start" x="29.76" y="-593.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="102.47" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27,-564 27,-586 141,-586 141,-564 27,-564"/>
+<text text-anchor="start" x="39.87" y="-571.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="92.36" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27,-542 27,-564 141,-564 141,-542 27,-542"/>
+<text text-anchor="start" x="46.87" y="-549.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="85.37" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27,-520 27,-542 141,-542 141,-520 27,-520"/>
+<text text-anchor="start" x="34.05" y="-527.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="98.19" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="334.16,-754 334.16,-776 523.16,-776 523.16,-754 334.16,-754"/>
+<polygon fill="none" stroke="black" points="334.16,-754 334.16,-776 523.16,-776 523.16,-754 334.16,-754"/>
+<text text-anchor="start" x="383.18" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="334.16,-732 334.16,-754 523.16,-754 523.16,-732 334.16,-732"/>
+<text text-anchor="start" x="389.59" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="407.87" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="334.16,-710 334.16,-732 523.16,-732 523.16,-710 334.16,-710"/>
+<text text-anchor="start" x="371.31" y="-717.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="426.14" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="334.16,-688 334.16,-710 523.16,-710 523.16,-688 334.16,-688"/>
+<text text-anchor="start" x="370.54" y="-695.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="451.01" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="334.16,-666 334.16,-688 523.16,-688 523.16,-666 334.16,-666"/>
+<polygon fill="none" stroke="black" points="334.16,-666 334.16,-688 523.16,-688 523.16,-666 334.16,-666"/>
+<text text-anchor="start" x="408.45" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="334.16,-644 334.16,-666 523.16,-666 523.16,-644 334.16,-644"/>
+<text text-anchor="start" x="336.91" y="-650.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M524.16,-721C593.56,-721 613.45,-721 678.01,-721"/>
+<polygon fill="black" stroke="black" points="678.32,-724.5 688.32,-721 678.32,-717.5 678.32,-724.5"/>
+<text text-anchor="middle" x="606.99" y="-725.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="331.16,-586 331.16,-608 526.16,-608 526.16,-586 331.16,-586"/>
+<polygon fill="none" stroke="black" points="331.16,-586 331.16,-608 526.16,-608 526.16,-586 331.16,-586"/>
+<text text-anchor="start" x="380.06" y="-593.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="331.16,-564 331.16,-586 526.16,-586 526.16,-564 331.16,-564"/>
+<text text-anchor="start" x="389.59" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="407.87" y="-571.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="331.16,-542 331.16,-564 526.16,-564 526.16,-542 331.16,-542"/>
+<text text-anchor="start" x="371.31" y="-549.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="426.14" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="331.16,-520 331.16,-542 526.16,-542 526.16,-520 331.16,-520"/>
+<polygon fill="none" stroke="black" points="331.16,-520 331.16,-542 526.16,-542 526.16,-520 331.16,-520"/>
+<text text-anchor="start" x="408.45" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="331.16,-498 331.16,-520 526.16,-520 526.16,-498 331.16,-498"/>
+<text text-anchor="start" x="333.79" y="-504.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M525.66,-553C574.28,-553 628.81,-700.04 678.19,-719"/>
+<polygon fill="black" stroke="black" points="677.83,-722.49 688.32,-721 679.19,-715.63 677.83,-722.49"/>
+<text text-anchor="middle" x="606.99" y="-651.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="344.16,-440 344.16,-462 512.16,-462 512.16,-440 344.16,-440"/>
+<polygon fill="none" stroke="black" points="344.16,-440 344.16,-462 512.16,-462 512.16,-440 344.16,-440"/>
+<text text-anchor="start" x="406.78" y="-447.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="344.16,-418 344.16,-440 512.16,-440 512.16,-418 344.16,-418"/>
+<text text-anchor="start" x="389.09" y="-425.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="407.37" y="-425.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="344.16,-396 344.16,-418 512.16,-418 512.16,-396 344.16,-396"/>
+<text text-anchor="start" x="370.81" y="-403.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="425.64" y="-403.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="344.16,-374 344.16,-396 512.16,-396 512.16,-374 344.16,-374"/>
+<text text-anchor="start" x="372.76" y="-381.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="423.7" y="-381.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="344.16,-352 344.16,-374 512.16,-374 512.16,-352 344.16,-352"/>
+<text text-anchor="start" x="371.2" y="-359.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="425.26" y="-359.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="344.16,-330 344.16,-352 512.16,-352 512.16,-330 344.16,-330"/>
+<text text-anchor="start" x="395.69" y="-337.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="424.86" y="-337.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="344.16,-308 344.16,-330 512.16,-330 512.16,-308 344.16,-308"/>
+<text text-anchor="start" x="380.54" y="-315.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="440.02" y="-315.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="344.16,-286 344.16,-308 512.16,-308 512.16,-286 344.16,-286"/>
+<text text-anchor="start" x="373.15" y="-293.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="423.3" y="-293.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="344.16,-264 344.16,-286 512.16,-286 512.16,-264 344.16,-264"/>
+<text text-anchor="start" x="368.87" y="-271.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="427.58" y="-271.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="344.16,-242 344.16,-264 512.16,-264 512.16,-242 344.16,-242"/>
+<text text-anchor="start" x="370.43" y="-249.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="426.02" y="-249.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="344.16,-220 344.16,-242 512.16,-242 512.16,-220 344.16,-220"/>
+<text text-anchor="start" x="389.86" y="-227.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="429.91" y="-227.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="344.16,-198 344.16,-220 512.16,-220 512.16,-198 344.16,-198"/>
+<text text-anchor="start" x="383.65" y="-205.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="436.91" y="-205.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="344.16,-176 344.16,-198 512.16,-198 512.16,-176 344.16,-176"/>
+<text text-anchor="start" x="379.76" y="-183.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="416.7" y="-183.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="344.16,-154 344.16,-176 512.16,-176 512.16,-154 344.16,-154"/>
+<text text-anchor="start" x="356.03" y="-161.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="464.52" y="-161.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="344.16,-132 344.16,-154 512.16,-154 512.16,-132 344.16,-132"/>
+<text text-anchor="start" x="347.09" y="-139.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="473.46" y="-139.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="344.16,-110 344.16,-132 512.16,-132 512.16,-110 344.16,-110"/>
+<text text-anchor="start" x="368.09" y="-117.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="452.46" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="344.16,-88 344.16,-110 512.16,-110 512.16,-88 344.16,-88"/>
+<text text-anchor="start" x="366.53" y="-95.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="454.02" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="344.16,-66 344.16,-88 512.16,-88 512.16,-66 344.16,-66"/>
+<polygon fill="none" stroke="black" points="344.16,-66 344.16,-88 512.16,-88 512.16,-66 344.16,-66"/>
+<text text-anchor="start" x="407.95" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="344.16,-44 344.16,-66 512.16,-66 512.16,-44 344.16,-44"/>
+<text text-anchor="start" x="360.51" y="-50.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id</text>
+<polygon fill="none" stroke="black" points="344.16,-22 344.16,-44 512.16,-44 512.16,-22 344.16,-22"/>
+<text text-anchor="start" x="362.45" y="-28.4" font-family="Times,serif" font-size="14.00">index_seasons_trakt_id</text>
+<polygon fill="none" stroke="black" points="344.16,0 344.16,-22 512.16,-22 512.16,0 344.16,0"/>
+<text text-anchor="start" x="360.89" y="-6.4" font-family="Times,serif" font-size="14.00">index_seasons_tmdb_id</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M513.16,-407C550.3,-407 635.25,-678.4 679.11,-716.56"/>
+<polygon fill="black" stroke="black" points="677.79,-719.81 688.32,-721 680.83,-713.51 677.79,-719.81"/>
+<text text-anchor="middle" x="606.99" y="-596.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="0,-462 0,-484 168,-484 168,-462 0,-462"/>
+<polygon fill="none" stroke="black" points="0,-462 0,-484 168,-484 168,-462 0,-462"/>
+<text text-anchor="start" x="59.9" y="-469.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="0,-440 0,-462 168,-462 168,-440 0,-440"/>
+<text text-anchor="start" x="44.93" y="-447.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="63.21" y="-447.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-418 0,-440 168,-440 168,-418 0,-418"/>
+<text text-anchor="start" x="22.77" y="-425.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="85.37" y="-425.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-396 0,-418 168,-418 168,-396 0,-396"/>
+<text text-anchor="start" x="28.6" y="-403.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="79.53" y="-403.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-374 0,-396 168,-396 168,-374 0,-374"/>
+<text text-anchor="start" x="27.03" y="-381.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="81.1" y="-381.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-352 0,-374 168,-374 168,-352 0,-352"/>
+<text text-anchor="start" x="51.53" y="-359.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="80.7" y="-359.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-330 0,-352 168,-352 168,-330 0,-330"/>
+<text text-anchor="start" x="36.38" y="-337.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="95.86" y="-337.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-308 0,-330 168,-330 168,-308 0,-308"/>
+<text text-anchor="start" x="31.71" y="-315.4" font-family="Times,serif" font-size="14.00">season: </text>
+<text text-anchor="start" x="76.42" y="-315.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-286 0,-308 168,-308 168,-286 0,-286"/>
+<text text-anchor="start" x="33.66" y="-293.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="98.58" y="-293.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-264 0,-286 168,-286 168,-264 0,-264"/>
+<text text-anchor="start" x="45.7" y="-271.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="85.75" y="-271.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="0,-242 0,-264 168,-264 168,-242 0,-242"/>
+<text text-anchor="start" x="35.6" y="-249.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="72.54" y="-249.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-220 0,-242 168,-242 168,-220 0,-220"/>
+<text text-anchor="start" x="11.87" y="-227.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="120.36" y="-227.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-198 0,-220 168,-220 168,-198 0,-198"/>
+<text text-anchor="start" x="2.93" y="-205.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="129.3" y="-205.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-176 0,-198 168,-198 168,-176 0,-176"/>
+<text text-anchor="start" x="23.93" y="-183.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="108.3" y="-183.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-154 0,-176 168,-176 168,-154 0,-154"/>
+<text text-anchor="start" x="22.37" y="-161.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="109.86" y="-161.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0,-132 0,-154 168,-154 168,-132 0,-132"/>
+<polygon fill="none" stroke="black" points="0,-132 0,-154 168,-154 168,-132 0,-132"/>
+<text text-anchor="start" x="63.79" y="-139.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0,-110 0,-132 168,-132 168,-110 0,-110"/>
+<text text-anchor="start" x="9.74" y="-116.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id</text>
+<polygon fill="none" stroke="black" points="0,-88 0,-110 168,-110 168,-88 0,-88"/>
+<text text-anchor="start" x="15.57" y="-94.4" font-family="Times,serif" font-size="14.00">index_episodes_trakt_id</text>
+<polygon fill="none" stroke="black" points="0,-66 0,-88 168,-88 168,-66 0,-66"/>
+<text text-anchor="start" x="14.01" y="-72.4" font-family="Times,serif" font-size="14.00">index_episodes_tmdb_id</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M168,-429C242.35,-429 263.45,-429 333.01,-429"/>
+<polygon fill="black" stroke="black" points="333.16,-432.5 343.16,-429 333.16,-425.5 333.16,-432.5"/>
+<text text-anchor="middle" x="249.33" y="-433.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/me.banes.chris.tivi.data.TiviDatabase/12.svg
+++ b/data-android/floorplan-output/me.banes.chris.tivi.data.TiviDatabase/12.svg
@@ -1,0 +1,345 @@
+<svg width="964px" height="1206px"
+ viewBox="0.00 0.00 964.32 1206.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1170)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1170 928.32,-1170 928.32,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="724.32,-710 724.32,-732 892.32,-732 892.32,-710 724.32,-710"/>
+<polygon fill="none" stroke="black" points="724.32,-710 724.32,-732 892.32,-732 892.32,-710 724.32,-710"/>
+<text text-anchor="start" x="790.82" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="724.32,-688 724.32,-710 892.32,-710 892.32,-688 724.32,-688"/>
+<text text-anchor="start" x="769.25" y="-695.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="787.53" y="-695.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="724.32,-666 724.32,-688 892.32,-688 892.32,-666 724.32,-666"/>
+<text text-anchor="start" x="775.86" y="-673.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="805.02" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-644 724.32,-666 892.32,-666 892.32,-644 724.32,-644"/>
+<text text-anchor="start" x="750.58" y="-651.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="830.3" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-622 724.32,-644 892.32,-644 892.32,-622 724.32,-622"/>
+<text text-anchor="start" x="752.92" y="-629.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="803.86" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="724.32,-600 724.32,-622 892.32,-622 892.32,-600 724.32,-600"/>
+<text text-anchor="start" x="751.36" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="805.42" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="724.32,-578 724.32,-600 892.32,-600 892.32,-578 724.32,-578"/>
+<text text-anchor="start" x="736.2" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="844.68" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-556 724.32,-578 892.32,-578 892.32,-556 724.32,-556"/>
+<text text-anchor="start" x="727.26" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="853.62" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-534 724.32,-556 892.32,-556 892.32,-534 724.32,-534"/>
+<text text-anchor="start" x="748.26" y="-541.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="832.62" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-512 724.32,-534 892.32,-534 892.32,-512 724.32,-512"/>
+<text text-anchor="start" x="746.69" y="-519.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="834.18" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-490 724.32,-512 892.32,-512 892.32,-490 724.32,-490"/>
+<text text-anchor="start" x="760.7" y="-497.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="820.18" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-468 724.32,-490 892.32,-490 892.32,-468 724.32,-468"/>
+<text text-anchor="start" x="757.98" y="-475.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="822.9" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-446 724.32,-468 892.32,-468 892.32,-446 724.32,-446"/>
+<text text-anchor="start" x="770.02" y="-453.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="810.07" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="724.32,-424 724.32,-446 892.32,-446 892.32,-424 724.32,-424"/>
+<text text-anchor="start" x="752.93" y="-431.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="827.95" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-402 724.32,-424 892.32,-424 892.32,-402 724.32,-402"/>
+<text text-anchor="start" x="765.36" y="-409.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="815.52" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-380 724.32,-402 892.32,-402 892.32,-380 724.32,-380"/>
+<text text-anchor="start" x="763.81" y="-387.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="817.07" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-358 724.32,-380 892.32,-380 892.32,-358 724.32,-358"/>
+<text text-anchor="start" x="752.92" y="-365.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="803.86" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="724.32,-336 724.32,-358 892.32,-358 892.32,-336 724.32,-336"/>
+<text text-anchor="start" x="768.48" y="-343.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="812.4" y="-343.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="724.32,-314 724.32,-336 892.32,-336 892.32,-314 724.32,-314"/>
+<polygon fill="none" stroke="black" points="724.32,-314 724.32,-336 892.32,-336 892.32,-314 724.32,-314"/>
+<text text-anchor="start" x="788.11" y="-321.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="724.32,-292 724.32,-314 892.32,-314 892.32,-292 724.32,-292"/>
+<text text-anchor="start" x="746.5" y="-298.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="724.32,-270 724.32,-292 892.32,-292 892.32,-270 724.32,-270"/>
+<text text-anchor="start" x="744.93" y="-276.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="371.16,-1112 371.16,-1134 558.16,-1134 558.16,-1112 371.16,-1112"/>
+<polygon fill="none" stroke="black" points="371.16,-1112 371.16,-1134 558.16,-1134 558.16,-1112 371.16,-1112"/>
+<text text-anchor="start" x="420.33" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="371.16,-1090 371.16,-1112 558.16,-1112 558.16,-1090 371.16,-1090"/>
+<text text-anchor="start" x="425.59" y="-1097.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="443.87" y="-1097.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="371.16,-1068 371.16,-1090 558.16,-1090 558.16,-1068 371.16,-1068"/>
+<text text-anchor="start" x="407.31" y="-1075.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="462.14" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="371.16,-1046 371.16,-1068 558.16,-1068 558.16,-1046 371.16,-1046"/>
+<text text-anchor="start" x="417.82" y="-1053.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="451.64" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="371.16,-1024 371.16,-1046 558.16,-1046 558.16,-1024 371.16,-1024"/>
+<text text-anchor="start" x="406.16" y="-1031.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="463.29" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="371.16,-1002 371.16,-1024 558.16,-1024 558.16,-1002 371.16,-1002"/>
+<polygon fill="none" stroke="black" points="371.16,-1002 371.16,-1024 558.16,-1024 558.16,-1002 371.16,-1002"/>
+<text text-anchor="start" x="444.45" y="-1009.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="371.16,-980 371.16,-1002 558.16,-1002 558.16,-980 371.16,-980"/>
+<text text-anchor="start" x="374.06" y="-986.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M559.16,-1079C602.23,-1079 668.97,-746.41 715.1,-703.53"/>
+<polygon fill="black" stroke="black" points="716.89,-706.55 724.32,-699 713.8,-700.27 716.89,-706.55"/>
+<text text-anchor="middle" x="642.99" y="-915.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="373.16,-922 373.16,-944 556.16,-944 556.16,-922 373.16,-922"/>
+<polygon fill="none" stroke="black" points="373.16,-922 373.16,-944 556.16,-944 556.16,-922 373.16,-922"/>
+<text text-anchor="start" x="422.28" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="373.16,-900 373.16,-922 556.16,-922 556.16,-900 373.16,-900"/>
+<text text-anchor="start" x="425.59" y="-907.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="443.87" y="-907.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="373.16,-878 373.16,-900 556.16,-900 556.16,-878 373.16,-878"/>
+<text text-anchor="start" x="407.31" y="-885.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="462.14" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="373.16,-856 373.16,-878 556.16,-878 556.16,-856 373.16,-856"/>
+<text text-anchor="start" x="417.82" y="-863.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="451.64" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="373.16,-834 373.16,-856 556.16,-856 556.16,-834 373.16,-834"/>
+<text text-anchor="start" x="399.55" y="-841.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="469.9" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="373.16,-812 373.16,-834 556.16,-834 556.16,-812 373.16,-812"/>
+<polygon fill="none" stroke="black" points="373.16,-812 373.16,-834 556.16,-834 556.16,-812 373.16,-812"/>
+<text text-anchor="start" x="444.45" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="373.16,-790 373.16,-812 556.16,-812 556.16,-790 373.16,-790"/>
+<text text-anchor="start" x="376.01" y="-796.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M557.16,-889C666.12,-889 615.29,-710.69 714.27,-699.55"/>
+<polygon fill="black" stroke="black" points="714.53,-703.04 724.32,-699 714.15,-696.05 714.53,-703.04"/>
+<text text-anchor="middle" x="642.99" y="-820.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="45,-652 45,-674 159,-674 159,-652 45,-652"/>
+<polygon fill="none" stroke="black" points="45,-652 45,-674 159,-674 159,-652 45,-652"/>
+<text text-anchor="start" x="87.62" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="45,-630 45,-652 159,-652 159,-630 45,-630"/>
+<text text-anchor="start" x="62.93" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="81.21" y="-637.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45,-608 45,-630 159,-630 159,-608 45,-608"/>
+<text text-anchor="start" x="53.6" y="-615.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="114.63" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="45,-586 45,-608 159,-608 159,-586 45,-586"/>
+<text text-anchor="start" x="65.26" y="-593.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="102.97" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="45,-564 45,-586 159,-586 159,-564 45,-564"/>
+<text text-anchor="start" x="47.76" y="-571.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="120.47" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="45,-542 45,-564 159,-564 159,-542 45,-542"/>
+<text text-anchor="start" x="57.87" y="-549.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="110.36" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="45,-520 45,-542 159,-542 159,-520 45,-520"/>
+<text text-anchor="start" x="64.87" y="-527.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="103.37" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="45,-498 45,-520 159,-520 159,-498 45,-498"/>
+<text text-anchor="start" x="52.05" y="-505.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="116.19" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="370.16,-732 370.16,-754 559.16,-754 559.16,-732 370.16,-732"/>
+<polygon fill="none" stroke="black" points="370.16,-732 370.16,-754 559.16,-754 559.16,-732 370.16,-732"/>
+<text text-anchor="start" x="419.18" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="370.16,-710 370.16,-732 559.16,-732 559.16,-710 370.16,-710"/>
+<text text-anchor="start" x="425.59" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="443.87" y="-717.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="370.16,-688 370.16,-710 559.16,-710 559.16,-688 370.16,-688"/>
+<text text-anchor="start" x="407.31" y="-695.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="462.14" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="370.16,-666 370.16,-688 559.16,-688 559.16,-666 370.16,-666"/>
+<text text-anchor="start" x="406.54" y="-673.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="487.01" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="370.16,-644 370.16,-666 559.16,-666 559.16,-644 370.16,-644"/>
+<polygon fill="none" stroke="black" points="370.16,-644 370.16,-666 559.16,-666 559.16,-644 370.16,-644"/>
+<text text-anchor="start" x="444.45" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="370.16,-622 370.16,-644 559.16,-644 559.16,-622 370.16,-622"/>
+<text text-anchor="start" x="372.91" y="-628.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M560.16,-699C629.56,-699 649.45,-699 714.01,-699"/>
+<polygon fill="black" stroke="black" points="714.32,-702.5 724.32,-699 714.32,-695.5 714.32,-702.5"/>
+<text text-anchor="middle" x="642.99" y="-703.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="367.16,-564 367.16,-586 562.16,-586 562.16,-564 367.16,-564"/>
+<polygon fill="none" stroke="black" points="367.16,-564 367.16,-586 562.16,-586 562.16,-564 367.16,-564"/>
+<text text-anchor="start" x="416.06" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="367.16,-542 367.16,-564 562.16,-564 562.16,-542 367.16,-542"/>
+<text text-anchor="start" x="425.59" y="-549.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="443.87" y="-549.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="367.16,-520 367.16,-542 562.16,-542 562.16,-520 367.16,-520"/>
+<text text-anchor="start" x="407.31" y="-527.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="462.14" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="367.16,-498 367.16,-520 562.16,-520 562.16,-498 367.16,-498"/>
+<polygon fill="none" stroke="black" points="367.16,-498 367.16,-520 562.16,-520 562.16,-498 367.16,-498"/>
+<text text-anchor="start" x="444.45" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="367.16,-476 367.16,-498 562.16,-498 562.16,-476 367.16,-476"/>
+<text text-anchor="start" x="369.79" y="-482.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M561.66,-531C610.28,-531 664.81,-678.04 714.19,-697"/>
+<polygon fill="black" stroke="black" points="713.83,-700.49 724.32,-699 715.19,-693.63 713.83,-700.49"/>
+<text text-anchor="middle" x="642.99" y="-629.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="369.16,-418 369.16,-440 560.16,-440 560.16,-418 369.16,-418"/>
+<polygon fill="none" stroke="black" points="369.16,-418 369.16,-440 560.16,-440 560.16,-418 369.16,-418"/>
+<text text-anchor="start" x="443.28" y="-425.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="369.16,-396 369.16,-418 560.16,-418 560.16,-396 369.16,-396"/>
+<text text-anchor="start" x="425.59" y="-403.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="443.87" y="-403.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="369.16,-374 369.16,-396 560.16,-396 560.16,-374 369.16,-374"/>
+<text text-anchor="start" x="407.31" y="-381.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="462.14" y="-381.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="369.16,-352 369.16,-374 560.16,-374 560.16,-352 369.16,-352"/>
+<text text-anchor="start" x="409.26" y="-359.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="460.2" y="-359.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="369.16,-330 369.16,-352 560.16,-352 560.16,-330 369.16,-330"/>
+<text text-anchor="start" x="407.7" y="-337.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="461.76" y="-337.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="369.16,-308 369.16,-330 560.16,-330 560.16,-308 369.16,-308"/>
+<text text-anchor="start" x="432.19" y="-315.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="461.36" y="-315.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="369.16,-286 369.16,-308 560.16,-308 560.16,-286 369.16,-286"/>
+<text text-anchor="start" x="417.04" y="-293.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="476.52" y="-293.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="369.16,-264 369.16,-286 560.16,-286 560.16,-264 369.16,-264"/>
+<text text-anchor="start" x="409.65" y="-271.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="459.8" y="-271.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="369.16,-242 369.16,-264 560.16,-264 560.16,-242 369.16,-242"/>
+<text text-anchor="start" x="405.37" y="-249.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="464.08" y="-249.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="369.16,-220 369.16,-242 560.16,-242 560.16,-220 369.16,-220"/>
+<text text-anchor="start" x="406.93" y="-227.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="462.52" y="-227.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="369.16,-198 369.16,-220 560.16,-220 560.16,-198 369.16,-198"/>
+<text text-anchor="start" x="426.36" y="-205.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="466.41" y="-205.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="369.16,-176 369.16,-198 560.16,-198 560.16,-176 369.16,-176"/>
+<text text-anchor="start" x="420.15" y="-183.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="473.41" y="-183.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="369.16,-154 369.16,-176 560.16,-176 560.16,-154 369.16,-154"/>
+<text text-anchor="start" x="416.26" y="-161.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="453.2" y="-161.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="369.16,-132 369.16,-154 560.16,-154 560.16,-132 369.16,-132"/>
+<text text-anchor="start" x="392.53" y="-139.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="501.02" y="-139.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="369.16,-110 369.16,-132 560.16,-132 560.16,-110 369.16,-110"/>
+<text text-anchor="start" x="383.59" y="-117.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="509.96" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="369.16,-88 369.16,-110 560.16,-110 560.16,-88 369.16,-88"/>
+<text text-anchor="start" x="404.59" y="-95.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="488.96" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="369.16,-66 369.16,-88 560.16,-88 560.16,-66 369.16,-66"/>
+<text text-anchor="start" x="403.03" y="-73.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="490.52" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="369.16,-44 369.16,-66 560.16,-66 560.16,-44 369.16,-44"/>
+<text text-anchor="start" x="393.32" y="-51.4" font-family="Times,serif" font-size="14.00">episodes_updated: </text>
+<text text-anchor="start" x="500.24" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="369.16,-22 369.16,-44 560.16,-44 560.16,-22 369.16,-22"/>
+<polygon fill="none" stroke="black" points="369.16,-22 369.16,-44 560.16,-44 560.16,-22 369.16,-22"/>
+<text text-anchor="start" x="444.45" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="369.16,0 369.16,-22 560.16,-22 560.16,0 369.16,0"/>
+<text text-anchor="start" x="372.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M561.16,-385C636.26,-385 645.01,-671.42 714.15,-697.16"/>
+<polygon fill="black" stroke="black" points="713.86,-700.66 724.32,-699 715.11,-693.77 713.86,-700.66"/>
+<text text-anchor="middle" x="642.99" y="-574.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="0,-440 0,-462 204,-462 204,-440 0,-440"/>
+<polygon fill="none" stroke="black" points="0,-440 0,-462 204,-462 204,-440 0,-440"/>
+<text text-anchor="start" x="77.9" y="-447.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="0,-418 0,-440 204,-440 204,-418 0,-418"/>
+<text text-anchor="start" x="62.93" y="-425.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="81.21" y="-425.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-396 0,-418 204,-418 204,-396 0,-396"/>
+<text text-anchor="start" x="40.77" y="-403.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="103.37" y="-403.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-374 0,-396 204,-396 204,-374 0,-374"/>
+<text text-anchor="start" x="46.6" y="-381.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="97.53" y="-381.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-352 0,-374 204,-374 204,-352 0,-352"/>
+<text text-anchor="start" x="45.03" y="-359.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="99.1" y="-359.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-330 0,-352 204,-352 204,-330 0,-330"/>
+<text text-anchor="start" x="69.53" y="-337.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="98.7" y="-337.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-308 0,-330 204,-330 204,-308 0,-308"/>
+<text text-anchor="start" x="54.38" y="-315.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="113.86" y="-315.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-286 0,-308 204,-308 204,-286 0,-286"/>
+<text text-anchor="start" x="46.99" y="-293.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="97.14" y="-293.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-264 0,-286 204,-286 204,-264 0,-264"/>
+<text text-anchor="start" x="51.66" y="-271.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="116.58" y="-271.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-242 0,-264 204,-264 204,-242 0,-242"/>
+<text text-anchor="start" x="63.7" y="-249.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="103.75" y="-249.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="0,-220 0,-242 204,-242 204,-220 0,-220"/>
+<text text-anchor="start" x="53.6" y="-227.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="90.54" y="-227.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-198 0,-220 204,-220 204,-198 0,-198"/>
+<text text-anchor="start" x="29.87" y="-205.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="138.36" y="-205.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-176 0,-198 204,-198 204,-176 0,-176"/>
+<text text-anchor="start" x="20.93" y="-183.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="147.3" y="-183.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-154 0,-176 204,-176 204,-154 0,-154"/>
+<text text-anchor="start" x="41.93" y="-161.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="126.3" y="-161.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-132 0,-154 204,-154 204,-132 0,-132"/>
+<text text-anchor="start" x="40.37" y="-139.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="127.86" y="-139.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0,-110 0,-132 204,-132 204,-110 0,-110"/>
+<polygon fill="none" stroke="black" points="0,-110 0,-132 204,-132 204,-110 0,-110"/>
+<text text-anchor="start" x="81.79" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0,-88 0,-110 204,-110 204,-88 0,-88"/>
+<text text-anchor="start" x="2.86" y="-94.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M204,-407C273.4,-407 293.29,-407 357.85,-407"/>
+<polygon fill="black" stroke="black" points="358.16,-410.5 368.16,-407 358.16,-403.5 358.16,-410.5"/>
+<text text-anchor="middle" x="285.33" y="-411.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/me.banes.chris.tivi.data.TiviDatabase/13.svg
+++ b/data-android/floorplan-output/me.banes.chris.tivi.data.TiviDatabase/13.svg
@@ -1,0 +1,348 @@
+<svg width="964px" height="1206px"
+ viewBox="0.00 0.00 964.32 1206.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1170)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1170 928.32,-1170 928.32,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="724.32,-710 724.32,-732 892.32,-732 892.32,-710 724.32,-710"/>
+<polygon fill="none" stroke="black" points="724.32,-710 724.32,-732 892.32,-732 892.32,-710 724.32,-710"/>
+<text text-anchor="start" x="790.82" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="724.32,-688 724.32,-710 892.32,-710 892.32,-688 724.32,-688"/>
+<text text-anchor="start" x="769.25" y="-695.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="787.53" y="-695.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="724.32,-666 724.32,-688 892.32,-688 892.32,-666 724.32,-666"/>
+<text text-anchor="start" x="775.86" y="-673.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="805.02" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-644 724.32,-666 892.32,-666 892.32,-644 724.32,-644"/>
+<text text-anchor="start" x="750.58" y="-651.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="830.3" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-622 724.32,-644 892.32,-644 892.32,-622 724.32,-622"/>
+<text text-anchor="start" x="752.92" y="-629.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="803.86" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="724.32,-600 724.32,-622 892.32,-622 892.32,-600 724.32,-600"/>
+<text text-anchor="start" x="751.36" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="805.42" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="724.32,-578 724.32,-600 892.32,-600 892.32,-578 724.32,-578"/>
+<text text-anchor="start" x="736.2" y="-585.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="844.68" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-556 724.32,-578 892.32,-578 892.32,-556 724.32,-556"/>
+<text text-anchor="start" x="727.26" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="853.62" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-534 724.32,-556 892.32,-556 892.32,-534 724.32,-534"/>
+<text text-anchor="start" x="748.26" y="-541.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="832.62" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-512 724.32,-534 892.32,-534 892.32,-512 724.32,-512"/>
+<text text-anchor="start" x="746.69" y="-519.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="834.18" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-490 724.32,-512 892.32,-512 892.32,-490 724.32,-490"/>
+<text text-anchor="start" x="760.7" y="-497.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="820.18" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-468 724.32,-490 892.32,-490 892.32,-468 724.32,-468"/>
+<text text-anchor="start" x="757.98" y="-475.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="822.9" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-446 724.32,-468 892.32,-468 892.32,-446 724.32,-446"/>
+<text text-anchor="start" x="770.02" y="-453.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="810.07" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="724.32,-424 724.32,-446 892.32,-446 892.32,-424 724.32,-424"/>
+<text text-anchor="start" x="752.93" y="-431.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="827.95" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-402 724.32,-424 892.32,-424 892.32,-402 724.32,-402"/>
+<text text-anchor="start" x="765.36" y="-409.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="815.52" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-380 724.32,-402 892.32,-402 892.32,-380 724.32,-380"/>
+<text text-anchor="start" x="763.81" y="-387.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="817.07" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="724.32,-358 724.32,-380 892.32,-380 892.32,-358 724.32,-358"/>
+<text text-anchor="start" x="752.92" y="-365.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="803.86" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="724.32,-336 724.32,-358 892.32,-358 892.32,-336 724.32,-336"/>
+<text text-anchor="start" x="768.48" y="-343.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="812.4" y="-343.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="724.32,-314 724.32,-336 892.32,-336 892.32,-314 724.32,-314"/>
+<polygon fill="none" stroke="black" points="724.32,-314 724.32,-336 892.32,-336 892.32,-314 724.32,-314"/>
+<text text-anchor="start" x="788.11" y="-321.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="724.32,-292 724.32,-314 892.32,-314 892.32,-292 724.32,-292"/>
+<text text-anchor="start" x="746.5" y="-298.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="724.32,-270 724.32,-292 892.32,-292 892.32,-270 724.32,-270"/>
+<text text-anchor="start" x="744.93" y="-276.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="371.16,-1112 371.16,-1134 558.16,-1134 558.16,-1112 371.16,-1112"/>
+<polygon fill="none" stroke="black" points="371.16,-1112 371.16,-1134 558.16,-1134 558.16,-1112 371.16,-1112"/>
+<text text-anchor="start" x="420.33" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="371.16,-1090 371.16,-1112 558.16,-1112 558.16,-1090 371.16,-1090"/>
+<text text-anchor="start" x="425.59" y="-1097.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="443.87" y="-1097.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="371.16,-1068 371.16,-1090 558.16,-1090 558.16,-1068 371.16,-1068"/>
+<text text-anchor="start" x="407.31" y="-1075.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="462.14" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="371.16,-1046 371.16,-1068 558.16,-1068 558.16,-1046 371.16,-1046"/>
+<text text-anchor="start" x="417.82" y="-1053.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="451.64" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="371.16,-1024 371.16,-1046 558.16,-1046 558.16,-1024 371.16,-1024"/>
+<text text-anchor="start" x="406.16" y="-1031.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="463.29" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="371.16,-1002 371.16,-1024 558.16,-1024 558.16,-1002 371.16,-1002"/>
+<polygon fill="none" stroke="black" points="371.16,-1002 371.16,-1024 558.16,-1024 558.16,-1002 371.16,-1002"/>
+<text text-anchor="start" x="444.45" y="-1009.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="371.16,-980 371.16,-1002 558.16,-1002 558.16,-980 371.16,-980"/>
+<text text-anchor="start" x="374.06" y="-986.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M559.16,-1079C602.23,-1079 668.97,-746.41 715.1,-703.53"/>
+<polygon fill="black" stroke="black" points="716.89,-706.55 724.32,-699 713.8,-700.27 716.89,-706.55"/>
+<text text-anchor="middle" x="642.99" y="-915.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="373.16,-922 373.16,-944 556.16,-944 556.16,-922 373.16,-922"/>
+<polygon fill="none" stroke="black" points="373.16,-922 373.16,-944 556.16,-944 556.16,-922 373.16,-922"/>
+<text text-anchor="start" x="422.28" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="373.16,-900 373.16,-922 556.16,-922 556.16,-900 373.16,-900"/>
+<text text-anchor="start" x="425.59" y="-907.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="443.87" y="-907.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="373.16,-878 373.16,-900 556.16,-900 556.16,-878 373.16,-878"/>
+<text text-anchor="start" x="407.31" y="-885.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="462.14" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="373.16,-856 373.16,-878 556.16,-878 556.16,-856 373.16,-856"/>
+<text text-anchor="start" x="417.82" y="-863.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="451.64" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="373.16,-834 373.16,-856 556.16,-856 556.16,-834 373.16,-834"/>
+<text text-anchor="start" x="399.55" y="-841.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="469.9" y="-841.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="373.16,-812 373.16,-834 556.16,-834 556.16,-812 373.16,-812"/>
+<polygon fill="none" stroke="black" points="373.16,-812 373.16,-834 556.16,-834 556.16,-812 373.16,-812"/>
+<text text-anchor="start" x="444.45" y="-819.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="373.16,-790 373.16,-812 556.16,-812 556.16,-790 373.16,-790"/>
+<text text-anchor="start" x="376.01" y="-796.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M557.16,-889C666.12,-889 615.29,-710.69 714.27,-699.55"/>
+<polygon fill="black" stroke="black" points="714.53,-703.04 724.32,-699 714.15,-696.05 714.53,-703.04"/>
+<text text-anchor="middle" x="642.99" y="-820.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="45,-652 45,-674 159,-674 159,-652 45,-652"/>
+<polygon fill="none" stroke="black" points="45,-652 45,-674 159,-674 159,-652 45,-652"/>
+<text text-anchor="start" x="87.62" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="45,-630 45,-652 159,-652 159,-630 45,-630"/>
+<text text-anchor="start" x="62.93" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="81.21" y="-637.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45,-608 45,-630 159,-630 159,-608 45,-608"/>
+<text text-anchor="start" x="53.6" y="-615.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="114.63" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="45,-586 45,-608 159,-608 159,-586 45,-586"/>
+<text text-anchor="start" x="65.26" y="-593.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="102.97" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="45,-564 45,-586 159,-586 159,-564 45,-564"/>
+<text text-anchor="start" x="47.76" y="-571.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="120.47" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="45,-542 45,-564 159,-564 159,-542 45,-542"/>
+<text text-anchor="start" x="57.87" y="-549.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="110.36" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="45,-520 45,-542 159,-542 159,-520 45,-520"/>
+<text text-anchor="start" x="64.87" y="-527.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="103.37" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="45,-498 45,-520 159,-520 159,-498 45,-498"/>
+<text text-anchor="start" x="52.05" y="-505.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="116.19" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="370.16,-732 370.16,-754 559.16,-754 559.16,-732 370.16,-732"/>
+<polygon fill="none" stroke="black" points="370.16,-732 370.16,-754 559.16,-754 559.16,-732 370.16,-732"/>
+<text text-anchor="start" x="419.18" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="370.16,-710 370.16,-732 559.16,-732 559.16,-710 370.16,-710"/>
+<text text-anchor="start" x="425.59" y="-717.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="443.87" y="-717.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="370.16,-688 370.16,-710 559.16,-710 559.16,-688 370.16,-688"/>
+<text text-anchor="start" x="407.31" y="-695.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="462.14" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="370.16,-666 370.16,-688 559.16,-688 559.16,-666 370.16,-666"/>
+<text text-anchor="start" x="406.54" y="-673.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="487.01" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="370.16,-644 370.16,-666 559.16,-666 559.16,-644 370.16,-644"/>
+<polygon fill="none" stroke="black" points="370.16,-644 370.16,-666 559.16,-666 559.16,-644 370.16,-644"/>
+<text text-anchor="start" x="444.45" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="370.16,-622 370.16,-644 559.16,-644 559.16,-622 370.16,-622"/>
+<text text-anchor="start" x="372.91" y="-628.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M560.16,-699C629.56,-699 649.45,-699 714.01,-699"/>
+<polygon fill="black" stroke="black" points="714.32,-702.5 724.32,-699 714.32,-695.5 714.32,-702.5"/>
+<text text-anchor="middle" x="642.99" y="-703.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="367.16,-564 367.16,-586 562.16,-586 562.16,-564 367.16,-564"/>
+<polygon fill="none" stroke="black" points="367.16,-564 367.16,-586 562.16,-586 562.16,-564 367.16,-564"/>
+<text text-anchor="start" x="416.06" y="-571.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="367.16,-542 367.16,-564 562.16,-564 562.16,-542 367.16,-542"/>
+<text text-anchor="start" x="425.59" y="-549.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="443.87" y="-549.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="367.16,-520 367.16,-542 562.16,-542 562.16,-520 367.16,-520"/>
+<text text-anchor="start" x="407.31" y="-527.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="462.14" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="367.16,-498 367.16,-520 562.16,-520 562.16,-498 367.16,-498"/>
+<polygon fill="none" stroke="black" points="367.16,-498 367.16,-520 562.16,-520 562.16,-498 367.16,-498"/>
+<text text-anchor="start" x="444.45" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="367.16,-476 367.16,-498 562.16,-498 562.16,-476 367.16,-476"/>
+<text text-anchor="start" x="369.79" y="-482.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M561.66,-531C610.28,-531 664.81,-678.04 714.19,-697"/>
+<polygon fill="black" stroke="black" points="713.83,-700.49 724.32,-699 715.19,-693.63 713.83,-700.49"/>
+<text text-anchor="middle" x="642.99" y="-629.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="369.16,-418 369.16,-440 560.16,-440 560.16,-418 369.16,-418"/>
+<polygon fill="none" stroke="black" points="369.16,-418 369.16,-440 560.16,-440 560.16,-418 369.16,-418"/>
+<text text-anchor="start" x="443.28" y="-425.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="369.16,-396 369.16,-418 560.16,-418 560.16,-396 369.16,-396"/>
+<text text-anchor="start" x="425.59" y="-403.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="443.87" y="-403.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="369.16,-374 369.16,-396 560.16,-396 560.16,-374 369.16,-374"/>
+<text text-anchor="start" x="407.31" y="-381.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="462.14" y="-381.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="369.16,-352 369.16,-374 560.16,-374 560.16,-352 369.16,-352"/>
+<text text-anchor="start" x="409.26" y="-359.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="460.2" y="-359.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="369.16,-330 369.16,-352 560.16,-352 560.16,-330 369.16,-330"/>
+<text text-anchor="start" x="407.7" y="-337.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="461.76" y="-337.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="369.16,-308 369.16,-330 560.16,-330 560.16,-308 369.16,-308"/>
+<text text-anchor="start" x="432.19" y="-315.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="461.36" y="-315.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="369.16,-286 369.16,-308 560.16,-308 560.16,-286 369.16,-286"/>
+<text text-anchor="start" x="417.04" y="-293.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="476.52" y="-293.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="369.16,-264 369.16,-286 560.16,-286 560.16,-264 369.16,-264"/>
+<text text-anchor="start" x="409.65" y="-271.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="459.8" y="-271.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="369.16,-242 369.16,-264 560.16,-264 560.16,-242 369.16,-242"/>
+<text text-anchor="start" x="405.37" y="-249.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="464.08" y="-249.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="369.16,-220 369.16,-242 560.16,-242 560.16,-220 369.16,-220"/>
+<text text-anchor="start" x="406.93" y="-227.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="462.52" y="-227.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="369.16,-198 369.16,-220 560.16,-220 560.16,-198 369.16,-198"/>
+<text text-anchor="start" x="426.36" y="-205.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="466.41" y="-205.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="369.16,-176 369.16,-198 560.16,-198 560.16,-176 369.16,-176"/>
+<text text-anchor="start" x="420.15" y="-183.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="473.41" y="-183.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="369.16,-154 369.16,-176 560.16,-176 560.16,-154 369.16,-154"/>
+<text text-anchor="start" x="416.26" y="-161.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="453.2" y="-161.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="369.16,-132 369.16,-154 560.16,-154 560.16,-132 369.16,-132"/>
+<text text-anchor="start" x="392.53" y="-139.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="501.02" y="-139.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="369.16,-110 369.16,-132 560.16,-132 560.16,-110 369.16,-110"/>
+<text text-anchor="start" x="383.59" y="-117.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="509.96" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="369.16,-88 369.16,-110 560.16,-110 560.16,-88 369.16,-88"/>
+<text text-anchor="start" x="404.59" y="-95.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="488.96" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="369.16,-66 369.16,-88 560.16,-88 560.16,-66 369.16,-66"/>
+<text text-anchor="start" x="403.03" y="-73.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="490.52" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="369.16,-44 369.16,-66 560.16,-66 560.16,-44 369.16,-44"/>
+<text text-anchor="start" x="393.32" y="-51.4" font-family="Times,serif" font-size="14.00">episodes_updated: </text>
+<text text-anchor="start" x="500.24" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="369.16,-22 369.16,-44 560.16,-44 560.16,-22 369.16,-22"/>
+<polygon fill="none" stroke="black" points="369.16,-22 369.16,-44 560.16,-44 560.16,-22 369.16,-22"/>
+<text text-anchor="start" x="444.45" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="369.16,0 369.16,-22 560.16,-22 560.16,0 369.16,0"/>
+<text text-anchor="start" x="372.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M561.16,-385C636.26,-385 645.01,-671.42 714.15,-697.16"/>
+<polygon fill="black" stroke="black" points="713.86,-700.66 724.32,-699 715.11,-693.77 713.86,-700.66"/>
+<text text-anchor="middle" x="642.99" y="-574.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="0,-440 0,-462 204,-462 204,-440 0,-440"/>
+<polygon fill="none" stroke="black" points="0,-440 0,-462 204,-462 204,-440 0,-440"/>
+<text text-anchor="start" x="77.9" y="-447.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="0,-418 0,-440 204,-440 204,-418 0,-418"/>
+<text text-anchor="start" x="62.93" y="-425.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="81.21" y="-425.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-396 0,-418 204,-418 204,-396 0,-396"/>
+<text text-anchor="start" x="40.77" y="-403.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="103.37" y="-403.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-374 0,-396 204,-396 204,-374 0,-374"/>
+<text text-anchor="start" x="46.6" y="-381.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="97.53" y="-381.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-352 0,-374 204,-374 204,-352 0,-352"/>
+<text text-anchor="start" x="45.03" y="-359.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="99.1" y="-359.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-330 0,-352 204,-352 204,-330 0,-330"/>
+<text text-anchor="start" x="69.53" y="-337.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="98.7" y="-337.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-308 0,-330 204,-330 204,-308 0,-308"/>
+<text text-anchor="start" x="54.38" y="-315.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="113.86" y="-315.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-286 0,-308 204,-308 204,-286 0,-286"/>
+<text text-anchor="start" x="46.99" y="-293.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="97.14" y="-293.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-264 0,-286 204,-286 204,-264 0,-264"/>
+<text text-anchor="start" x="51.66" y="-271.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="116.58" y="-271.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-242 0,-264 204,-264 204,-242 0,-242"/>
+<text text-anchor="start" x="63.7" y="-249.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="103.75" y="-249.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="0,-220 0,-242 204,-242 204,-220 0,-220"/>
+<text text-anchor="start" x="53.6" y="-227.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="90.54" y="-227.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-198 0,-220 204,-220 204,-198 0,-198"/>
+<text text-anchor="start" x="29.87" y="-205.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="138.36" y="-205.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-176 0,-198 204,-198 204,-176 0,-176"/>
+<text text-anchor="start" x="20.93" y="-183.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="147.3" y="-183.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-154 0,-176 204,-176 204,-154 0,-154"/>
+<text text-anchor="start" x="41.93" y="-161.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="126.3" y="-161.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-132 0,-154 204,-154 204,-132 0,-132"/>
+<text text-anchor="start" x="40.37" y="-139.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="127.86" y="-139.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-110 0,-132 204,-132 204,-110 0,-110"/>
+<text text-anchor="start" x="35.33" y="-117.4" font-family="Times,serif" font-size="14.00">last_watched_at: </text>
+<text text-anchor="start" x="132.91" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0,-88 0,-110 204,-110 204,-88 0,-88"/>
+<polygon fill="none" stroke="black" points="0,-88 0,-110 204,-110 204,-88 0,-88"/>
+<text text-anchor="start" x="81.79" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0,-66 0,-88 204,-88 204,-66 0,-66"/>
+<text text-anchor="start" x="2.86" y="-72.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M204,-407C273.4,-407 293.29,-407 357.85,-407"/>
+<polygon fill="black" stroke="black" points="358.16,-410.5 368.16,-407 358.16,-403.5 358.16,-410.5"/>
+<text text-anchor="middle" x="285.33" y="-411.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/me.banes.chris.tivi.data.TiviDatabase/14.svg
+++ b/data-android/floorplan-output/me.banes.chris.tivi.data.TiviDatabase/14.svg
@@ -1,0 +1,388 @@
+<svg width="983px" height="1418px"
+ viewBox="0.00 0.00 983.32 1418.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1382)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1382 947.32,-1382 947.32,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="743.32,-754 743.32,-776 911.32,-776 911.32,-754 743.32,-754"/>
+<polygon fill="none" stroke="black" points="743.32,-754 743.32,-776 911.32,-776 911.32,-754 743.32,-754"/>
+<text text-anchor="start" x="809.82" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="743.32,-732 743.32,-754 911.32,-754 911.32,-732 743.32,-732"/>
+<text text-anchor="start" x="788.25" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="806.53" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="743.32,-710 743.32,-732 911.32,-732 911.32,-710 743.32,-710"/>
+<text text-anchor="start" x="794.86" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="824.02" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="743.32,-688 743.32,-710 911.32,-710 911.32,-688 743.32,-688"/>
+<text text-anchor="start" x="769.58" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="849.3" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="743.32,-666 743.32,-688 911.32,-688 911.32,-666 743.32,-666"/>
+<text text-anchor="start" x="771.92" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="822.86" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="743.32,-644 743.32,-666 911.32,-666 911.32,-644 743.32,-644"/>
+<text text-anchor="start" x="770.36" y="-651.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="824.42" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="743.32,-622 743.32,-644 911.32,-644 911.32,-622 743.32,-622"/>
+<text text-anchor="start" x="755.2" y="-629.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="863.68" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="743.32,-600 743.32,-622 911.32,-622 911.32,-600 743.32,-600"/>
+<text text-anchor="start" x="746.26" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="872.62" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="743.32,-578 743.32,-600 911.32,-600 911.32,-578 743.32,-578"/>
+<text text-anchor="start" x="767.26" y="-585.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="851.62" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="743.32,-556 743.32,-578 911.32,-578 911.32,-556 743.32,-556"/>
+<text text-anchor="start" x="765.69" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="853.18" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="743.32,-534 743.32,-556 911.32,-556 911.32,-534 743.32,-534"/>
+<text text-anchor="start" x="779.7" y="-541.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="839.18" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="743.32,-512 743.32,-534 911.32,-534 911.32,-512 743.32,-512"/>
+<text text-anchor="start" x="776.98" y="-519.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="841.9" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="743.32,-490 743.32,-512 911.32,-512 911.32,-490 743.32,-490"/>
+<text text-anchor="start" x="789.02" y="-497.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="829.07" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="743.32,-468 743.32,-490 911.32,-490 911.32,-468 743.32,-468"/>
+<text text-anchor="start" x="771.93" y="-475.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="846.95" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="743.32,-446 743.32,-468 911.32,-468 911.32,-446 743.32,-446"/>
+<text text-anchor="start" x="784.36" y="-453.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="834.52" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="743.32,-424 743.32,-446 911.32,-446 911.32,-424 743.32,-424"/>
+<text text-anchor="start" x="782.81" y="-431.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="836.07" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="743.32,-402 743.32,-424 911.32,-424 911.32,-402 743.32,-402"/>
+<text text-anchor="start" x="771.92" y="-409.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="822.86" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="743.32,-380 743.32,-402 911.32,-402 911.32,-380 743.32,-380"/>
+<text text-anchor="start" x="787.48" y="-387.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="831.4" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="743.32,-358 743.32,-380 911.32,-380 911.32,-358 743.32,-358"/>
+<polygon fill="none" stroke="black" points="743.32,-358 743.32,-380 911.32,-380 911.32,-358 743.32,-358"/>
+<text text-anchor="start" x="807.11" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="743.32,-336 743.32,-358 911.32,-358 911.32,-336 743.32,-336"/>
+<text text-anchor="start" x="765.5" y="-342.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="743.32,-314 743.32,-336 911.32,-336 911.32,-314 743.32,-314"/>
+<text text-anchor="start" x="763.93" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="380.66,-1324 380.66,-1346 567.66,-1346 567.66,-1324 380.66,-1324"/>
+<polygon fill="none" stroke="black" points="380.66,-1324 380.66,-1346 567.66,-1346 567.66,-1324 380.66,-1324"/>
+<text text-anchor="start" x="429.83" y="-1331.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="380.66,-1302 380.66,-1324 567.66,-1324 567.66,-1302 380.66,-1302"/>
+<text text-anchor="start" x="435.09" y="-1309.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="453.37" y="-1309.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="380.66,-1280 380.66,-1302 567.66,-1302 567.66,-1280 380.66,-1280"/>
+<text text-anchor="start" x="416.81" y="-1287.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="471.64" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="380.66,-1258 380.66,-1280 567.66,-1280 567.66,-1258 380.66,-1258"/>
+<text text-anchor="start" x="427.32" y="-1265.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="461.14" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="380.66,-1236 380.66,-1258 567.66,-1258 567.66,-1236 380.66,-1236"/>
+<text text-anchor="start" x="415.66" y="-1243.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="472.79" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="380.66,-1214 380.66,-1236 567.66,-1236 567.66,-1214 380.66,-1214"/>
+<polygon fill="none" stroke="black" points="380.66,-1214 380.66,-1236 567.66,-1236 567.66,-1214 380.66,-1214"/>
+<text text-anchor="start" x="453.95" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="380.66,-1192 380.66,-1214 567.66,-1214 567.66,-1192 380.66,-1192"/>
+<text text-anchor="start" x="383.56" y="-1198.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M568.66,-1291C598.49,-1291 697.01,-813.36 735.96,-749.93"/>
+<polygon fill="black" stroke="black" points="738.44,-752.4 743.32,-743 733.64,-747.3 738.44,-752.4"/>
+<text text-anchor="middle" x="661.99" y="-1021.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="382.66,-1134 382.66,-1156 565.66,-1156 565.66,-1134 382.66,-1134"/>
+<polygon fill="none" stroke="black" points="382.66,-1134 382.66,-1156 565.66,-1156 565.66,-1134 382.66,-1134"/>
+<text text-anchor="start" x="431.78" y="-1141.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="382.66,-1112 382.66,-1134 565.66,-1134 565.66,-1112 382.66,-1112"/>
+<text text-anchor="start" x="435.09" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="453.37" y="-1119.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="382.66,-1090 382.66,-1112 565.66,-1112 565.66,-1090 382.66,-1090"/>
+<text text-anchor="start" x="416.81" y="-1097.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="471.64" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="382.66,-1068 382.66,-1090 565.66,-1090 565.66,-1068 382.66,-1068"/>
+<text text-anchor="start" x="427.32" y="-1075.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="461.14" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="382.66,-1046 382.66,-1068 565.66,-1068 565.66,-1046 382.66,-1046"/>
+<text text-anchor="start" x="409.05" y="-1053.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="479.4" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="382.66,-1024 382.66,-1046 565.66,-1046 565.66,-1024 382.66,-1024"/>
+<polygon fill="none" stroke="black" points="382.66,-1024 382.66,-1046 565.66,-1046 565.66,-1024 382.66,-1024"/>
+<text text-anchor="start" x="453.95" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="382.66,-1002 382.66,-1024 565.66,-1024 565.66,-1002 382.66,-1002"/>
+<text text-anchor="start" x="385.51" y="-1008.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M566.66,-1101C651.91,-1101 654.53,-770.42 733.32,-744.6"/>
+<polygon fill="black" stroke="black" points="734,-748.03 743.32,-743 732.89,-741.12 734,-748.03"/>
+<text text-anchor="middle" x="661.99" y="-926.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="45,-864 45,-886 159,-886 159,-864 45,-864"/>
+<polygon fill="none" stroke="black" points="45,-864 45,-886 159,-886 159,-864 45,-864"/>
+<text text-anchor="start" x="87.62" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="45,-842 45,-864 159,-864 159,-842 45,-842"/>
+<text text-anchor="start" x="62.93" y="-849.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="81.21" y="-849.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45,-820 45,-842 159,-842 159,-820 45,-820"/>
+<text text-anchor="start" x="53.6" y="-827.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="114.63" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="45,-798 45,-820 159,-820 159,-798 45,-798"/>
+<text text-anchor="start" x="65.26" y="-805.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="102.97" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="45,-776 45,-798 159,-798 159,-776 45,-776"/>
+<text text-anchor="start" x="47.76" y="-783.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="120.47" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="45,-754 45,-776 159,-776 159,-754 45,-754"/>
+<text text-anchor="start" x="57.87" y="-761.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="110.36" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="45,-732 45,-754 159,-754 159,-732 45,-732"/>
+<text text-anchor="start" x="64.87" y="-739.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="103.37" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="45,-710 45,-732 159,-732 159,-710 45,-710"/>
+<text text-anchor="start" x="52.05" y="-717.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="116.19" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="379.66,-944 379.66,-966 568.66,-966 568.66,-944 379.66,-944"/>
+<polygon fill="none" stroke="black" points="379.66,-944 379.66,-966 568.66,-966 568.66,-944 379.66,-944"/>
+<text text-anchor="start" x="428.68" y="-951.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="379.66,-922 379.66,-944 568.66,-944 568.66,-922 379.66,-922"/>
+<text text-anchor="start" x="435.09" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="453.37" y="-929.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="379.66,-900 379.66,-922 568.66,-922 568.66,-900 379.66,-900"/>
+<text text-anchor="start" x="416.81" y="-907.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="471.64" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="379.66,-878 379.66,-900 568.66,-900 568.66,-878 379.66,-878"/>
+<text text-anchor="start" x="416.04" y="-885.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="496.51" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="379.66,-856 379.66,-878 568.66,-878 568.66,-856 379.66,-856"/>
+<polygon fill="none" stroke="black" points="379.66,-856 379.66,-878 568.66,-878 568.66,-856 379.66,-856"/>
+<text text-anchor="start" x="453.95" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="379.66,-834 379.66,-856 568.66,-856 568.66,-834 379.66,-834"/>
+<text text-anchor="start" x="382.41" y="-840.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M569.66,-911C673.48,-911 638.5,-753.97 733.1,-743.54"/>
+<polygon fill="black" stroke="black" points="733.52,-747.03 743.32,-743 733.15,-740.04 733.52,-747.03"/>
+<text text-anchor="middle" x="661.99" y="-836.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="376.66,-776 376.66,-798 571.66,-798 571.66,-776 376.66,-776"/>
+<polygon fill="none" stroke="black" points="376.66,-776 376.66,-798 571.66,-798 571.66,-776 376.66,-776"/>
+<text text-anchor="start" x="425.56" y="-783.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="376.66,-754 376.66,-776 571.66,-776 571.66,-754 376.66,-754"/>
+<text text-anchor="start" x="435.09" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="453.37" y="-761.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="376.66,-732 376.66,-754 571.66,-754 571.66,-732 376.66,-732"/>
+<text text-anchor="start" x="416.81" y="-739.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="471.64" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="376.66,-710 376.66,-732 571.66,-732 571.66,-710 376.66,-710"/>
+<polygon fill="none" stroke="black" points="376.66,-710 376.66,-732 571.66,-732 571.66,-710 376.66,-710"/>
+<text text-anchor="start" x="453.95" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="376.66,-688 376.66,-710 571.66,-710 571.66,-688 376.66,-688"/>
+<text text-anchor="start" x="379.29" y="-694.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M572.66,-743C644.95,-743 665.57,-743 733.02,-743"/>
+<polygon fill="black" stroke="black" points="733.32,-746.5 743.32,-743 733.32,-739.5 733.32,-746.5"/>
+<text text-anchor="middle" x="661.99" y="-747.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="378.66,-630 378.66,-652 569.66,-652 569.66,-630 378.66,-630"/>
+<polygon fill="none" stroke="black" points="378.66,-630 378.66,-652 569.66,-652 569.66,-630 378.66,-630"/>
+<text text-anchor="start" x="452.78" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="378.66,-608 378.66,-630 569.66,-630 569.66,-608 378.66,-608"/>
+<text text-anchor="start" x="435.09" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="453.37" y="-615.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="378.66,-586 378.66,-608 569.66,-608 569.66,-586 378.66,-586"/>
+<text text-anchor="start" x="416.81" y="-593.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="471.64" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="378.66,-564 378.66,-586 569.66,-586 569.66,-564 378.66,-564"/>
+<text text-anchor="start" x="418.76" y="-571.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="469.7" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="378.66,-542 378.66,-564 569.66,-564 569.66,-542 378.66,-542"/>
+<text text-anchor="start" x="417.2" y="-549.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="471.26" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="378.66,-520 378.66,-542 569.66,-542 569.66,-520 378.66,-520"/>
+<text text-anchor="start" x="441.69" y="-527.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="470.86" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="378.66,-498 378.66,-520 569.66,-520 569.66,-498 378.66,-498"/>
+<text text-anchor="start" x="426.54" y="-505.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="486.02" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="378.66,-476 378.66,-498 569.66,-498 569.66,-476 378.66,-476"/>
+<text text-anchor="start" x="419.15" y="-483.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="469.3" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="378.66,-454 378.66,-476 569.66,-476 569.66,-454 378.66,-454"/>
+<text text-anchor="start" x="414.87" y="-461.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="473.58" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="378.66,-432 378.66,-454 569.66,-454 569.66,-432 378.66,-432"/>
+<text text-anchor="start" x="416.43" y="-439.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="472.02" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="378.66,-410 378.66,-432 569.66,-432 569.66,-410 378.66,-410"/>
+<text text-anchor="start" x="435.86" y="-417.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="475.91" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="378.66,-388 378.66,-410 569.66,-410 569.66,-388 378.66,-388"/>
+<text text-anchor="start" x="429.65" y="-395.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="482.91" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="378.66,-366 378.66,-388 569.66,-388 569.66,-366 378.66,-366"/>
+<text text-anchor="start" x="425.76" y="-373.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="462.7" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="378.66,-344 378.66,-366 569.66,-366 569.66,-344 378.66,-344"/>
+<text text-anchor="start" x="402.03" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="510.52" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="378.66,-322 378.66,-344 569.66,-344 569.66,-322 378.66,-322"/>
+<text text-anchor="start" x="393.09" y="-329.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="519.46" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="378.66,-300 378.66,-322 569.66,-322 569.66,-300 378.66,-300"/>
+<text text-anchor="start" x="414.09" y="-307.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="498.46" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="378.66,-278 378.66,-300 569.66,-300 569.66,-278 378.66,-278"/>
+<text text-anchor="start" x="412.53" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="500.02" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="378.66,-256 378.66,-278 569.66,-278 569.66,-256 378.66,-256"/>
+<text text-anchor="start" x="402.82" y="-263.4" font-family="Times,serif" font-size="14.00">episodes_updated: </text>
+<text text-anchor="start" x="509.74" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="378.66,-234 378.66,-256 569.66,-256 569.66,-234 378.66,-234"/>
+<polygon fill="none" stroke="black" points="378.66,-234 378.66,-256 569.66,-256 569.66,-234 378.66,-234"/>
+<text text-anchor="start" x="453.95" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="378.66,-212 378.66,-234 569.66,-234 569.66,-212 378.66,-212"/>
+<text text-anchor="start" x="381.62" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M570.66,-597C628.99,-597 626.82,-643.49 671.32,-681.2 700.6,-706.01 701.29,-736.85 732.98,-742.19"/>
+<polygon fill="black" stroke="black" points="733.08,-745.71 743.32,-743 733.62,-738.73 733.08,-745.71"/>
+<text text-anchor="middle" x="661.99" y="-685.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="0,-652 0,-674 204,-674 204,-652 0,-652"/>
+<polygon fill="none" stroke="black" points="0,-652 0,-674 204,-674 204,-652 0,-652"/>
+<text text-anchor="start" x="77.9" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="0,-630 0,-652 204,-652 204,-630 0,-630"/>
+<text text-anchor="start" x="62.93" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="81.21" y="-637.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-608 0,-630 204,-630 204,-608 0,-608"/>
+<text text-anchor="start" x="40.77" y="-615.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="103.37" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-586 0,-608 204,-608 204,-586 0,-586"/>
+<text text-anchor="start" x="46.6" y="-593.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="97.53" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-564 0,-586 204,-586 204,-564 0,-564"/>
+<text text-anchor="start" x="45.03" y="-571.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="99.1" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-542 0,-564 204,-564 204,-542 0,-542"/>
+<text text-anchor="start" x="69.53" y="-549.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="98.7" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-520 0,-542 204,-542 204,-520 0,-520"/>
+<text text-anchor="start" x="54.38" y="-527.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="113.86" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-498 0,-520 204,-520 204,-498 0,-498"/>
+<text text-anchor="start" x="46.99" y="-505.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="97.14" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-476 0,-498 204,-498 204,-476 0,-476"/>
+<text text-anchor="start" x="51.66" y="-483.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="116.58" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-454 0,-476 204,-476 204,-454 0,-454"/>
+<text text-anchor="start" x="63.7" y="-461.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="103.75" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="0,-432 0,-454 204,-454 204,-432 0,-432"/>
+<text text-anchor="start" x="53.6" y="-439.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="90.54" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0,-410 0,-432 204,-432 204,-410 0,-410"/>
+<text text-anchor="start" x="29.87" y="-417.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="138.36" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-388 0,-410 204,-410 204,-388 0,-388"/>
+<text text-anchor="start" x="20.93" y="-395.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="147.3" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-366 0,-388 204,-388 204,-366 0,-366"/>
+<text text-anchor="start" x="41.93" y="-373.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="126.3" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-344 0,-366 204,-366 204,-344 0,-344"/>
+<text text-anchor="start" x="40.37" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="127.86" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0,-322 0,-344 204,-344 204,-322 0,-322"/>
+<text text-anchor="start" x="35.33" y="-329.4" font-family="Times,serif" font-size="14.00">last_watched_at: </text>
+<text text-anchor="start" x="132.91" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0,-300 0,-322 204,-322 204,-300 0,-300"/>
+<polygon fill="none" stroke="black" points="0,-300 0,-322 204,-322 204,-300 0,-300"/>
+<text text-anchor="start" x="81.79" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0,-278 0,-300 204,-300 204,-278 0,-278"/>
+<text text-anchor="start" x="2.86" y="-284.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M204,-619C277.72,-619 298.63,-619 367.6,-619"/>
+<polygon fill="black" stroke="black" points="367.66,-622.5 377.66,-619 367.66,-615.5 367.66,-622.5"/>
+<text text-anchor="middle" x="285.33" y="-623.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="366.66,-154 366.66,-176 580.66,-176 580.66,-154 366.66,-154"/>
+<polygon fill="none" stroke="black" points="366.66,-154 366.66,-176 580.66,-176 580.66,-154 366.66,-154"/>
+<text text-anchor="start" x="433.62" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="366.66,-132 366.66,-154 580.66,-154 580.66,-132 366.66,-132"/>
+<text text-anchor="start" x="434.59" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="452.87" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="366.66,-110 366.66,-132 580.66,-132 580.66,-110 366.66,-110"/>
+<text text-anchor="start" x="416.31" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="471.14" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="366.66,-88 366.66,-110 580.66,-110 580.66,-88 366.66,-88"/>
+<text text-anchor="start" x="398.43" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="489.03" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="366.66,-66 366.66,-88 580.66,-88 580.66,-66 366.66,-66"/>
+<text text-anchor="start" x="406.21" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="481.24" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="366.66,-44 366.66,-66 580.66,-66 580.66,-44 366.66,-44"/>
+<polygon fill="none" stroke="black" points="366.66,-44 366.66,-66 580.66,-66 580.66,-44 366.66,-44"/>
+<text text-anchor="start" x="453.45" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="366.66,-22 366.66,-44 580.66,-44 580.66,-22 366.66,-22"/>
+<text text-anchor="start" x="387.35" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="366.66,0 366.66,-22 580.66,-22 580.66,0 366.66,0"/>
+<text text-anchor="start" x="369.46" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M580.66,-99C722.16,-99 636.44,-267.06 671.32,-404.2 689.41,-475.3 668.5,-718.65 733.15,-741.31"/>
+<polygon fill="black" stroke="black" points="732.88,-744.81 743.32,-743 734.03,-737.9 732.88,-744.81"/>
+<text text-anchor="middle" x="661.99" y="-409.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M580.66,-121C650.3,-121 635.08,-358.61 652.66,-426 670.25,-493.43 670.11,-719.38 733.11,-741.29"/>
+<polygon fill="black" stroke="black" points="732.88,-744.8 743.32,-743 734.04,-737.9 732.88,-744.8"/>
+<text text-anchor="middle" x="661.99" y="-563.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/me.banes.chris.tivi.data.TiviDatabase/15.svg
+++ b/data-android/floorplan-output/me.banes.chris.tivi.data.TiviDatabase/15.svg
@@ -1,0 +1,424 @@
+<svg width="1385px" height="1418px"
+ viewBox="0.00 0.00 1384.98 1418.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1382)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1382 1348.98,-1382 1348.98,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1144.98,-754 1144.98,-776 1312.98,-776 1312.98,-754 1144.98,-754"/>
+<polygon fill="none" stroke="black" points="1144.98,-754 1144.98,-776 1312.98,-776 1312.98,-754 1144.98,-754"/>
+<text text-anchor="start" x="1211.48" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="1144.98,-732 1144.98,-754 1312.98,-754 1312.98,-732 1144.98,-732"/>
+<text text-anchor="start" x="1189.91" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="1208.19" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-710 1144.98,-732 1312.98,-732 1312.98,-710 1144.98,-710"/>
+<text text-anchor="start" x="1196.52" y="-717.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="1225.68" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-688 1144.98,-710 1312.98,-710 1312.98,-688 1144.98,-688"/>
+<text text-anchor="start" x="1171.24" y="-695.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="1250.96" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-666 1144.98,-688 1312.98,-688 1312.98,-666 1144.98,-666"/>
+<text text-anchor="start" x="1173.58" y="-673.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="1224.52" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-644 1144.98,-666 1312.98,-666 1312.98,-644 1144.98,-644"/>
+<text text-anchor="start" x="1172.02" y="-651.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="1226.08" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-622 1144.98,-644 1312.98,-644 1312.98,-622 1144.98,-622"/>
+<text text-anchor="start" x="1156.86" y="-629.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="1265.34" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-600 1144.98,-622 1312.98,-622 1312.98,-600 1144.98,-600"/>
+<text text-anchor="start" x="1147.92" y="-607.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="1274.28" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-578 1144.98,-600 1312.98,-600 1312.98,-578 1144.98,-578"/>
+<text text-anchor="start" x="1168.92" y="-585.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="1253.28" y="-585.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-556 1144.98,-578 1312.98,-578 1312.98,-556 1144.98,-556"/>
+<text text-anchor="start" x="1167.35" y="-563.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="1254.85" y="-563.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-534 1144.98,-556 1312.98,-556 1312.98,-534 1144.98,-534"/>
+<text text-anchor="start" x="1181.36" y="-541.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="1240.84" y="-541.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-512 1144.98,-534 1312.98,-534 1312.98,-512 1144.98,-512"/>
+<text text-anchor="start" x="1178.64" y="-519.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="1243.56" y="-519.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-490 1144.98,-512 1312.98,-512 1312.98,-490 1144.98,-490"/>
+<text text-anchor="start" x="1190.68" y="-497.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="1230.73" y="-497.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="1144.98,-468 1144.98,-490 1312.98,-490 1312.98,-468 1144.98,-468"/>
+<text text-anchor="start" x="1173.59" y="-475.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="1248.61" y="-475.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-446 1144.98,-468 1312.98,-468 1312.98,-446 1144.98,-446"/>
+<text text-anchor="start" x="1186.02" y="-453.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="1236.18" y="-453.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-424 1144.98,-446 1312.98,-446 1312.98,-424 1144.98,-424"/>
+<text text-anchor="start" x="1184.47" y="-431.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="1237.73" y="-431.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="1144.98,-402 1144.98,-424 1312.98,-424 1312.98,-402 1144.98,-402"/>
+<text text-anchor="start" x="1173.58" y="-409.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="1224.52" y="-409.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1144.98,-380 1144.98,-402 1312.98,-402 1312.98,-380 1144.98,-380"/>
+<text text-anchor="start" x="1189.14" y="-387.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="1233.06" y="-387.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<polygon fill="none" stroke="black" points="1144.98,-358 1144.98,-380 1312.98,-380 1312.98,-358 1144.98,-358"/>
+<text text-anchor="start" x="1208.77" y="-365.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1144.98,-336 1144.98,-358 1312.98,-358 1312.98,-336 1144.98,-336"/>
+<text text-anchor="start" x="1167.16" y="-342.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="1144.98,-314 1144.98,-336 1312.98,-336 1312.98,-314 1144.98,-314"/>
+<text text-anchor="start" x="1165.6" y="-320.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="782.32,-1324 782.32,-1346 969.32,-1346 969.32,-1324 782.32,-1324"/>
+<polygon fill="none" stroke="black" points="782.32,-1324 782.32,-1346 969.32,-1346 969.32,-1324 782.32,-1324"/>
+<text text-anchor="start" x="831.5" y="-1331.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="782.32,-1302 782.32,-1324 969.32,-1324 969.32,-1302 782.32,-1302"/>
+<text text-anchor="start" x="836.75" y="-1309.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1309.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1280 782.32,-1302 969.32,-1302 969.32,-1280 782.32,-1280"/>
+<text text-anchor="start" x="818.47" y="-1287.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1287.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1258 782.32,-1280 969.32,-1280 969.32,-1258 782.32,-1258"/>
+<text text-anchor="start" x="828.98" y="-1265.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1265.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="782.32,-1236 782.32,-1258 969.32,-1258 969.32,-1236 782.32,-1236"/>
+<text text-anchor="start" x="817.32" y="-1243.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="874.46" y="-1243.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<polygon fill="none" stroke="black" points="782.32,-1214 782.32,-1236 969.32,-1236 969.32,-1214 782.32,-1214"/>
+<text text-anchor="start" x="855.61" y="-1221.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="782.32,-1192 782.32,-1214 969.32,-1214 969.32,-1192 782.32,-1192"/>
+<text text-anchor="start" x="785.22" y="-1198.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M970.32,-1291C1000.15,-1291 1098.67,-813.36 1137.62,-749.93"/>
+<polygon fill="black" stroke="black" points="1140.1,-752.4 1144.98,-743 1135.3,-747.3 1140.1,-752.4"/>
+<text text-anchor="middle" x="1063.65" y="-1021.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="784.32,-1134 784.32,-1156 967.32,-1156 967.32,-1134 784.32,-1134"/>
+<polygon fill="none" stroke="black" points="784.32,-1134 784.32,-1156 967.32,-1156 967.32,-1134 784.32,-1134"/>
+<text text-anchor="start" x="833.44" y="-1141.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="784.32,-1112 784.32,-1134 967.32,-1134 967.32,-1112 784.32,-1112"/>
+<text text-anchor="start" x="836.75" y="-1119.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-1119.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1090 784.32,-1112 967.32,-1112 967.32,-1090 784.32,-1090"/>
+<text text-anchor="start" x="818.47" y="-1097.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-1097.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1068 784.32,-1090 967.32,-1090 967.32,-1068 784.32,-1068"/>
+<text text-anchor="start" x="828.98" y="-1075.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="862.8" y="-1075.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="784.32,-1046 784.32,-1068 967.32,-1068 967.32,-1046 784.32,-1046"/>
+<text text-anchor="start" x="810.71" y="-1053.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="881.06" y="-1053.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<polygon fill="none" stroke="black" points="784.32,-1024 784.32,-1046 967.32,-1046 967.32,-1024 784.32,-1024"/>
+<text text-anchor="start" x="855.61" y="-1031.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="784.32,-1002 784.32,-1024 967.32,-1024 967.32,-1002 784.32,-1002"/>
+<text text-anchor="start" x="787.17" y="-1008.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M968.32,-1101C1053.57,-1101 1056.19,-770.42 1134.98,-744.6"/>
+<polygon fill="black" stroke="black" points="1135.66,-748.03 1144.98,-743 1134.56,-741.12 1135.66,-748.03"/>
+<text text-anchor="middle" x="1063.65" y="-926.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="62.5,-886 62.5,-908 176.5,-908 176.5,-886 62.5,-886"/>
+<polygon fill="none" stroke="black" points="62.5,-886 62.5,-908 176.5,-908 176.5,-886 62.5,-886"/>
+<text text-anchor="start" x="105.12" y="-893.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="62.5,-864 62.5,-886 176.5,-886 176.5,-864 62.5,-864"/>
+<text text-anchor="start" x="80.43" y="-871.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="98.71" y="-871.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="62.5,-842 62.5,-864 176.5,-864 176.5,-842 62.5,-842"/>
+<text text-anchor="start" x="71.1" y="-849.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="132.13" y="-849.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-820 62.5,-842 176.5,-842 176.5,-820 62.5,-820"/>
+<text text-anchor="start" x="82.76" y="-827.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="120.47" y="-827.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-798 62.5,-820 176.5,-820 176.5,-798 62.5,-798"/>
+<text text-anchor="start" x="65.26" y="-805.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="137.97" y="-805.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-776 62.5,-798 176.5,-798 176.5,-776 62.5,-776"/>
+<text text-anchor="start" x="75.37" y="-783.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="127.86" y="-783.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-754 62.5,-776 176.5,-776 176.5,-754 62.5,-754"/>
+<text text-anchor="start" x="82.37" y="-761.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="120.87" y="-761.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="62.5,-732 62.5,-754 176.5,-754 176.5,-732 62.5,-732"/>
+<text text-anchor="start" x="69.55" y="-739.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="133.69" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="781.32,-944 781.32,-966 970.32,-966 970.32,-944 781.32,-944"/>
+<polygon fill="none" stroke="black" points="781.32,-944 781.32,-966 970.32,-966 970.32,-944 781.32,-944"/>
+<text text-anchor="start" x="830.34" y="-951.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="781.32,-922 781.32,-944 970.32,-944 970.32,-922 781.32,-922"/>
+<text text-anchor="start" x="836.75" y="-929.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-929.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-900 781.32,-922 970.32,-922 970.32,-900 781.32,-900"/>
+<text text-anchor="start" x="818.47" y="-907.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-907.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="781.32,-878 781.32,-900 970.32,-900 970.32,-878 781.32,-878"/>
+<text text-anchor="start" x="817.7" y="-885.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="898.17" y="-885.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<polygon fill="none" stroke="black" points="781.32,-856 781.32,-878 970.32,-878 970.32,-856 781.32,-856"/>
+<text text-anchor="start" x="855.61" y="-863.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="781.32,-834 781.32,-856 970.32,-856 970.32,-834 781.32,-834"/>
+<text text-anchor="start" x="784.07" y="-840.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M971.32,-911C1075.14,-911 1040.16,-753.97 1134.77,-743.54"/>
+<polygon fill="black" stroke="black" points="1135.18,-747.03 1144.98,-743 1134.81,-740.04 1135.18,-747.03"/>
+<text text-anchor="middle" x="1063.65" y="-836.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="778.32,-776 778.32,-798 973.32,-798 973.32,-776 778.32,-776"/>
+<polygon fill="none" stroke="black" points="778.32,-776 778.32,-798 973.32,-798 973.32,-776 778.32,-776"/>
+<text text-anchor="start" x="827.22" y="-783.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="778.32,-754 778.32,-776 973.32,-776 973.32,-754 778.32,-754"/>
+<text text-anchor="start" x="836.75" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-761.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="778.32,-732 778.32,-754 973.32,-754 973.32,-732 778.32,-732"/>
+<text text-anchor="start" x="818.47" y="-739.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-739.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<polygon fill="none" stroke="black" points="778.32,-710 778.32,-732 973.32,-732 973.32,-710 778.32,-710"/>
+<text text-anchor="start" x="855.61" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="778.32,-688 778.32,-710 973.32,-710 973.32,-688 778.32,-688"/>
+<text text-anchor="start" x="780.95" y="-694.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M974.32,-743C1046.61,-743 1067.23,-743 1134.68,-743"/>
+<polygon fill="black" stroke="black" points="1134.98,-746.5 1144.98,-743 1134.98,-739.5 1134.98,-746.5"/>
+<text text-anchor="middle" x="1063.65" y="-748.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- seasons -->
+<g id="node7" class="node">
+<title>seasons</title>
+<polygon fill="#caff70" stroke="transparent" points="780.32,-630 780.32,-652 971.32,-652 971.32,-630 780.32,-630"/>
+<polygon fill="none" stroke="black" points="780.32,-630 780.32,-652 971.32,-652 971.32,-630 780.32,-630"/>
+<text text-anchor="start" x="854.44" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">seasons</text>
+<polygon fill="none" stroke="black" points="780.32,-608 780.32,-630 971.32,-630 971.32,-608 780.32,-608"/>
+<text text-anchor="start" x="836.75" y="-615.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="855.03" y="-615.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-586 780.32,-608 971.32,-608 971.32,-586 780.32,-586"/>
+<text text-anchor="start" x="818.47" y="-593.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="873.3" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-564 780.32,-586 971.32,-586 971.32,-564 780.32,-564"/>
+<text text-anchor="start" x="820.42" y="-571.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="871.36" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-542 780.32,-564 971.32,-564 971.32,-542 780.32,-542"/>
+<text text-anchor="start" x="818.86" y="-549.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="872.92" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-520 780.32,-542 971.32,-542 971.32,-520 780.32,-520"/>
+<text text-anchor="start" x="843.36" y="-527.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="872.52" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-498 780.32,-520 971.32,-520 971.32,-498 780.32,-498"/>
+<text text-anchor="start" x="828.2" y="-505.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="887.68" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-476 780.32,-498 971.32,-498 971.32,-476 780.32,-476"/>
+<text text-anchor="start" x="820.81" y="-483.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="870.97" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-454 780.32,-476 971.32,-476 971.32,-454 780.32,-454"/>
+<text text-anchor="start" x="816.53" y="-461.4" font-family="Times,serif" font-size="14.00">ep_count: </text>
+<text text-anchor="start" x="875.24" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-432 780.32,-454 971.32,-454 971.32,-432 780.32,-432"/>
+<text text-anchor="start" x="818.09" y="-439.4" font-family="Times,serif" font-size="14.00">ep_aired: </text>
+<text text-anchor="start" x="873.68" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-410 780.32,-432 971.32,-432 971.32,-410 780.32,-410"/>
+<text text-anchor="start" x="837.52" y="-417.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="877.57" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="780.32,-388 780.32,-410 971.32,-410 971.32,-388 780.32,-388"/>
+<text text-anchor="start" x="831.31" y="-395.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="884.57" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-366 780.32,-388 971.32,-388 971.32,-366 780.32,-366"/>
+<text text-anchor="start" x="827.42" y="-373.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="864.36" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="780.32,-344 780.32,-366 971.32,-366 971.32,-344 780.32,-344"/>
+<text text-anchor="start" x="803.7" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="912.18" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-322 780.32,-344 971.32,-344 971.32,-322 780.32,-322"/>
+<text text-anchor="start" x="794.76" y="-329.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="921.12" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-300 780.32,-322 971.32,-322 971.32,-300 780.32,-300"/>
+<text text-anchor="start" x="815.76" y="-307.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="900.12" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-278 780.32,-300 971.32,-300 971.32,-278 780.32,-278"/>
+<text text-anchor="start" x="814.19" y="-285.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="901.68" y="-285.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="780.32,-256 780.32,-278 971.32,-278 971.32,-256 780.32,-256"/>
+<text text-anchor="start" x="804.48" y="-263.4" font-family="Times,serif" font-size="14.00">episodes_updated: </text>
+<text text-anchor="start" x="911.4" y="-263.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<polygon fill="none" stroke="black" points="780.32,-234 780.32,-256 971.32,-256 971.32,-234 780.32,-234"/>
+<text text-anchor="start" x="855.61" y="-241.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="780.32,-212 780.32,-234 971.32,-234 971.32,-212 780.32,-212"/>
+<text text-anchor="start" x="783.28" y="-218.4" font-family="Times,serif" font-size="14.00">index_seasons_show_id_number</text>
+</g>
+<!-- seasons&#45;&gt;shows -->
+<g id="edge5" class="edge">
+<title>seasons:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M972.32,-597C1030.65,-597 1028.48,-643.49 1072.98,-681.2 1102.27,-706.01 1102.95,-736.85 1134.64,-742.19"/>
+<polygon fill="black" stroke="black" points="1134.74,-745.71 1144.98,-743 1135.28,-738.73 1134.74,-745.71"/>
+<text text-anchor="middle" x="1063.65" y="-686.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episodes -->
+<g id="node8" class="node">
+<title>episodes</title>
+<polygon fill="#caff70" stroke="transparent" points="401.66,-652 401.66,-674 605.66,-674 605.66,-652 401.66,-652"/>
+<polygon fill="none" stroke="black" points="401.66,-652 401.66,-674 605.66,-674 605.66,-652 401.66,-652"/>
+<text text-anchor="start" x="479.56" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episodes</text>
+<polygon fill="none" stroke="black" points="401.66,-630 401.66,-652 605.66,-652 605.66,-630 401.66,-630"/>
+<text text-anchor="start" x="464.59" y="-637.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="482.87" y="-637.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-608 401.66,-630 605.66,-630 605.66,-608 401.66,-608"/>
+<text text-anchor="start" x="442.43" y="-615.4" font-family="Times,serif" font-size="14.00">season_id: </text>
+<text text-anchor="start" x="505.03" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-586 401.66,-608 605.66,-608 605.66,-586 401.66,-586"/>
+<text text-anchor="start" x="448.26" y="-593.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="499.2" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-564 401.66,-586 605.66,-586 605.66,-564 401.66,-564"/>
+<text text-anchor="start" x="446.7" y="-571.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="500.76" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-542 401.66,-564 605.66,-564 605.66,-542 401.66,-542"/>
+<text text-anchor="start" x="471.19" y="-549.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="500.36" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-520 401.66,-542 605.66,-542 605.66,-520 401.66,-520"/>
+<text text-anchor="start" x="456.04" y="-527.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="515.52" y="-527.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-498 401.66,-520 605.66,-520 605.66,-498 401.66,-498"/>
+<text text-anchor="start" x="448.65" y="-505.4" font-family="Times,serif" font-size="14.00">number: </text>
+<text text-anchor="start" x="498.8" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-476 401.66,-498 605.66,-498 605.66,-476 401.66,-476"/>
+<text text-anchor="start" x="453.32" y="-483.4" font-family="Times,serif" font-size="14.00">first_aired: </text>
+<text text-anchor="start" x="518.24" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-454 401.66,-476 605.66,-476 605.66,-454 401.66,-454"/>
+<text text-anchor="start" x="465.36" y="-461.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="505.41" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="401.66,-432 401.66,-454 605.66,-454 605.66,-432 401.66,-432"/>
+<text text-anchor="start" x="455.26" y="-439.4" font-family="Times,serif" font-size="14.00">votes: </text>
+<text text-anchor="start" x="492.2" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="401.66,-410 401.66,-432 605.66,-432 605.66,-410 401.66,-410"/>
+<text text-anchor="start" x="431.53" y="-417.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="540.02" y="-417.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-388 401.66,-410 605.66,-410 605.66,-388 401.66,-388"/>
+<text text-anchor="start" x="422.59" y="-395.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="548.96" y="-395.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-366 401.66,-388 605.66,-388 605.66,-366 401.66,-366"/>
+<text text-anchor="start" x="443.59" y="-373.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="527.96" y="-373.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-344 401.66,-366 605.66,-366 605.66,-344 401.66,-344"/>
+<text text-anchor="start" x="442.03" y="-351.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="529.52" y="-351.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="401.66,-322 401.66,-344 605.66,-344 605.66,-322 401.66,-322"/>
+<text text-anchor="start" x="436.99" y="-329.4" font-family="Times,serif" font-size="14.00">last_watched_at: </text>
+<text text-anchor="start" x="534.57" y="-329.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<polygon fill="none" stroke="black" points="401.66,-300 401.66,-322 605.66,-322 605.66,-300 401.66,-300"/>
+<text text-anchor="start" x="483.45" y="-307.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="401.66,-278 401.66,-300 605.66,-300 605.66,-278 401.66,-278"/>
+<text text-anchor="start" x="404.52" y="-284.4" font-family="Times,serif" font-size="14.00">index_episodes_season_id_number</text>
+</g>
+<!-- episodes&#45;&gt;seasons -->
+<g id="edge6" class="edge">
+<title>episodes:season_id&#45;&gt;seasons:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M605.66,-619C679.38,-619 700.29,-619 769.26,-619"/>
+<polygon fill="black" stroke="black" points="769.32,-622.5 779.32,-619 769.32,-615.5 769.32,-622.5"/>
+<text text-anchor="middle" x="686.99" y="-623.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows -->
+<g id="node9" class="node">
+<title>related_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<polygon fill="none" stroke="black" points="768.32,-154 768.32,-176 982.32,-176 982.32,-154 768.32,-154"/>
+<text text-anchor="start" x="835.28" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">related_shows</text>
+<polygon fill="none" stroke="black" points="768.32,-132 768.32,-154 982.32,-154 982.32,-132 768.32,-132"/>
+<text text-anchor="start" x="836.25" y="-139.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="854.53" y="-139.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-110 768.32,-132 982.32,-132 982.32,-110 768.32,-110"/>
+<text text-anchor="start" x="817.97" y="-117.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="872.8" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-88 768.32,-110 982.32,-110 982.32,-88 768.32,-88"/>
+<text text-anchor="start" x="800.09" y="-95.4" font-family="Times,serif" font-size="14.00">other_show_id: </text>
+<text text-anchor="start" x="890.69" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="768.32,-66 768.32,-88 982.32,-88 982.32,-66 768.32,-66"/>
+<text text-anchor="start" x="807.87" y="-73.4" font-family="Times,serif" font-size="14.00">order_index: </text>
+<text text-anchor="start" x="882.9" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<polygon fill="none" stroke="black" points="768.32,-44 768.32,-66 982.32,-66 982.32,-44 768.32,-44"/>
+<text text-anchor="start" x="855.11" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="768.32,-22 768.32,-44 982.32,-44 982.32,-22 768.32,-22"/>
+<text text-anchor="start" x="789.01" y="-28.4" font-family="Times,serif" font-size="14.00">index_related_shows_show_id</text>
+<polygon fill="none" stroke="black" points="768.32,0 768.32,-22 982.32,-22 982.32,0 768.32,0"/>
+<text text-anchor="start" x="771.12" y="-6.4" font-family="Times,serif" font-size="14.00">index_related_shows_other_show_id</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge7" class="edge">
+<title>related_shows:other_show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-99C1123.82,-99 1038.1,-267.06 1072.98,-404.2 1091.07,-475.3 1070.16,-718.65 1134.81,-741.31"/>
+<polygon fill="black" stroke="black" points="1134.54,-744.81 1144.98,-743 1135.69,-737.9 1134.54,-744.81"/>
+<text text-anchor="middle" x="1063.65" y="-409.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- related_shows&#45;&gt;shows -->
+<g id="edge8" class="edge">
+<title>related_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M982.32,-121C1051.96,-121 1036.74,-358.61 1054.32,-426 1071.91,-493.43 1071.77,-719.38 1134.77,-741.29"/>
+<polygon fill="black" stroke="black" points="1134.54,-744.8 1144.98,-743 1135.7,-737.9 1134.54,-744.8"/>
+<text text-anchor="middle" x="1063.65" y="-564.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- episode_watch_entries -->
+<g id="node10" class="node">
+<title>episode_watch_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-674 0.5,-696 239.5,-696 239.5,-674 0.5,-674"/>
+<polygon fill="none" stroke="black" points="0.5,-674 0.5,-696 239.5,-696 239.5,-674 0.5,-674"/>
+<text text-anchor="start" x="56.25" y="-681.4" font-family="Times,serif" font-weight="bold" font-size="14.00">episode_watch_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-652 0.5,-674 239.5,-674 239.5,-652 0.5,-652"/>
+<text text-anchor="start" x="80.93" y="-659.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="99.21" y="-659.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-630 0.5,-652 239.5,-652 239.5,-630 0.5,-630"/>
+<text text-anchor="start" x="56.04" y="-637.4" font-family="Times,serif" font-size="14.00">episode_id: </text>
+<text text-anchor="start" x="124.09" y="-637.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-608 0.5,-630 239.5,-630 239.5,-608 0.5,-608"/>
+<text text-anchor="start" x="64.6" y="-615.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="115.53" y="-615.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-586 0.5,-608 239.5,-608 239.5,-586 0.5,-586"/>
+<text text-anchor="start" x="66.55" y="-593.4" font-family="Times,serif" font-size="14.00">watched_at: </text>
+<text text-anchor="start" x="137.69" y="-593.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-564 0.5,-586 239.5,-586 239.5,-564 0.5,-564"/>
+<text text-anchor="start" x="68.1" y="-571.4" font-family="Times,serif" font-size="14.00">source: </text>
+<text text-anchor="start" x="112.03" y="-571.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<polygon fill="none" stroke="black" points="0.5,-542 0.5,-564 239.5,-564 239.5,-542 0.5,-542"/>
+<text text-anchor="start" x="99.79" y="-549.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-520 0.5,-542 239.5,-542 239.5,-520 0.5,-520"/>
+<text text-anchor="start" x="3.37" y="-526.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_episode_id</text>
+<polygon fill="none" stroke="black" points="0.5,-498 0.5,-520 239.5,-520 239.5,-498 0.5,-498"/>
+<text text-anchor="start" x="11.92" y="-504.4" font-family="Times,serif" font-size="14.00">index_episode_watch_entries_trakt_id</text>
+</g>
+<!-- episode_watch_entries&#45;&gt;episodes -->
+<g id="edge9" class="edge">
+<title>episode_watch_entries:episode_id&#45;&gt;episodes:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M239,-641C307.76,-641 327.47,-641 391.45,-641"/>
+<polygon fill="black" stroke="black" points="391.66,-644.5 401.66,-641 391.66,-637.5 391.66,-644.5"/>
+<text text-anchor="middle" x="320.33" y="-645.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/me.banes.chris.tivi.data.TiviDatabase/8.svg
+++ b/data-android/floorplan-output/me.banes.chris.tivi.data.TiviDatabase/8.svg
@@ -1,0 +1,174 @@
+<svg width="592px" height="848px"
+ viewBox="0.00 0.00 591.66 848.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 812)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-812 555.66,-812 555.66,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="351.66,-330 351.66,-352 519.66,-352 519.66,-330 351.66,-330"/>
+<polygon fill="none" stroke="black" points="351.66,-330 351.66,-352 519.66,-352 519.66,-330 351.66,-330"/>
+<text text-anchor="start" x="418.16" y="-337.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="351.66,-308 351.66,-330 519.66,-330 519.66,-308 351.66,-308"/>
+<text text-anchor="start" x="396.59" y="-315.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="414.87" y="-315.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="351.66,-286 351.66,-308 519.66,-308 519.66,-286 351.66,-286"/>
+<text text-anchor="start" x="403.19" y="-293.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="432.36" y="-293.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="351.66,-264 351.66,-286 519.66,-286 519.66,-264 351.66,-264"/>
+<text text-anchor="start" x="377.92" y="-271.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="457.64" y="-271.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="351.66,-242 351.66,-264 519.66,-264 519.66,-242 351.66,-242"/>
+<text text-anchor="start" x="380.26" y="-249.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="431.2" y="-249.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="351.66,-220 351.66,-242 519.66,-242 519.66,-220 351.66,-220"/>
+<text text-anchor="start" x="378.7" y="-227.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="432.76" y="-227.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="351.66,-198 351.66,-220 519.66,-220 519.66,-198 351.66,-198"/>
+<text text-anchor="start" x="363.53" y="-205.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="472.02" y="-205.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="351.66,-176 351.66,-198 519.66,-198 519.66,-176 351.66,-176"/>
+<text text-anchor="start" x="354.59" y="-183.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="480.96" y="-183.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="351.66,-154 351.66,-176 519.66,-176 519.66,-154 351.66,-154"/>
+<text text-anchor="start" x="375.59" y="-161.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="459.96" y="-161.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="351.66,-132 351.66,-154 519.66,-154 519.66,-132 351.66,-132"/>
+<text text-anchor="start" x="374.03" y="-139.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="461.52" y="-139.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="351.66,-110 351.66,-132 519.66,-132 519.66,-110 351.66,-110"/>
+<text text-anchor="start" x="388.04" y="-117.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="447.52" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="351.66,-88 351.66,-110 519.66,-110 519.66,-88 351.66,-88"/>
+<text text-anchor="start" x="385.32" y="-95.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="450.24" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="351.66,-66 351.66,-88 519.66,-88 519.66,-66 351.66,-66"/>
+<text text-anchor="start" x="397.36" y="-73.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="437.41" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="351.66,-44 351.66,-66 519.66,-66 519.66,-44 351.66,-44"/>
+<polygon fill="none" stroke="black" points="351.66,-44 351.66,-66 519.66,-66 519.66,-44 351.66,-44"/>
+<text text-anchor="start" x="415.45" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="351.66,-22 351.66,-44 519.66,-44 519.66,-22 351.66,-22"/>
+<text text-anchor="start" x="373.84" y="-28.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="351.66,0 351.66,-22 519.66,-22 519.66,0 351.66,0"/>
+<text text-anchor="start" x="372.27" y="-6.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="1.5,-542 1.5,-564 188.5,-564 188.5,-542 1.5,-542"/>
+<polygon fill="none" stroke="black" points="1.5,-542 1.5,-564 188.5,-564 188.5,-542 1.5,-542"/>
+<text text-anchor="start" x="50.67" y="-549.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="1.5,-520 1.5,-542 188.5,-542 188.5,-520 1.5,-520"/>
+<text text-anchor="start" x="55.93" y="-527.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="74.21" y="-527.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1.5,-498 1.5,-520 188.5,-520 188.5,-498 1.5,-498"/>
+<text text-anchor="start" x="37.65" y="-505.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="92.48" y="-505.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1.5,-476 1.5,-498 188.5,-498 188.5,-476 1.5,-476"/>
+<text text-anchor="start" x="48.16" y="-483.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="81.98" y="-483.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="1.5,-454 1.5,-476 188.5,-476 188.5,-454 1.5,-454"/>
+<text text-anchor="start" x="36.5" y="-461.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="93.63" y="-461.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="1.5,-432 1.5,-454 188.5,-454 188.5,-432 1.5,-432"/>
+<polygon fill="none" stroke="black" points="1.5,-432 1.5,-454 188.5,-454 188.5,-432 1.5,-432"/>
+<text text-anchor="start" x="74.79" y="-439.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="1.5,-410 1.5,-432 188.5,-432 188.5,-410 1.5,-410"/>
+<text text-anchor="start" x="4.4" y="-416.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M189,-509C296.58,-509 244.17,-331.05 341.43,-319.58"/>
+<polygon fill="black" stroke="black" points="341.87,-323.06 351.66,-319 341.48,-316.07 341.87,-323.06"/>
+<text text-anchor="middle" x="270.33" y="-446.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="3.5,-352 3.5,-374 186.5,-374 186.5,-352 3.5,-352"/>
+<polygon fill="none" stroke="black" points="3.5,-352 3.5,-374 186.5,-374 186.5,-352 3.5,-352"/>
+<text text-anchor="start" x="52.62" y="-359.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="3.5,-330 3.5,-352 186.5,-352 186.5,-330 3.5,-330"/>
+<text text-anchor="start" x="55.93" y="-337.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="74.21" y="-337.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="3.5,-308 3.5,-330 186.5,-330 186.5,-308 3.5,-308"/>
+<text text-anchor="start" x="37.65" y="-315.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="92.48" y="-315.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="3.5,-286 3.5,-308 186.5,-308 186.5,-286 3.5,-286"/>
+<text text-anchor="start" x="48.16" y="-293.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="81.98" y="-293.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="3.5,-264 3.5,-286 186.5,-286 186.5,-264 3.5,-264"/>
+<text text-anchor="start" x="29.89" y="-271.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="100.24" y="-271.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="3.5,-242 3.5,-264 186.5,-264 186.5,-242 3.5,-242"/>
+<polygon fill="none" stroke="black" points="3.5,-242 3.5,-264 186.5,-264 186.5,-242 3.5,-242"/>
+<text text-anchor="start" x="74.79" y="-249.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="3.5,-220 3.5,-242 186.5,-242 186.5,-220 3.5,-220"/>
+<text text-anchor="start" x="6.35" y="-226.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M187.5,-319C256.9,-319 276.79,-319 341.35,-319"/>
+<polygon fill="black" stroke="black" points="341.66,-322.5 351.66,-319 341.66,-315.5 341.66,-322.5"/>
+<text text-anchor="middle" x="270.33" y="-323.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="37.5,-754 37.5,-776 151.5,-776 151.5,-754 37.5,-754"/>
+<polygon fill="none" stroke="black" points="37.5,-754 37.5,-776 151.5,-776 151.5,-754 37.5,-754"/>
+<text text-anchor="start" x="80.12" y="-761.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="37.5,-732 37.5,-754 151.5,-754 151.5,-732 37.5,-732"/>
+<text text-anchor="start" x="55.43" y="-739.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="73.71" y="-739.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="37.5,-710 37.5,-732 151.5,-732 151.5,-710 37.5,-710"/>
+<text text-anchor="start" x="46.1" y="-717.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="107.13" y="-717.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-688 37.5,-710 151.5,-710 151.5,-688 37.5,-688"/>
+<text text-anchor="start" x="57.76" y="-695.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="95.47" y="-695.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-666 37.5,-688 151.5,-688 151.5,-666 37.5,-666"/>
+<text text-anchor="start" x="40.26" y="-673.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="112.97" y="-673.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-644 37.5,-666 151.5,-666 151.5,-644 37.5,-644"/>
+<text text-anchor="start" x="50.37" y="-651.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="102.86" y="-651.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-622 37.5,-644 151.5,-644 151.5,-622 37.5,-622"/>
+<text text-anchor="start" x="57.37" y="-629.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="95.87" y="-629.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-600 37.5,-622 151.5,-622 151.5,-600 37.5,-600"/>
+<text text-anchor="start" x="44.55" y="-607.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="108.69" y="-607.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-162 0.5,-184 189.5,-184 189.5,-162 0.5,-162"/>
+<polygon fill="none" stroke="black" points="0.5,-162 0.5,-184 189.5,-184 189.5,-162 0.5,-162"/>
+<text text-anchor="start" x="49.52" y="-169.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-140 0.5,-162 189.5,-162 189.5,-140 0.5,-140"/>
+<text text-anchor="start" x="55.93" y="-147.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="74.21" y="-147.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-118 0.5,-140 189.5,-140 189.5,-118 0.5,-118"/>
+<text text-anchor="start" x="37.65" y="-125.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="92.48" y="-125.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-96 0.5,-118 189.5,-118 189.5,-96 0.5,-96"/>
+<text text-anchor="start" x="36.88" y="-103.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="117.35" y="-103.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-74 0.5,-96 189.5,-96 189.5,-74 0.5,-74"/>
+<polygon fill="none" stroke="black" points="0.5,-74 0.5,-96 189.5,-96 189.5,-74 0.5,-74"/>
+<text text-anchor="start" x="74.79" y="-81.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-52 0.5,-74 189.5,-74 189.5,-52 0.5,-52"/>
+<text text-anchor="start" x="3.25" y="-58.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M189,-129C296.58,-129 244.17,-306.95 341.43,-318.42"/>
+<polygon fill="black" stroke="black" points="341.48,-321.93 351.66,-319 341.87,-314.94 341.48,-321.93"/>
+<text text-anchor="middle" x="270.33" y="-256.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>

--- a/data-android/floorplan-output/me.banes.chris.tivi.data.TiviDatabase/9.svg
+++ b/data-android/floorplan-output/me.banes.chris.tivi.data.TiviDatabase/9.svg
@@ -1,0 +1,214 @@
+<svg width="598px" height="1053px"
+ viewBox="0.00 0.00 597.66 1053.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1017)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1017 561.66,-1017 561.66,36 -36,36"/>
+<!-- shows -->
+<g id="node1" class="node">
+<title>shows</title>
+<polygon fill="#caff70" stroke="transparent" points="357.66,-440 357.66,-462 525.66,-462 525.66,-440 357.66,-440"/>
+<polygon fill="none" stroke="black" points="357.66,-440 357.66,-462 525.66,-462 525.66,-440 357.66,-440"/>
+<text text-anchor="start" x="424.16" y="-447.4" font-family="Times,serif" font-weight="bold" font-size="14.00">shows</text>
+<polygon fill="none" stroke="black" points="357.66,-418 357.66,-440 525.66,-440 525.66,-418 357.66,-418"/>
+<text text-anchor="start" x="402.59" y="-425.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="420.87" y="-425.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="357.66,-396 357.66,-418 525.66,-418 525.66,-396 357.66,-396"/>
+<text text-anchor="start" x="409.19" y="-403.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="438.36" y="-403.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-374 357.66,-396 525.66,-396 525.66,-374 357.66,-374"/>
+<text text-anchor="start" x="383.92" y="-381.4" font-family="Times,serif" font-size="14.00">original_title: </text>
+<text text-anchor="start" x="463.64" y="-381.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-352 357.66,-374 525.66,-374 525.66,-352 357.66,-352"/>
+<text text-anchor="start" x="386.26" y="-359.4" font-family="Times,serif" font-size="14.00">trakt_id: </text>
+<text text-anchor="start" x="437.2" y="-359.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="357.66,-330 357.66,-352 525.66,-352 525.66,-330 357.66,-330"/>
+<text text-anchor="start" x="384.7" y="-337.4" font-family="Times,serif" font-size="14.00">tmdb_id: </text>
+<text text-anchor="start" x="438.76" y="-337.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="357.66,-308 357.66,-330 525.66,-330 525.66,-308 357.66,-308"/>
+<text text-anchor="start" x="369.53" y="-315.4" font-family="Times,serif" font-size="14.00">tmdb_poster_path: </text>
+<text text-anchor="start" x="478.02" y="-315.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-286 357.66,-308 525.66,-308 525.66,-286 357.66,-286"/>
+<text text-anchor="start" x="360.59" y="-293.4" font-family="Times,serif" font-size="14.00">tmdb_backdrop_path: </text>
+<text text-anchor="start" x="486.96" y="-293.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-264 357.66,-286 525.66,-286 525.66,-264 357.66,-264"/>
+<text text-anchor="start" x="381.59" y="-271.4" font-family="Times,serif" font-size="14.00">trakt_updated: </text>
+<text text-anchor="start" x="465.96" y="-271.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-242 357.66,-264 525.66,-264 525.66,-242 357.66,-242"/>
+<text text-anchor="start" x="380.03" y="-249.4" font-family="Times,serif" font-size="14.00">tmdb_updated: </text>
+<text text-anchor="start" x="467.52" y="-249.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-220 357.66,-242 525.66,-242 525.66,-220 357.66,-220"/>
+<text text-anchor="start" x="394.04" y="-227.4" font-family="Times,serif" font-size="14.00">overview: </text>
+<text text-anchor="start" x="453.52" y="-227.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-198 357.66,-220 525.66,-220 525.66,-198 357.66,-198"/>
+<text text-anchor="start" x="391.32" y="-205.4" font-family="Times,serif" font-size="14.00">homepage: </text>
+<text text-anchor="start" x="456.24" y="-205.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-176 357.66,-198 525.66,-198 525.66,-176 357.66,-176"/>
+<text text-anchor="start" x="403.36" y="-183.4" font-family="Times,serif" font-size="14.00">rating: </text>
+<text text-anchor="start" x="443.41" y="-183.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="357.66,-154 357.66,-176 525.66,-176 525.66,-154 357.66,-154"/>
+<text text-anchor="start" x="386.27" y="-161.4" font-family="Times,serif" font-size="14.00">certification: </text>
+<text text-anchor="start" x="461.29" y="-161.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-132 357.66,-154 525.66,-154 525.66,-132 357.66,-132"/>
+<text text-anchor="start" x="398.7" y="-139.4" font-family="Times,serif" font-size="14.00">country: </text>
+<text text-anchor="start" x="448.86" y="-139.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-110 357.66,-132 525.66,-132 525.66,-110 357.66,-110"/>
+<text text-anchor="start" x="397.15" y="-117.4" font-family="Times,serif" font-size="14.00">network: </text>
+<text text-anchor="start" x="450.41" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="357.66,-88 357.66,-110 525.66,-110 525.66,-88 357.66,-88"/>
+<text text-anchor="start" x="386.26" y="-95.4" font-family="Times,serif" font-size="14.00">runtime: </text>
+<text text-anchor="start" x="437.2" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="357.66,-66 357.66,-88 525.66,-88 525.66,-66 357.66,-66"/>
+<text text-anchor="start" x="401.82" y="-73.4" font-family="Times,serif" font-size="14.00">genres: </text>
+<text text-anchor="start" x="445.74" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="357.66,-44 357.66,-66 525.66,-66 525.66,-44 357.66,-44"/>
+<polygon fill="none" stroke="black" points="357.66,-44 357.66,-66 525.66,-66 525.66,-44 357.66,-44"/>
+<text text-anchor="start" x="421.45" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="357.66,-22 357.66,-44 525.66,-44 525.66,-22 357.66,-22"/>
+<text text-anchor="start" x="379.84" y="-28.4" font-family="Times,serif" font-size="14.00">index_shows_trakt_id</text>
+<polygon fill="none" stroke="black" points="357.66,0 357.66,-22 525.66,-22 525.66,0 357.66,0"/>
+<text text-anchor="start" x="378.27" y="-6.4" font-family="Times,serif" font-size="14.00">index_shows_tmdb_id</text>
+</g>
+<!-- trending_shows -->
+<g id="node2" class="node">
+<title>trending_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="4.5,-747 4.5,-769 191.5,-769 191.5,-747 4.5,-747"/>
+<polygon fill="none" stroke="black" points="4.5,-747 4.5,-769 191.5,-769 191.5,-747 4.5,-747"/>
+<text text-anchor="start" x="53.67" y="-754.4" font-family="Times,serif" font-weight="bold" font-size="14.00">trending_shows</text>
+<polygon fill="none" stroke="black" points="4.5,-725 4.5,-747 191.5,-747 191.5,-725 4.5,-725"/>
+<text text-anchor="start" x="58.93" y="-732.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="77.21" y="-732.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="4.5,-703 4.5,-725 191.5,-725 191.5,-703 4.5,-703"/>
+<text text-anchor="start" x="40.65" y="-710.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="95.48" y="-710.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="4.5,-681 4.5,-703 191.5,-703 191.5,-681 4.5,-681"/>
+<text text-anchor="start" x="51.16" y="-688.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="84.98" y="-688.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="4.5,-659 4.5,-681 191.5,-681 191.5,-659 4.5,-659"/>
+<text text-anchor="start" x="39.5" y="-666.4" font-family="Times,serif" font-size="14.00">watchers: </text>
+<text text-anchor="start" x="96.63" y="-666.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="4.5,-637 4.5,-659 191.5,-659 191.5,-637 4.5,-637"/>
+<polygon fill="none" stroke="black" points="4.5,-637 4.5,-659 191.5,-659 191.5,-637 4.5,-637"/>
+<text text-anchor="start" x="77.79" y="-644.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="4.5,-615 4.5,-637 191.5,-637 191.5,-615 4.5,-615"/>
+<text text-anchor="start" x="7.4" y="-621.4" font-family="Times,serif" font-size="14.00">index_trending_shows_show_id</text>
+</g>
+<!-- trending_shows&#45;&gt;shows -->
+<g id="edge1" class="edge">
+<title>trending_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M192.5,-714C262.27,-714 282.58,-455.09 347.71,-430.82"/>
+<polygon fill="black" stroke="black" points="348.45,-434.24 357.66,-429 347.19,-427.36 348.45,-434.24"/>
+<text text-anchor="middle" x="276.33" y="-592.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- popular_shows -->
+<g id="node3" class="node">
+<title>popular_shows</title>
+<polygon fill="#caff70" stroke="transparent" points="6.5,-557 6.5,-579 189.5,-579 189.5,-557 6.5,-557"/>
+<polygon fill="none" stroke="black" points="6.5,-557 6.5,-579 189.5,-579 189.5,-557 6.5,-557"/>
+<text text-anchor="start" x="55.62" y="-564.4" font-family="Times,serif" font-weight="bold" font-size="14.00">popular_shows</text>
+<polygon fill="none" stroke="black" points="6.5,-535 6.5,-557 189.5,-557 189.5,-535 6.5,-535"/>
+<text text-anchor="start" x="58.93" y="-542.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="77.21" y="-542.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="6.5,-513 6.5,-535 189.5,-535 189.5,-513 6.5,-513"/>
+<text text-anchor="start" x="40.65" y="-520.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="95.48" y="-520.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="6.5,-491 6.5,-513 189.5,-513 189.5,-491 6.5,-491"/>
+<text text-anchor="start" x="51.16" y="-498.4" font-family="Times,serif" font-size="14.00">page: </text>
+<text text-anchor="start" x="84.98" y="-498.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="6.5,-469 6.5,-491 189.5,-491 189.5,-469 6.5,-469"/>
+<text text-anchor="start" x="32.89" y="-476.4" font-family="Times,serif" font-size="14.00">page_order: </text>
+<text text-anchor="start" x="103.24" y="-476.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="6.5,-447 6.5,-469 189.5,-469 189.5,-447 6.5,-447"/>
+<polygon fill="none" stroke="black" points="6.5,-447 6.5,-469 189.5,-469 189.5,-447 6.5,-447"/>
+<text text-anchor="start" x="77.79" y="-454.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="6.5,-425 6.5,-447 189.5,-447 189.5,-425 6.5,-425"/>
+<text text-anchor="start" x="9.35" y="-431.4" font-family="Times,serif" font-size="14.00">index_popular_shows_show_id</text>
+</g>
+<!-- popular_shows&#45;&gt;shows -->
+<g id="edge2" class="edge">
+<title>popular_shows:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M190.5,-524C272.45,-524 272.36,-436.63 347.58,-429.47"/>
+<polygon fill="black" stroke="black" points="347.83,-432.96 357.66,-429 347.51,-425.97 347.83,-432.96"/>
+<text text-anchor="middle" x="276.33" y="-486.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- users -->
+<g id="node4" class="node">
+<title>users</title>
+<polygon fill="#caff70" stroke="transparent" points="40.5,-959 40.5,-981 154.5,-981 154.5,-959 40.5,-959"/>
+<polygon fill="none" stroke="black" points="40.5,-959 40.5,-981 154.5,-981 154.5,-959 40.5,-959"/>
+<text text-anchor="start" x="83.12" y="-966.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="40.5,-937 40.5,-959 154.5,-959 154.5,-937 40.5,-937"/>
+<text text-anchor="start" x="58.43" y="-944.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="76.71" y="-944.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="40.5,-915 40.5,-937 154.5,-937 154.5,-915 40.5,-915"/>
+<text text-anchor="start" x="49.1" y="-922.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="110.13" y="-922.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="40.5,-893 40.5,-915 154.5,-915 154.5,-893 40.5,-893"/>
+<text text-anchor="start" x="60.76" y="-900.4" font-family="Times,serif" font-size="14.00">name: </text>
+<text text-anchor="start" x="98.47" y="-900.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="40.5,-871 40.5,-893 154.5,-893 154.5,-871 40.5,-871"/>
+<text text-anchor="start" x="43.26" y="-878.4" font-family="Times,serif" font-size="14.00">joined_date: </text>
+<text text-anchor="start" x="115.97" y="-878.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="40.5,-849 40.5,-871 154.5,-871 154.5,-849 40.5,-849"/>
+<text text-anchor="start" x="53.37" y="-856.4" font-family="Times,serif" font-size="14.00">location: </text>
+<text text-anchor="start" x="105.86" y="-856.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="40.5,-827 40.5,-849 154.5,-849 154.5,-827 40.5,-827"/>
+<text text-anchor="start" x="60.37" y="-834.4" font-family="Times,serif" font-size="14.00">about: </text>
+<text text-anchor="start" x="98.87" y="-834.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="40.5,-805 40.5,-827 154.5,-827 154.5,-805 40.5,-805"/>
+<text text-anchor="start" x="47.55" y="-812.4" font-family="Times,serif" font-size="14.00">avatar_url: </text>
+<text text-anchor="start" x="111.69" y="-812.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- watched_entries -->
+<g id="node5" class="node">
+<title>watched_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="3.5,-367 3.5,-389 192.5,-389 192.5,-367 3.5,-367"/>
+<polygon fill="none" stroke="black" points="3.5,-367 3.5,-389 192.5,-389 192.5,-367 3.5,-367"/>
+<text text-anchor="start" x="52.52" y="-374.4" font-family="Times,serif" font-weight="bold" font-size="14.00">watched_entries</text>
+<polygon fill="none" stroke="black" points="3.5,-345 3.5,-367 192.5,-367 192.5,-345 3.5,-345"/>
+<text text-anchor="start" x="58.93" y="-352.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="77.21" y="-352.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="3.5,-323 3.5,-345 192.5,-345 192.5,-323 3.5,-323"/>
+<text text-anchor="start" x="40.65" y="-330.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="95.48" y="-330.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="3.5,-301 3.5,-323 192.5,-323 192.5,-301 3.5,-301"/>
+<text text-anchor="start" x="39.88" y="-308.4" font-family="Times,serif" font-size="14.00">last_watched: </text>
+<text text-anchor="start" x="120.35" y="-308.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="3.5,-279 3.5,-301 192.5,-301 192.5,-279 3.5,-279"/>
+<polygon fill="none" stroke="black" points="3.5,-279 3.5,-301 192.5,-301 192.5,-279 3.5,-279"/>
+<text text-anchor="start" x="77.79" y="-286.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="3.5,-257 3.5,-279 192.5,-279 192.5,-257 3.5,-257"/>
+<text text-anchor="start" x="6.25" y="-263.4" font-family="Times,serif" font-size="14.00">index_watched_entries_show_id</text>
+</g>
+<!-- watched_entries&#45;&gt;shows -->
+<g id="edge3" class="edge">
+<title>watched_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M193.5,-334C274.17,-334 273.58,-421.01 347.27,-428.49"/>
+<polygon fill="black" stroke="black" points="347.5,-432 357.66,-429 347.84,-425.01 347.5,-432"/>
+<text text-anchor="middle" x="276.33" y="-396.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- myshows_entries -->
+<g id="node6" class="node">
+<title>myshows_entries</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-199 0.5,-221 195.5,-221 195.5,-199 0.5,-199"/>
+<polygon fill="none" stroke="black" points="0.5,-199 0.5,-221 195.5,-221 195.5,-199 0.5,-199"/>
+<text text-anchor="start" x="49.4" y="-206.4" font-family="Times,serif" font-weight="bold" font-size="14.00">myshows_entries</text>
+<polygon fill="none" stroke="black" points="0.5,-177 0.5,-199 195.5,-199 195.5,-177 0.5,-177"/>
+<text text-anchor="start" x="58.93" y="-184.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="77.21" y="-184.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-155 0.5,-177 195.5,-177 195.5,-155 0.5,-155"/>
+<text text-anchor="start" x="40.65" y="-162.4" font-family="Times,serif" font-size="14.00">show_id: </text>
+<text text-anchor="start" x="95.48" y="-162.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="0.5,-133 0.5,-155 195.5,-155 195.5,-133 0.5,-133"/>
+<polygon fill="none" stroke="black" points="0.5,-133 0.5,-155 195.5,-155 195.5,-133 0.5,-133"/>
+<text text-anchor="start" x="77.79" y="-140.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="0.5,-111 0.5,-133 195.5,-133 195.5,-111 0.5,-111"/>
+<text text-anchor="start" x="3.13" y="-117.4" font-family="Times,serif" font-size="14.00">index_myshows_entries_show_id</text>
+</g>
+<!-- myshows_entries&#45;&gt;shows -->
+<g id="edge4" class="edge">
+<title>myshows_entries:show_id&#45;&gt;shows:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M195,-166C257.06,-166 252.25,-219.9 285.66,-272.2 325.01,-333.79 285.09,-420.42 347.66,-428.4"/>
+<polygon fill="black" stroke="black" points="347.47,-431.9 357.66,-429 347.89,-424.91 347.47,-431.9"/>
+<text text-anchor="middle" x="276.33" y="-276.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+</g>
+</svg>


### PR DESCRIPTION
[FloorPlan](https://github.com/julioz/FloorPlan) translates Room schemas into entity-relationship diagrams, to make it easier to inspect changes in the persistance-layer schema of the app.

Here, I am configuring the first version of FloorPlan to output `SVG` files by mimicking the Room directory structure, into a sibling directory under the `:data-android` module. 
The first commit is the plugin configuration, the second is checking in the actual diagrams.

You can manually generate the diagrams by running

```
./gradlew :data-android:generateFloorPlan
```

Optionally, we could also make `compileDebugJava`/`kaptDebugKotlin` depend on `generateFloorPlan`, and we would get automatic diagram generation on builds for that module, similarly to how [Room hooks into the build process to generate the JSON schemas](https://stackoverflow.com/a/57103344/12511149).
Let me know your thoughts on this.