### PR TITLE
Start injecting the initial ViewModel state again

### DIFF
--- a/app/src/main/java/app/tivi/home/HomeActivityViewModel.kt
+++ b/app/src/main/java/app/tivi/home/HomeActivityViewModel.kt
@@ -34,7 +34,9 @@ class HomeActivityViewModel @ViewModelInject constructor(
     private val updateUserDetails: UpdateUserDetails,
     observeUserDetails: ObserveUserDetails,
     private val logger: Logger
-) : ReduxViewModel<HomeActivityViewState>() {
+) : ReduxViewModel<HomeActivityViewState>(
+    HomeActivityViewState()
+) {
     init {
         viewModelScope.launchObserve(observeUserDetails) {
             it.execute {
@@ -55,9 +57,5 @@ class HomeActivityViewModel @ViewModelInject constructor(
         selectSubscribe(HomeActivityViewState::user) { user ->
             logger.setUserId(user?.username ?: "")
         }
-    }
-
-    override fun createInitialState(): HomeActivityViewState {
-        return HomeActivityViewState()
     }
 }

--- a/buildSrc/src/main/java/app/tivi/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/app/tivi/buildsrc/dependencies.kt
@@ -222,6 +222,12 @@ object Libs {
         const val coil = "io.coil-kt:coil:$version"
     }
 
+    object AssistedInject {
+        private const val version = "0.5.2"
+        const val annotationDagger2 = "com.squareup.inject:assisted-inject-annotations-dagger2:$version"
+        const val processorDagger2 = "com.squareup.inject:assisted-inject-processor-dagger2:$version"
+    }
+
     object Roomigrant {
         private const val version = "0.1.7"
         const val library = "com.github.MatrixDev.Roomigrant:RoomigrantLib:$version"

--- a/common-entrygrid/src/main/java/app/tivi/util/EntryViewModel.kt
+++ b/common-entrygrid/src/main/java/app/tivi/util/EntryViewModel.kt
@@ -43,7 +43,9 @@ import kotlinx.coroutines.launch
 
 abstract class EntryViewModel<LI : EntryWithShow<out Entry>, PI : PagingInteractor<*, LI>>(
     private val pageSize: Int = 21
-) : ReduxViewModel<EntryViewState>() {
+) : ReduxViewModel<EntryViewState>(
+    EntryViewState()
+) {
     protected abstract val dispatchers: AppCoroutineDispatchers
     protected abstract val pagingInteractor: PI
     protected abstract val logger: Logger
@@ -162,10 +164,6 @@ abstract class EntryViewModel<LI : EntryWithShow<out Entry>, PI : PagingInteract
                 }
             }
         }
-    }
-
-    override fun createInitialState(): EntryViewState {
-        return EntryViewState()
     }
 
     protected abstract fun callRefresh(fromUser: Boolean): Flow<InvokeStatus>

--- a/common-ui-view/src/main/java/app/tivi/extensions/ViewModelExtensions.kt
+++ b/common-ui-view/src/main/java/app/tivi/extensions/ViewModelExtensions.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.tivi.extensions
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+inline fun <VM : ViewModel> viewModelProviderFactoryOf(
+    crossinline f: () -> VM
+): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T = f() as T
+}

--- a/ui-account/src/main/java/app/tivi/account/AccountUiViewModel.kt
+++ b/ui-account/src/main/java/app/tivi/account/AccountUiViewModel.kt
@@ -36,7 +36,9 @@ class AccountUiViewModel @ViewModelInject constructor(
     observeTraktAuthState: ObserveTraktAuthState,
     observeUserDetails: ObserveUserDetails,
     private val appNavigator: Provider<AppNavigator>
-) : ReduxViewModel<AccountUiViewState>() {
+) : ReduxViewModel<AccountUiViewState>(
+    AccountUiViewState()
+) {
     private val pendingActions = Channel<AccountUiAction>(Channel.BUFFERED)
 
     init {
@@ -72,9 +74,5 @@ class AccountUiViewModel @ViewModelInject constructor(
         viewModelScope.launch {
             traktManager.clearAuth()
         }
-    }
-
-    override fun createInitialState(): AccountUiViewState {
-        return AccountUiViewState()
     }
 }

--- a/ui-discover/src/main/java/app/tivi/home/discover/DiscoverFragment.kt
+++ b/ui-discover/src/main/java/app/tivi/home/discover/DiscoverFragment.kt
@@ -39,7 +39,6 @@ import app.tivi.ui.authStateToolbarMenuBinder
 import app.tivi.ui.createSharedElementHelperForItemId
 import app.tivi.ui.createSharedElementHelperForItems
 import app.tivi.ui.transitions.GridToGridTransitioner
-import app.tivi.withState
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -99,8 +98,8 @@ class DiscoverFragment : FragmentWithBinding<FragmentDiscoverBinding>() {
 
         controller!!.callbacks = object : DiscoverEpoxyController.Callbacks {
             override fun onTrendingHeaderClicked() {
-                withState(viewModel) { state ->
-                    val extras = binding.summaryRv.createSharedElementHelperForItems(state.trendingItems)
+                with(viewModel.currentState()) {
+                    val extras = binding.summaryRv.createSharedElementHelperForItems(trendingItems)
 
                     findNavController().navigate(
                         R.id.navigation_trending,
@@ -112,8 +111,8 @@ class DiscoverFragment : FragmentWithBinding<FragmentDiscoverBinding>() {
             }
 
             override fun onPopularHeaderClicked() {
-                withState(viewModel) { state ->
-                    val extras = binding.summaryRv.createSharedElementHelperForItems(state.popularItems)
+                with(viewModel.currentState()) {
+                    val extras = binding.summaryRv.createSharedElementHelperForItems(popularItems)
 
                     findNavController().navigate(
                         R.id.navigation_popular,
@@ -125,8 +124,8 @@ class DiscoverFragment : FragmentWithBinding<FragmentDiscoverBinding>() {
             }
 
             override fun onRecommendedHeaderClicked() {
-                withState(viewModel) { state ->
-                    val extras = binding.summaryRv.createSharedElementHelperForItems(state.recommendedItems)
+                with(viewModel.currentState()) {
+                    val extras = binding.summaryRv.createSharedElementHelperForItems(recommendedItems)
 
                     findNavController().navigate(
                         R.id.navigation_recommended,
@@ -149,10 +148,10 @@ class DiscoverFragment : FragmentWithBinding<FragmentDiscoverBinding>() {
             }
 
             override fun onNextEpisodeToWatchClicked() {
-                withState(viewModel) {
-                    checkNotNull(it.nextEpisodeWithShowToWatched)
-                    val show = it.nextEpisodeWithShowToWatched.show
-                    val episode = it.nextEpisodeWithShowToWatched.episode
+                with(viewModel.currentState()) {
+                    checkNotNull(nextEpisodeWithShowToWatched)
+                    val show = nextEpisodeWithShowToWatched.show
+                    val episode = nextEpisodeWithShowToWatched.episode
                     findNavController().navigate(
                         "app.tivi://show/${show.id}/episode/${episode.id}".toUri()
                     )

--- a/ui-discover/src/main/java/app/tivi/home/discover/DiscoverViewModel.kt
+++ b/ui-discover/src/main/java/app/tivi/home/discover/DiscoverViewModel.kt
@@ -51,7 +51,9 @@ internal class DiscoverViewModel @ViewModelInject constructor(
     observeTraktAuthState: ObserveTraktAuthState,
     observeUserDetails: ObserveUserDetails,
     private val appNavigator: Provider<AppNavigator>
-) : ReduxViewModel<DiscoverViewState>() {
+) : ReduxViewModel<DiscoverViewState>(
+    DiscoverViewState()
+) {
     private val trendingLoadingState = ObservableLoadingCounter()
     private val popularLoadingState = ObservableLoadingCounter()
     private val recommendedLoadingState = ObservableLoadingCounter()
@@ -144,9 +146,5 @@ internal class DiscoverViewModel @ViewModelInject constructor(
                 recommendedLoadingState.collectFrom(it)
             }
         }
-    }
-
-    override fun createInitialState(): DiscoverViewState {
-        return DiscoverViewState()
     }
 }

--- a/ui-episodedetails/build.gradle
+++ b/ui-episodedetails/build.gradle
@@ -34,6 +34,13 @@ android {
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk
+
+        // Needed because we're using AssistedInject to inject our ViewModel
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments["dagger.hilt.disableModulesHaveInstallInCheck"] = "true"
+            }
+        }
     }
 
     compileOptions {
@@ -85,6 +92,9 @@ dependencies {
 
     implementation Libs.Hilt.library
     kapt Libs.Hilt.compiler
+
+    compileOnly Libs.AssistedInject.annotationDagger2
+    kapt Libs.AssistedInject.processorDagger2
 
     implementation Libs.AndroidX.Hilt.viewmodel
     kapt Libs.AndroidX.Hilt.compiler

--- a/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsFragment.kt
+++ b/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsFragment.kt
@@ -26,6 +26,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import app.tivi.common.compose.observeWindowInsets
+import app.tivi.extensions.viewModelProviderFactoryOf
 import app.tivi.util.TiviDateFormatter
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -36,28 +37,29 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class EpisodeDetailsFragment : BottomSheetDialogFragment() {
+    @Inject @JvmField internal var vmFactory: EpisodeDetailsViewModel.Factory? = null
+
     companion object {
+        private const val ARG_KEY_ID = "episode_id"
+
         @JvmStatic
         fun create(id: Long): EpisodeDetailsFragment {
             return EpisodeDetailsFragment().apply {
-                arguments = bundleOf("episode_id" to id)
+                arguments = bundleOf(ARG_KEY_ID to id)
             }
         }
     }
 
-    private val viewModel: EpisodeDetailsViewModel by viewModels()
+    private val viewModel: EpisodeDetailsViewModel by viewModels {
+        viewModelProviderFactoryOf {
+            vmFactory!!.create(requireArguments().getLong(ARG_KEY_ID))
+        }
+    }
 
     @Inject @JvmField internal var tiviDateFormatter: TiviDateFormatter? = null
     @Inject @JvmField internal var textCreator: EpisodeDetailsTextCreator? = null
 
     private val pendingActions = Channel<EpisodeDetailsAction>(Channel.BUFFERED)
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        val args = requireArguments()
-        viewModel.setEpisodeId(args.getLong("episode_id"))
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsInject.kt
+++ b/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsInject.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,12 @@
 
 package app.tivi.episodedetails
 
-enum class Action {
-    WATCH,
-    UNWATCH
-}
+import com.squareup.inject.assisted.dagger2.AssistedModule
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.FragmentComponent
+
+@InstallIn(FragmentComponent::class)
+@Module(includes = [AssistedInject_EpisodeDetailsAssistedModule::class])
+@AssistedModule
+internal object EpisodeDetailsAssistedModule

--- a/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsViewModel.kt
+++ b/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsViewModel.kt
@@ -51,7 +51,9 @@ class EpisodeDetailsViewModel @ViewModelInject constructor(
     private val removeEpisodeWatches: RemoveEpisodeWatches,
     private val removeEpisodeWatch: RemoveEpisodeWatch,
     private val logger: Logger
-) : ReduxViewModel<EpisodeDetailsViewState>() {
+) : ReduxViewModel<EpisodeDetailsViewState>(
+    EpisodeDetailsViewState()
+) {
 
     private val loadingState = ObservableLoadingCounter()
     private val snackbarManager = SnackbarManager()
@@ -156,10 +158,6 @@ class EpisodeDetailsViewModel @ViewModelInject constructor(
                 loadingState.removeLoader()
             }
         }
-    }
-
-    override fun createInitialState(): EpisodeDetailsViewState {
-        return EpisodeDetailsViewState()
     }
 
     fun setEpisodeId(id: Long) = setState { copy(episodeId = id) }

--- a/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsViewState.kt
+++ b/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsViewState.kt
@@ -22,7 +22,7 @@ import app.tivi.data.entities.EpisodeWatchEntry
 import app.tivi.data.entities.Season
 
 data class EpisodeDetailsViewState(
-    val episodeId: Long? = null,
+    val episodeId: Long,
     val season: Season? = null,
     val episode: Episode? = null,
     val watches: List<EpisodeWatchEntry> = emptyList(),

--- a/ui-followed/src/main/java/app/tivi/home/followed/FollowedViewModel.kt
+++ b/ui-followed/src/main/java/app/tivi/home/followed/FollowedViewModel.kt
@@ -51,7 +51,9 @@ internal class FollowedViewModel @ViewModelInject constructor(
     private val changeShowFollowStatus: ChangeShowFollowStatus,
     private val observeUserDetails: ObserveUserDetails,
     private val appNavigator: AppNavigator
-) : ReduxViewModel<FollowedViewState>() {
+) : ReduxViewModel<FollowedViewState>(
+    FollowedViewState()
+) {
     private val boundaryCallback = object : PagedList.BoundaryCallback<FollowedShowEntryWithShow>() {
         override fun onZeroItemsLoaded() {
             setState { copy(isEmpty = filter.isNullOrEmpty()) }
@@ -188,10 +190,6 @@ internal class FollowedViewModel @ViewModelInject constructor(
                 loadingState.collectFrom(it)
             }
         }
-    }
-
-    override fun createInitialState(): FollowedViewState {
-        return FollowedViewState()
     }
 
     companion object {

--- a/ui-search/src/main/java/app/tivi/home/search/SearchViewModel.kt
+++ b/ui-search/src/main/java/app/tivi/home/search/SearchViewModel.kt
@@ -33,7 +33,9 @@ import kotlinx.coroutines.launch
 
 internal class SearchViewModel @ViewModelInject constructor(
     private val searchShows: SearchShows
-) : ReduxViewModel<SearchViewState>() {
+) : ReduxViewModel<SearchViewState>(
+    SearchViewState()
+) {
     private val searchQuery = ConflatedBroadcastChannel<String>()
     private val loadingState = ObservableLoadingCounter()
 
@@ -65,8 +67,4 @@ internal class SearchViewModel @ViewModelInject constructor(
     }
 
     fun clearQuery() = setSearchQuery("")
-
-    override fun createInitialState(): SearchViewState {
-        return SearchViewState()
-    }
 }

--- a/ui-showdetails/build.gradle
+++ b/ui-showdetails/build.gradle
@@ -34,6 +34,13 @@ android {
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk
+
+        // Needed because we're using AssistedInject to inject our ViewModel
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments["dagger.hilt.disableModulesHaveInstallInCheck"] = "true"
+            }
+        }
     }
 
     compileOptions {
@@ -90,6 +97,9 @@ dependencies {
 
     implementation Libs.Hilt.library
     kapt Libs.Hilt.compiler
+
+    compileOnly Libs.AssistedInject.annotationDagger2
+    kapt Libs.AssistedInject.processorDagger2
 
     implementation Libs.AndroidX.Hilt.viewmodel
     kapt Libs.AndroidX.Hilt.compiler

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragment.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragment.kt
@@ -31,6 +31,7 @@ import androidx.navigation.fragment.findNavController
 import app.tivi.common.compose.observeWindowInsets
 import app.tivi.episodedetails.EpisodeDetailsFragment
 import app.tivi.extensions.scheduleStartPostponedTransitions
+import app.tivi.extensions.viewModelProviderFactoryOf
 import app.tivi.util.TiviDateFormatter
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.channels.Channel
@@ -40,21 +41,22 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class ShowDetailsFragment : Fragment() {
-    private val viewModel: ShowDetailsFragmentViewModel by viewModels()
-
+    @Inject @JvmField internal var vmFactory: ShowDetailsFragmentViewModel.Factory? = null
     @Inject @JvmField internal var textCreator: ShowDetailsTextCreator? = null
     @Inject @JvmField internal var tiviDateFormatter: TiviDateFormatter? = null
 
     private val pendingActions = Channel<ShowDetailsAction>(Channel.BUFFERED)
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        val args = requireArguments()
-        viewModel.setShowId(args.getLong("show_id"))
-
-        if (args.containsKey("episode_id")) {
-            viewModel.submitAction(OpenEpisodeDetails(args.getLong("episode_id")))
+    private val viewModel: ShowDetailsFragmentViewModel by viewModels {
+        viewModelProviderFactoryOf {
+            val args = requireArguments()
+            vmFactory!!.create(
+                showId = args.getLong("show_id"),
+                pendingEpisodeId = when {
+                    args.containsKey("episode_id") -> args.getLong("episode_id")
+                    else -> null
+                }
+            )
         }
     }
 

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentInject.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentInject.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.tivi.showdetails.details
+
+import com.squareup.inject.assisted.dagger2.AssistedModule
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.FragmentComponent
+
+@InstallIn(FragmentComponent::class)
+@Module(includes = [AssistedInject_ShowDetailsAssistedModule::class])
+@AssistedModule
+internal object ShowDetailsAssistedModule

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentViewModel.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentViewModel.kt
@@ -71,7 +71,9 @@ class ShowDetailsFragmentViewModel @ViewModelInject constructor(
     private val changeSeasonFollowStatus: ChangeSeasonFollowStatus,
     private val getEpisode: GetEpisodeDetails,
     private val logger: Logger
-) : ReduxViewModel<ShowDetailsViewState>() {
+) : ReduxViewModel<ShowDetailsViewState>(
+    ShowDetailsViewState()
+) {
 
     private val loadingState = ObservableLoadingCounter()
     private val snackbarManager = SnackbarManager()
@@ -274,9 +276,5 @@ class ShowDetailsFragmentViewModel @ViewModelInject constructor(
         super.onCleared()
         pendingActions.cancel()
         snackbarManager.close()
-    }
-
-    override fun createInitialState(): ShowDetailsViewState {
-        return ShowDetailsViewState()
     }
 }

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsViewState.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsViewState.kt
@@ -27,7 +27,7 @@ import app.tivi.data.resultentities.SeasonWithEpisodesAndWatches
 import app.tivi.data.views.FollowedShowsWatchStats
 
 data class ShowDetailsViewState(
-    val showId: Long? = null,
+    val showId: Long,
     val isFollowed: Boolean = false,
     val show: TiviShow = TiviShow.EMPTY_SHOW,
     val posterImage: ShowTmdbImage? = null,

--- a/ui-watched/src/main/java/app/tivi/home/watched/WatchedViewModel.kt
+++ b/ui-watched/src/main/java/app/tivi/home/watched/WatchedViewModel.kt
@@ -50,7 +50,9 @@ internal class WatchedViewModel @ViewModelInject constructor(
     private val observeTraktAuthState: ObserveTraktAuthState,
     observeUserDetails: ObserveUserDetails,
     private val appNavigator: AppNavigator
-) : ReduxViewModel<WatchedViewState>() {
+) : ReduxViewModel<WatchedViewState>(
+    WatchedViewState()
+) {
     private val boundaryCallback = object : PagedList.BoundaryCallback<WatchedShowEntryWithShow>() {
         override fun onZeroItemsLoaded() {
             setState { copy(isEmpty = filter.isNullOrEmpty()) }
@@ -190,10 +192,6 @@ internal class WatchedViewModel @ViewModelInject constructor(
                 loadingState.collectFrom(it)
             }
         }
-    }
-
-    override fun createInitialState(): WatchedViewState {
-        return WatchedViewState()
     }
 
     companion object {


### PR DESCRIPTION
When we moved to Hilt, I removed the `AssistedInject`ed initial state to aid migration. This PR adds it back in for the ViewModels which need an initial state (show details and episode details).

I've also moved all of the other ViewModels to pass in their initial state via a constructor param. If any of those ViewModels need some init state in the future it will be easy to add.