### PR TITLE
Start scoping operations back to the ViewModel again

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -189,7 +189,6 @@ dependencies {
 
     implementation Libs.AndroidX.Lifecycle.livedata
     implementation Libs.AndroidX.Lifecycle.viewmodel
-    implementation Libs.AndroidX.Lifecycle.process
 
     implementation Libs.AndroidX.appcompat
     implementation Libs.AndroidX.browser

--- a/app/src/main/java/app/tivi/inject/AppModule.kt
+++ b/app/src/main/java/app/tivi/inject/AppModule.kt
@@ -20,8 +20,6 @@ import android.app.Application
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
-import androidx.lifecycle.ProcessLifecycleOwner
-import androidx.lifecycle.coroutineScope
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.preference.PreferenceManager
 import app.tivi.BuildConfig
@@ -36,7 +34,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ApplicationComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.threeten.bp.format.DateTimeFormatter
 import org.threeten.bp.format.FormatStyle
@@ -140,12 +137,6 @@ object AppModule {
         @ApplicationContext context: Context
     ): DateTimeFormatter {
         return DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(context)
-    }
-
-    @Provides
-    @ProcessLifetime
-    fun provideLongLifetimeScope(): CoroutineScope {
-        return ProcessLifecycleOwner.get().lifecycle.coroutineScope
     }
 
     @Provides

--- a/base/src/main/java/app/tivi/inject/Annotations.kt
+++ b/base/src/main/java/app/tivi/inject/Annotations.kt
@@ -57,8 +57,3 @@ annotation class ShortTime
 @Qualifier
 @MustBeDocumented
 annotation class ApplicationId
-
-@Retention(AnnotationRetention.RUNTIME)
-@Qualifier
-@MustBeDocumented
-annotation class ProcessLifetime

--- a/buildSrc/src/main/java/app/tivi/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/app/tivi/buildsrc/dependencies.kt
@@ -136,7 +136,6 @@ object Libs {
             private const val version = "2.2.0"
             const val extensions = "androidx.lifecycle:lifecycle-extensions:$version"
             const val livedata = "androidx.lifecycle:lifecycle-livedata-ktx:$version"
-            const val process = "androidx.lifecycle:lifecycle-process:$version"
             const val viewmodel = "androidx.lifecycle:lifecycle-viewmodel-ktx:$version"
         }
 

--- a/common-ui-view/src/main/java/app/tivi/util/ObservableLoadingCounter.kt
+++ b/common-ui-view/src/main/java/app/tivi/util/ObservableLoadingCounter.kt
@@ -47,12 +47,12 @@ class ObservableLoadingCounter {
     }
 }
 
-suspend fun ObservableLoadingCounter.collectFrom(statuses: Flow<InvokeStatus>) {
-    statuses.collect {
+suspend fun Flow<InvokeStatus>.collectInto(counter: ObservableLoadingCounter) {
+    collect {
         if (it == InvokeStarted) {
-            addLoader()
+            counter.addLoader()
         } else if (it == InvokeSuccess || it is InvokeError) {
-            removeLoader()
+            counter.removeLoader()
         }
     }
 }

--- a/domain/src/main/java/app/tivi/domain/interactors/AddEpisodeWatch.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/AddEpisodeWatch.kt
@@ -18,22 +18,21 @@ package app.tivi.domain.interactors
 
 import app.tivi.data.repositories.episodes.SeasonsEpisodesRepository
 import app.tivi.domain.Interactor
-import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import org.threeten.bp.OffsetDateTime
 import javax.inject.Inject
 
 class AddEpisodeWatch @Inject constructor(
     private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
-    dispatchers: AppCoroutineDispatchers,
-    @ProcessLifetime val processScope: CoroutineScope
-) : Interactor<AddEpisodeWatch.Params>() {
-    override val scope: CoroutineScope = processScope + dispatchers.io
+    private val dispatchers: AppCoroutineDispatchers
 
+) : Interactor<AddEpisodeWatch.Params>() {
     override suspend fun doWork(params: Params) {
-        seasonsEpisodesRepository.addEpisodeWatch(params.episodeId, params.timestamp)
+        withContext(dispatchers.io) {
+            seasonsEpisodesRepository.addEpisodeWatch(params.episodeId, params.timestamp)
+        }
     }
 
     data class Params(val episodeId: Long, val timestamp: OffsetDateTime)

--- a/domain/src/main/java/app/tivi/domain/interactors/ChangeSeasonFollowStatus.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/ChangeSeasonFollowStatus.kt
@@ -18,28 +18,28 @@ package app.tivi.domain.interactors
 
 import app.tivi.data.repositories.episodes.SeasonsEpisodesRepository
 import app.tivi.domain.Interactor
-import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class ChangeSeasonFollowStatus @Inject constructor(
     private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
-    dispatchers: AppCoroutineDispatchers,
-    @ProcessLifetime val processScope: CoroutineScope
+    private val dispatchers: AppCoroutineDispatchers
 ) : Interactor<ChangeSeasonFollowStatus.Params>() {
-    override val scope: CoroutineScope = processScope + dispatchers.io
-
-    override suspend fun doWork(params: Params) = when (params.action) {
-        Action.FOLLOW -> {
-            seasonsEpisodesRepository.markSeasonFollowed(params.seasonId)
-        }
-        Action.IGNORE -> {
-            seasonsEpisodesRepository.markSeasonIgnored(params.seasonId)
-        }
-        Action.IGNORE_PREVIOUS -> {
-            seasonsEpisodesRepository.markPreviousSeasonsIgnored(params.seasonId)
+    override suspend fun doWork(params: Params) {
+        return withContext(dispatchers.io) {
+            when (params.action) {
+                Action.FOLLOW -> {
+                    seasonsEpisodesRepository.markSeasonFollowed(params.seasonId)
+                }
+                Action.IGNORE -> {
+                    seasonsEpisodesRepository.markSeasonIgnored(params.seasonId)
+                }
+                Action.IGNORE_PREVIOUS -> {
+                    seasonsEpisodesRepository.markPreviousSeasonsIgnored(params.seasonId)
+                }
+            }
         }
     }
 

--- a/domain/src/main/java/app/tivi/domain/interactors/ChangeSeasonWatchedStatus.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/ChangeSeasonWatchedStatus.kt
@@ -19,29 +19,30 @@ package app.tivi.domain.interactors
 import app.tivi.data.entities.ActionDate
 import app.tivi.data.repositories.episodes.SeasonsEpisodesRepository
 import app.tivi.domain.Interactor
-import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class ChangeSeasonWatchedStatus @Inject constructor(
     private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
-    dispatchers: AppCoroutineDispatchers,
-    @ProcessLifetime val processScope: CoroutineScope
+    private val dispatchers: AppCoroutineDispatchers
 ) : Interactor<ChangeSeasonWatchedStatus.Params>() {
-    override val scope: CoroutineScope = processScope + dispatchers.io
 
-    override suspend fun doWork(params: Params) = when (params.action) {
-        Action.WATCHED -> {
-            seasonsEpisodesRepository.markSeasonWatched(
-                params.seasonId,
-                params.onlyAired,
-                params.actionDate
-            )
-        }
-        Action.UNWATCH -> {
-            seasonsEpisodesRepository.markSeasonUnwatched(params.seasonId)
+    override suspend fun doWork(params: Params) {
+        return withContext(dispatchers.io) {
+            when (params.action) {
+                Action.WATCHED -> {
+                    seasonsEpisodesRepository.markSeasonWatched(
+                        params.seasonId,
+                        params.onlyAired,
+                        params.actionDate
+                    )
+                }
+                Action.UNWATCH -> {
+                    seasonsEpisodesRepository.markSeasonUnwatched(params.seasonId)
+                }
+            }
         }
     }
 

--- a/domain/src/main/java/app/tivi/domain/interactors/ChangeShowFollowStatus.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/ChangeShowFollowStatus.kt
@@ -24,10 +24,9 @@ import app.tivi.data.repositories.followedshows.FollowedShowsRepository
 import app.tivi.data.repositories.showimages.ShowImagesStore
 import app.tivi.data.repositories.shows.ShowStore
 import app.tivi.domain.Interactor
-import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class ChangeShowFollowStatus @Inject constructor(
@@ -35,13 +34,10 @@ class ChangeShowFollowStatus @Inject constructor(
     private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
     private val showStore: ShowStore,
     private val showImagesStore: ShowImagesStore,
-    dispatchers: AppCoroutineDispatchers,
-    private val showTasks: ShowTasks,
-    @ProcessLifetime val processScope: CoroutineScope
+    private val dispatchers: AppCoroutineDispatchers,
+    private val showTasks: ShowTasks
 ) : Interactor<ChangeShowFollowStatus.Params>() {
-    override val scope: CoroutineScope = processScope + dispatchers.io
-
-    override suspend fun doWork(params: Params) {
+    override suspend fun doWork(params: Params) = withContext(dispatchers.io) {
         params.showIds.forEach { showId ->
             when (params.action) {
                 Action.TOGGLE -> {

--- a/domain/src/main/java/app/tivi/domain/interactors/DeleteFolder.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/DeleteFolder.kt
@@ -17,22 +17,20 @@
 package app.tivi.domain.interactors
 
 import app.tivi.domain.Interactor
-import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import java.io.File
 import javax.inject.Inject
 
 class DeleteFolder @Inject constructor(
-    dispatchers: AppCoroutineDispatchers,
-    @ProcessLifetime val processScope: CoroutineScope
+    private val dispatchers: AppCoroutineDispatchers
 ) : Interactor<DeleteFolder.Params>() {
-    override val scope: CoroutineScope = processScope + dispatchers.io
-
     override suspend fun doWork(params: Params) {
-        if (params.directory.exists()) {
-            params.directory.deleteRecursively()
+        withContext(dispatchers.io) {
+            if (params.directory.exists()) {
+                params.directory.deleteRecursively()
+            }
         }
     }
 

--- a/domain/src/main/java/app/tivi/domain/interactors/GetEpisodeDetails.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/GetEpisodeDetails.kt
@@ -20,18 +20,15 @@ import app.tivi.data.entities.Episode
 import app.tivi.data.repositories.episodes.SeasonsEpisodesRepository
 import app.tivi.domain.ResultInteractor
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class GetEpisodeDetails @Inject constructor(
     private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
     private val dispatchers: AppCoroutineDispatchers
 ) : ResultInteractor<GetEpisodeDetails.Params, Episode?>() {
-    override val dispatcher: CoroutineDispatcher
-        get() = dispatchers.io
-
-    override suspend fun doWork(params: Params): Episode? {
-        return seasonsEpisodesRepository.getEpisode(params.episodeId)
+    override suspend fun doWork(params: Params): Episode? = withContext(dispatchers.io) {
+        seasonsEpisodesRepository.getEpisode(params.episodeId)
     }
 
     data class Params(val episodeId: Long)

--- a/domain/src/main/java/app/tivi/domain/interactors/RemoveEpisodeWatch.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/RemoveEpisodeWatch.kt
@@ -18,21 +18,19 @@ package app.tivi.domain.interactors
 
 import app.tivi.data.repositories.episodes.SeasonsEpisodesRepository
 import app.tivi.domain.Interactor
-import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class RemoveEpisodeWatch @Inject constructor(
     private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
-    dispatchers: AppCoroutineDispatchers,
-    @ProcessLifetime val processScope: CoroutineScope
+    private val dispatchers: AppCoroutineDispatchers
 ) : Interactor<RemoveEpisodeWatch.Params>() {
-    override val scope: CoroutineScope = processScope + dispatchers.io
-
     override suspend fun doWork(params: Params) {
-        seasonsEpisodesRepository.removeEpisodeWatch(params.episodeWatchId)
+        withContext(dispatchers.io) {
+            seasonsEpisodesRepository.removeEpisodeWatch(params.episodeWatchId)
+        }
     }
 
     data class Params(val episodeWatchId: Long)

--- a/domain/src/main/java/app/tivi/domain/interactors/RemoveEpisodeWatches.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/RemoveEpisodeWatches.kt
@@ -18,21 +18,19 @@ package app.tivi.domain.interactors
 
 import app.tivi.data.repositories.episodes.SeasonsEpisodesRepository
 import app.tivi.domain.Interactor
-import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class RemoveEpisodeWatches @Inject constructor(
     private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
-    dispatchers: AppCoroutineDispatchers,
-    @ProcessLifetime val processScope: CoroutineScope
+    private val dispatchers: AppCoroutineDispatchers
 ) : Interactor<RemoveEpisodeWatches.Params>() {
-    override val scope: CoroutineScope = processScope + dispatchers.io
-
     override suspend fun doWork(params: Params) {
-        seasonsEpisodesRepository.removeAllEpisodeWatches(params.episodeId)
+        withContext(dispatchers.io) {
+            seasonsEpisodesRepository.removeAllEpisodeWatches(params.episodeId)
+        }
     }
 
     data class Params(val episodeId: Long)

--- a/domain/src/main/java/app/tivi/domain/interactors/SearchShows.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/SearchShows.kt
@@ -27,7 +27,7 @@ import javax.inject.Inject
 class SearchShows @Inject constructor(
     private val searchRepository: SearchRepository,
     private val showFtsDao: ShowFtsDao,
-    dispatchers: AppCoroutineDispatchers
+    private val dispatchers: AppCoroutineDispatchers
 ) : SuspendingWorkInteractor<SearchShows.Params, SearchResults>() {
     override val dispatcher: CoroutineDispatcher = dispatchers.io
 

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateEpisodeDetails.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateEpisodeDetails.kt
@@ -18,18 +18,15 @@ package app.tivi.domain.interactors
 
 import app.tivi.data.repositories.episodes.SeasonsEpisodesRepository
 import app.tivi.domain.Interactor
-import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
 import javax.inject.Inject
 
 class UpdateEpisodeDetails @Inject constructor(
     private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
-    dispatchers: AppCoroutineDispatchers,
-    @ProcessLifetime val processScope: CoroutineScope
+    private val dispatchers: AppCoroutineDispatchers
+
 ) : Interactor<UpdateEpisodeDetails.Params>() {
-    override val scope: CoroutineScope = processScope + dispatchers.io
 
     override suspend fun doWork(params: Params) {
         seasonsEpisodesRepository.updateEpisode(params.episodeId)

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateShowDetails.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateShowDetails.kt
@@ -16,30 +16,29 @@
 
 package app.tivi.domain.interactors
 
+import app.tivi.data.entities.TiviShow
 import app.tivi.data.fetch
 import app.tivi.data.repositories.shows.ShowLastRequestStore
 import app.tivi.data.repositories.shows.ShowStore
 import app.tivi.domain.Interactor
 import app.tivi.domain.interactors.UpdateShowDetails.Params
-import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import org.threeten.bp.Period
 import javax.inject.Inject
 
 class UpdateShowDetails @Inject constructor(
     private val showStore: ShowStore,
     private val lastRequestStore: ShowLastRequestStore,
-    dispatchers: AppCoroutineDispatchers,
-    @ProcessLifetime val processScope: CoroutineScope
+    private val dispatchers: AppCoroutineDispatchers
 ) : Interactor<Params>() {
-    override val scope: CoroutineScope = processScope + dispatchers.io
-
-    override suspend fun doWork(params: Params) {
-        showStore.fetch(params.showId, params.forceLoad) {
-            // Refresh if our cached data is over 14 days old
-            lastRequestStore.isRequestExpired(params.showId, Period.ofDays(14))
+    override suspend fun doWork(params: Params): TiviShow {
+        return withContext(dispatchers.io) {
+            showStore.fetch(params.showId, params.forceLoad) {
+                // Refresh if our cached data is over 14 days old
+                lastRequestStore.isRequestExpired(params.showId, Period.ofDays(14))
+            }
         }
     }
 

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateShowDetails.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateShowDetails.kt
@@ -16,7 +16,6 @@
 
 package app.tivi.domain.interactors
 
-import app.tivi.data.entities.TiviShow
 import app.tivi.data.fetch
 import app.tivi.data.repositories.shows.ShowLastRequestStore
 import app.tivi.data.repositories.shows.ShowStore
@@ -33,8 +32,8 @@ class UpdateShowDetails @Inject constructor(
     private val lastRequestStore: ShowLastRequestStore,
     private val dispatchers: AppCoroutineDispatchers
 ) : Interactor<Params>() {
-    override suspend fun doWork(params: Params): TiviShow {
-        return withContext(dispatchers.io) {
+    override suspend fun doWork(params: Params) {
+        withContext(dispatchers.io) {
             showStore.fetch(params.showId, params.forceLoad) {
                 // Refresh if our cached data is over 14 days old
                 lastRequestStore.isRequestExpired(params.showId, Period.ofDays(14))

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateShowImages.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateShowImages.kt
@@ -16,13 +16,11 @@
 
 package app.tivi.domain.interactors
 
-import app.tivi.data.entities.ShowTmdbImage
 import app.tivi.data.fetchCollection
 import app.tivi.data.repositories.showimages.ShowImagesLastRequestStore
 import app.tivi.data.repositories.showimages.ShowImagesStore
 import app.tivi.domain.Interactor
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
 import org.threeten.bp.Period
 import javax.inject.Inject
@@ -32,8 +30,8 @@ class UpdateShowImages @Inject constructor(
     private val lastRequestStore: ShowImagesLastRequestStore,
     private val dispatchers: AppCoroutineDispatchers
 ) : Interactor<UpdateShowImages.Params>() {
-    override suspend fun doWork(params: Params): List<ShowTmdbImage> {
-        return withContext(dispatchers.io) {
+    override suspend fun doWork(params: Params) {
+        withContext(dispatchers.io) {
             showImagesStore.fetchCollection(params.showId, params.forceLoad) {
                 // Refresh if our local data is over 30 days old
                 lastRequestStore.isRequestExpired(params.showId, Period.ofDays(30))

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateShowImages.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateShowImages.kt
@@ -16,29 +16,28 @@
 
 package app.tivi.domain.interactors
 
+import app.tivi.data.entities.ShowTmdbImage
 import app.tivi.data.fetchCollection
 import app.tivi.data.repositories.showimages.ShowImagesLastRequestStore
 import app.tivi.data.repositories.showimages.ShowImagesStore
 import app.tivi.domain.Interactor
-import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import org.threeten.bp.Period
 import javax.inject.Inject
 
 class UpdateShowImages @Inject constructor(
     private val showImagesStore: ShowImagesStore,
     private val lastRequestStore: ShowImagesLastRequestStore,
-    dispatchers: AppCoroutineDispatchers,
-    @ProcessLifetime val processScope: CoroutineScope
+    private val dispatchers: AppCoroutineDispatchers
 ) : Interactor<UpdateShowImages.Params>() {
-    override val scope: CoroutineScope = processScope + dispatchers.io
-
-    override suspend fun doWork(params: Params) {
-        showImagesStore.fetchCollection(params.showId, params.forceLoad) {
-            // Refresh if our local data is over 30 days old
-            lastRequestStore.isRequestExpired(params.showId, Period.ofDays(30))
+    override suspend fun doWork(params: Params): List<ShowTmdbImage> {
+        return withContext(dispatchers.io) {
+            showImagesStore.fetchCollection(params.showId, params.forceLoad) {
+                // Refresh if our local data is over 30 days old
+                lastRequestStore.isRequestExpired(params.showId, Period.ofDays(30))
+            }
         }
     }
 

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateShowSeasonData.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateShowSeasonData.kt
@@ -20,32 +20,30 @@ import app.tivi.data.repositories.episodes.SeasonsEpisodesRepository
 import app.tivi.data.repositories.followedshows.FollowedShowsRepository
 import app.tivi.domain.Interactor
 import app.tivi.domain.interactors.UpdateShowSeasonData.Params
-import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class UpdateShowSeasonData @Inject constructor(
     private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
     private val followedShowsRepository: FollowedShowsRepository,
-    dispatchers: AppCoroutineDispatchers,
-    @ProcessLifetime val processScope: CoroutineScope
+    private val dispatchers: AppCoroutineDispatchers
 ) : Interactor<Params>() {
-    override val scope: CoroutineScope = processScope + dispatchers.io
-
     override suspend fun doWork(params: Params) {
-        if (followedShowsRepository.isShowFollowed(params.showId)) {
-            // Then update the seasons/episodes
-            if (params.forceRefresh || seasonsEpisodesRepository.needShowSeasonsUpdate(params.showId)) {
-                seasonsEpisodesRepository.updateSeasonsEpisodes(params.showId)
+        withContext(dispatchers.io) {
+            if (followedShowsRepository.isShowFollowed(params.showId)) {
+                // Then update the seasons/episodes
+                if (params.forceRefresh || seasonsEpisodesRepository.needShowSeasonsUpdate(params.showId)) {
+                    seasonsEpisodesRepository.updateSeasonsEpisodes(params.showId)
+                }
+                // Finally update any watched progress
+                if (params.forceRefresh || seasonsEpisodesRepository.needShowEpisodeWatchesSync(params.showId)) {
+                    seasonsEpisodesRepository.syncEpisodeWatchesForShow(params.showId)
+                }
+            } else {
+                seasonsEpisodesRepository.removeShowSeasonData(params.showId)
             }
-            // Finally update any watched progress
-            if (params.forceRefresh || seasonsEpisodesRepository.needShowEpisodeWatchesSync(params.showId)) {
-                seasonsEpisodesRepository.syncEpisodeWatchesForShow(params.showId)
-            }
-        } else {
-            seasonsEpisodesRepository.removeShowSeasonData(params.showId)
         }
     }
 

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateShowSeasons.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateShowSeasons.kt
@@ -19,21 +19,19 @@ package app.tivi.domain.interactors
 import app.tivi.data.repositories.episodes.SeasonsEpisodesRepository
 import app.tivi.domain.Interactor
 import app.tivi.domain.interactors.UpdateShowSeasons.Params
-import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class UpdateShowSeasons @Inject constructor(
     private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
-    dispatchers: AppCoroutineDispatchers,
-    @ProcessLifetime val processScope: CoroutineScope
+    private val dispatchers: AppCoroutineDispatchers
 ) : Interactor<Params>() {
-    override val scope: CoroutineScope = processScope + dispatchers.io
-
     override suspend fun doWork(params: Params) {
-        seasonsEpisodesRepository.updateSeasonsEpisodes(params.showId)
+        withContext(dispatchers.io) {
+            seasonsEpisodesRepository.updateSeasonsEpisodes(params.showId)
+        }
     }
 
     data class Params(val showId: Long)

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateTmdbConfig.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateTmdbConfig.kt
@@ -17,21 +17,19 @@
 package app.tivi.domain.interactors
 
 import app.tivi.domain.Interactor
-import app.tivi.inject.ProcessLifetime
 import app.tivi.tmdb.TmdbManager
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class UpdateTmdbConfig @Inject constructor(
     private val tmdbManager: TmdbManager,
-    dispatchers: AppCoroutineDispatchers,
-    @ProcessLifetime val processScope: CoroutineScope
+    private val dispatchers: AppCoroutineDispatchers
 ) : Interactor<Unit>() {
-    override val scope: CoroutineScope = processScope + dispatchers.io
-
     override suspend fun doWork(params: Unit) {
-        tmdbManager.refreshConfiguration()
+        withContext(dispatchers.io) {
+            tmdbManager.refreshConfiguration()
+        }
     }
 }

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateUserDetails.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateUserDetails.kt
@@ -19,22 +19,20 @@ package app.tivi.domain.interactors
 import app.tivi.data.repositories.traktusers.TraktUsersRepository
 import app.tivi.domain.Interactor
 import app.tivi.domain.interactors.UpdateUserDetails.Params
-import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class UpdateUserDetails @Inject constructor(
     private val repository: TraktUsersRepository,
-    dispatchers: AppCoroutineDispatchers,
-    @ProcessLifetime val processScope: CoroutineScope
+    private val dispatchers: AppCoroutineDispatchers
 ) : Interactor<Params>() {
-    override val scope: CoroutineScope = processScope + dispatchers.io
-
     override suspend fun doWork(params: Params) {
-        if (params.forceLoad || repository.needUpdate(params.username)) {
-            repository.updateUser(params.username)
+        withContext(dispatchers.io) {
+            if (params.forceLoad || repository.needUpdate(params.username)) {
+                repository.updateUser(params.username)
+            }
         }
     }
 

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateWatchedShows.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateWatchedShows.kt
@@ -23,12 +23,11 @@ import app.tivi.data.repositories.shows.ShowStore
 import app.tivi.data.repositories.watchedshows.WatchedShowsLastRequestStore
 import app.tivi.data.repositories.watchedshows.WatchedShowsStore
 import app.tivi.domain.Interactor
-import app.tivi.inject.ProcessLifetime
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import org.threeten.bp.Duration
 import javax.inject.Inject
 
@@ -37,18 +36,17 @@ class UpdateWatchedShows @Inject constructor(
     private val showsStore: ShowStore,
     private val showImagesStore: ShowImagesStore,
     private val lastRequestStore: WatchedShowsLastRequestStore,
-    dispatchers: AppCoroutineDispatchers,
-    @ProcessLifetime val processScope: CoroutineScope
+    private val dispatchers: AppCoroutineDispatchers
 ) : Interactor<UpdateWatchedShows.Params>() {
-    override val scope: CoroutineScope = processScope + dispatchers.io
-
     override suspend fun doWork(params: Params) {
-        watchedShowsStore.fetchCollection(Unit, forceFresh = params.forceRefresh) {
-            // Refresh if our local data is over 12 hours old
-            lastRequestStore.isRequestExpired(Duration.ofHours(12))
-        }.asFlow().collect {
-            showsStore.fetch(it.showId)
-            showImagesStore.fetchCollection(it.showId)
+        withContext(dispatchers.io) {
+            watchedShowsStore.fetchCollection(Unit, forceFresh = params.forceRefresh) {
+                // Refresh if our local data is over 12 hours old
+                lastRequestStore.isRequestExpired(Duration.ofHours(12))
+            }.asFlow().collect {
+                showsStore.fetch(it.showId)
+                showImagesStore.fetchCollection(it.showId)
+            }
         }
     }
 

--- a/ui-discover/src/main/java/app/tivi/home/discover/DiscoverViewModel.kt
+++ b/ui-discover/src/main/java/app/tivi/home/discover/DiscoverViewModel.kt
@@ -33,7 +33,7 @@ import app.tivi.domain.observers.ObserveTrendingShows
 import app.tivi.domain.observers.ObserveUserDetails
 import app.tivi.trakt.TraktAuthState
 import app.tivi.util.ObservableLoadingCounter
-import app.tivi.util.collectFrom
+import app.tivi.util.collectInto
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.onEach
@@ -131,20 +131,17 @@ internal class DiscoverViewModel @ViewModelInject constructor(
     fun refresh() = refresh(true)
 
     private fun refresh(fromUser: Boolean) {
-        updatePopularShows(UpdatePopularShows.Params(UpdatePopularShows.Page.REFRESH, fromUser)).also {
-            viewModelScope.launch {
-                popularLoadingState.collectFrom(it)
-            }
+        viewModelScope.launch {
+            updatePopularShows(UpdatePopularShows.Params(UpdatePopularShows.Page.REFRESH, fromUser))
+                .collectInto(popularLoadingState)
         }
-        updateTrendingShows(UpdateTrendingShows.Params(UpdateTrendingShows.Page.REFRESH, fromUser)).also {
-            viewModelScope.launch {
-                trendingLoadingState.collectFrom(it)
-            }
+        viewModelScope.launch {
+            updateTrendingShows(UpdateTrendingShows.Params(UpdateTrendingShows.Page.REFRESH, fromUser))
+                .collectInto(trendingLoadingState)
         }
-        updateRecommendedShows(UpdateRecommendedShows.Params(UpdateRecommendedShows.Page.REFRESH, fromUser)).also {
-            viewModelScope.launch {
-                recommendedLoadingState.collectFrom(it)
-            }
+        viewModelScope.launch {
+            updateRecommendedShows(UpdateRecommendedShows.Params(UpdateRecommendedShows.Page.REFRESH, fromUser))
+                .collectInto(recommendedLoadingState)
         }
     }
 }

--- a/ui-followed/src/main/java/app/tivi/home/followed/FollowedViewModel.kt
+++ b/ui-followed/src/main/java/app/tivi/home/followed/FollowedViewModel.kt
@@ -35,7 +35,7 @@ import app.tivi.domain.observers.ObserveUserDetails
 import app.tivi.trakt.TraktAuthState
 import app.tivi.util.ObservableLoadingCounter
 import app.tivi.util.ShowStateSelector
-import app.tivi.util.collectFrom
+import app.tivi.util.collectInto
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.debounce
@@ -171,12 +171,14 @@ internal class FollowedViewModel @ViewModelInject constructor(
     }
 
     fun unfollowSelectedShows() {
-        changeShowFollowStatus(
-            ChangeShowFollowStatus.Params(
-                showSelection.getSelectedShowIds(),
-                ChangeShowFollowStatus.Action.UNFOLLOW
+        viewModelScope.launch {
+            changeShowFollowStatus.executeSync(
+                ChangeShowFollowStatus.Params(
+                    showSelection.getSelectedShowIds(),
+                    ChangeShowFollowStatus.Action.UNFOLLOW
+                )
             )
-        )
+        }
         showSelection.clearSelection()
     }
 
@@ -185,10 +187,9 @@ internal class FollowedViewModel @ViewModelInject constructor(
     }
 
     private fun refreshFollowed(fromInteraction: Boolean) {
-        updateFollowedShows(UpdateFollowedShows.Params(fromInteraction, RefreshType.QUICK)).also {
-            viewModelScope.launch {
-                loadingState.collectFrom(it)
-            }
+        viewModelScope.launch {
+            updateFollowedShows(UpdateFollowedShows.Params(fromInteraction, RefreshType.QUICK))
+                .collectInto(loadingState)
         }
     }
 

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentViewModel.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragmentViewModel.kt
@@ -221,8 +221,7 @@ internal class ShowDetailsFragmentViewModel @AssistedInject constructor(
     }
 
     private fun onMarkSeasonUnwatched(action: MarkSeasonUnwatchedAction) {
-        changeSeasonWatchedStatus(Params(action.seasonId, Action.UNWATCH))
-            .watchStatus()
+        changeSeasonWatchedStatus(Params(action.seasonId, Action.UNWATCH)).watchStatus()
     }
 
     private fun onChangeSeasonExpandState(seasonId: Long, expanded: Boolean) = setState {


### PR DESCRIPTION
We were previously scoping operations to a 'ProcessLifetime' scope, but meant that we tended to start and queue up a lot of requests. This PR means we will now start cancelling requests which should help with performance.