### PR TITLE
Use `yield()` and `ensureActive()`

### DIFF
--- a/domain/src/main/java/app/tivi/domain/interactors/UpdatePopularShows.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdatePopularShows.kt
@@ -26,10 +26,9 @@ import app.tivi.data.repositories.shows.ShowStore
 import app.tivi.domain.Interactor
 import app.tivi.domain.interactors.UpdatePopularShows.Params
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import org.threeten.bp.Period
 import javax.inject.Inject
 
@@ -52,7 +51,10 @@ class UpdatePopularShows @Inject constructor(
             popularShowStore.fetchCollection(page, forceFresh = params.forceRefresh) {
                 // Refresh if our local data is over 7 days old
                 page == 0 && lastRequestStore.isRequestExpired(Period.ofDays(7))
-            }.asFlow().collect {
+            }.forEach {
+                // yield here to to let other calls potentially run
+                yield()
+
                 showsStore.fetch(it.showId)
                 showImagesStore.fetchCollection(it.showId)
             }

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateRecommendedShows.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateRecommendedShows.kt
@@ -26,11 +26,10 @@ import app.tivi.domain.Interactor
 import app.tivi.trakt.TraktAuthState
 import app.tivi.trakt.TraktManager
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import org.threeten.bp.Duration
 import javax.inject.Inject
 
@@ -52,7 +51,10 @@ class UpdateRecommendedShows @Inject constructor(
             recommendedShowsStore.fetchCollection(0, forceFresh = params.forceRefresh) {
                 // Refresh if our local data is over 3 hours old
                 lastRequestStore.isRequestExpired(Duration.ofHours(3))
-            }.asFlow().collect {
+            }.forEach {
+                // yield here to to let other calls potentially run
+                yield()
+
                 showsStore.fetch(it.showId)
                 showImagesStore.fetchCollection(it.showId)
             }

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateRelatedShows.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateRelatedShows.kt
@@ -25,10 +25,9 @@ import app.tivi.data.repositories.shows.ShowStore
 import app.tivi.domain.Interactor
 import app.tivi.domain.interactors.UpdateRelatedShows.Params
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import org.threeten.bp.Period
 import javax.inject.Inject
 
@@ -44,7 +43,10 @@ class UpdateRelatedShows @Inject constructor(
             relatedShowsStore.fetchCollection(params.showId, forceFresh = params.forceLoad) {
                 // Refresh if our local data is over 28 days old
                 lastRequestStore.isRequestExpired(params.showId, Period.ofDays(28))
-            }.asFlow().collect {
+            }.forEach {
+                // yield here to to let other calls potentially run
+                yield()
+
                 showsStore.fetch(it.showId)
                 showImagesStore.fetchCollection(it.showId)
             }

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateShowSeasonData.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateShowSeasonData.kt
@@ -21,6 +21,7 @@ import app.tivi.data.repositories.followedshows.FollowedShowsRepository
 import app.tivi.domain.Interactor
 import app.tivi.domain.interactors.UpdateShowSeasonData.Params
 import app.tivi.util.AppCoroutineDispatchers
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -37,6 +38,8 @@ class UpdateShowSeasonData @Inject constructor(
                 if (params.forceRefresh || seasonsEpisodesRepository.needShowSeasonsUpdate(params.showId)) {
                     seasonsEpisodesRepository.updateSeasonsEpisodes(params.showId)
                 }
+
+                ensureActive()
                 // Finally update any watched progress
                 if (params.forceRefresh || seasonsEpisodesRepository.needShowEpisodeWatchesSync(params.showId)) {
                     seasonsEpisodesRepository.syncEpisodeWatchesForShow(params.showId)

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateTrendingShows.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateTrendingShows.kt
@@ -26,10 +26,9 @@ import app.tivi.data.repositories.trendingshows.TrendingShowsStore
 import app.tivi.domain.Interactor
 import app.tivi.domain.interactors.UpdateTrendingShows.Params
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import org.threeten.bp.Duration
 import javax.inject.Inject
 
@@ -52,7 +51,10 @@ class UpdateTrendingShows @Inject constructor(
             trendingShowsStore.fetchCollection(page, forceFresh = params.forceRefresh) {
                 // Refresh if our local data is over 3 hours old
                 page == 0 && lastRequestStore.isRequestExpired(Duration.ofHours(3))
-            }.asFlow().collect {
+            }.forEach {
+                // yield here to to let other calls potentially run
+                yield()
+
                 showsStore.fetch(it.showId)
                 showImagesStore.fetchCollection(it.showId)
             }

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateWatchedShows.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateWatchedShows.kt
@@ -24,10 +24,9 @@ import app.tivi.data.repositories.watchedshows.WatchedShowsLastRequestStore
 import app.tivi.data.repositories.watchedshows.WatchedShowsStore
 import app.tivi.domain.Interactor
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import org.threeten.bp.Duration
 import javax.inject.Inject
 
@@ -43,7 +42,10 @@ class UpdateWatchedShows @Inject constructor(
             watchedShowsStore.fetchCollection(Unit, forceFresh = params.forceRefresh) {
                 // Refresh if our local data is over 12 hours old
                 lastRequestStore.isRequestExpired(Duration.ofHours(12))
-            }.asFlow().collect {
+            }.forEach {
+                // yield here to to let other calls potentially run
+                yield()
+
                 showsStore.fetch(it.showId)
                 showImagesStore.fetchCollection(it.showId)
             }


### PR DESCRIPTION
Ensures that the long running interactors will cancel cooperatively.