### PR TITLE
Use asFlow() to process lists instead of parallelMap

### DIFF
--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateFollowedShows.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateFollowedShows.kt
@@ -25,11 +25,12 @@ import app.tivi.data.repositories.followedshows.FollowedShowsRepository
 import app.tivi.data.repositories.showimages.ShowImagesStore
 import app.tivi.data.repositories.shows.ShowStore
 import app.tivi.domain.Interactor
-import app.tivi.extensions.parallelForEach
 import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.plus
 import javax.inject.Inject
 
@@ -49,7 +50,7 @@ class UpdateFollowedShows @Inject constructor(
         }
 
         // Finally sync the seasons/episodes and watches
-        followedShowsRepository.getFollowedShows().parallelForEach {
+        followedShowsRepository.getFollowedShows().asFlow().collect {
             showStore.fetch(it.showId)
             showImagesStore.fetchCollection(it.showId)
 

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdatePopularShows.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdatePopularShows.kt
@@ -25,10 +25,11 @@ import app.tivi.data.repositories.showimages.ShowImagesStore
 import app.tivi.data.repositories.shows.ShowStore
 import app.tivi.domain.Interactor
 import app.tivi.domain.interactors.UpdatePopularShows.Params
-import app.tivi.extensions.parallelForEach
 import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.plus
 import org.threeten.bp.Period
 import javax.inject.Inject
@@ -54,7 +55,7 @@ class UpdatePopularShows @Inject constructor(
         popularShowStore.fetchCollection(page, forceFresh = params.forceRefresh) {
             // Refresh if our local data is over 7 days old
             page == 0 && lastRequestStore.isRequestExpired(Period.ofDays(7))
-        }.parallelForEach {
+        }.asFlow().collect {
             showsStore.fetch(it.showId)
             showImagesStore.fetchCollection(it.showId)
         }

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateRecommendedShows.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateRecommendedShows.kt
@@ -23,12 +23,13 @@ import app.tivi.data.repositories.recommendedshows.RecommendedShowsStore
 import app.tivi.data.repositories.showimages.ShowImagesStore
 import app.tivi.data.repositories.shows.ShowStore
 import app.tivi.domain.Interactor
-import app.tivi.extensions.parallelForEach
 import app.tivi.inject.ProcessLifetime
 import app.tivi.trakt.TraktAuthState
 import app.tivi.trakt.TraktManager
 import app.tivi.util.AppCoroutineDispatchers
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.plus
 import org.threeten.bp.Duration
@@ -55,7 +56,7 @@ class UpdateRecommendedShows @Inject constructor(
         recommendedShowsStore.fetchCollection(0, forceFresh = params.forceRefresh) {
             // Refresh if our local data is over 3 hours old
             lastRequestStore.isRequestExpired(Duration.ofHours(3))
-        }.parallelForEach {
+        }.asFlow().collect {
             showsStore.fetch(it.showId)
             showImagesStore.fetchCollection(it.showId)
         }

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateRelatedShows.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateRelatedShows.kt
@@ -24,10 +24,11 @@ import app.tivi.data.repositories.showimages.ShowImagesStore
 import app.tivi.data.repositories.shows.ShowStore
 import app.tivi.domain.Interactor
 import app.tivi.domain.interactors.UpdateRelatedShows.Params
-import app.tivi.extensions.parallelForEach
 import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.plus
 import org.threeten.bp.Period
 import javax.inject.Inject
@@ -46,7 +47,7 @@ class UpdateRelatedShows @Inject constructor(
         relatedShowsStore.fetchCollection(params.showId, forceFresh = params.forceLoad) {
             // Refresh if our local data is over 28 days old
             lastRequestStore.isRequestExpired(params.showId, Period.ofDays(28))
-        }.parallelForEach {
+        }.asFlow().collect {
             showsStore.fetch(it.showId)
             showImagesStore.fetchCollection(it.showId)
         }

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateTrendingShows.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateTrendingShows.kt
@@ -25,10 +25,11 @@ import app.tivi.data.repositories.trendingshows.TrendingShowsLastRequestStore
 import app.tivi.data.repositories.trendingshows.TrendingShowsStore
 import app.tivi.domain.Interactor
 import app.tivi.domain.interactors.UpdateTrendingShows.Params
-import app.tivi.extensions.parallelForEach
 import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.plus
 import org.threeten.bp.Duration
 import javax.inject.Inject
@@ -54,7 +55,7 @@ class UpdateTrendingShows @Inject constructor(
         trendingShowsStore.fetchCollection(page, forceFresh = params.forceRefresh) {
             // Refresh if our local data is over 3 hours old
             page == 0 && lastRequestStore.isRequestExpired(Duration.ofHours(3))
-        }.parallelForEach {
+        }.asFlow().collect {
             showsStore.fetch(it.showId)
             showImagesStore.fetchCollection(it.showId)
         }

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateWatchedShows.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateWatchedShows.kt
@@ -23,10 +23,11 @@ import app.tivi.data.repositories.shows.ShowStore
 import app.tivi.data.repositories.watchedshows.WatchedShowsLastRequestStore
 import app.tivi.data.repositories.watchedshows.WatchedShowsStore
 import app.tivi.domain.Interactor
-import app.tivi.extensions.parallelForEach
 import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.plus
 import org.threeten.bp.Duration
 import javax.inject.Inject
@@ -45,7 +46,7 @@ class UpdateWatchedShows @Inject constructor(
         watchedShowsStore.fetchCollection(Unit, forceFresh = params.forceRefresh) {
             // Refresh if our local data is over 12 hours old
             lastRequestStore.isRequestExpired(Duration.ofHours(12))
-        }.parallelForEach {
+        }.asFlow().collect {
             showsStore.fetch(it.showId)
             showImagesStore.fetchCollection(it.showId)
         }


### PR DESCRIPTION
We will eventually be able to use the (hopefully) upcoming parallel operator.