### PR TITLE
Lots of improvements around Coroutines usage

### DIFF
--- a/base/src/main/java/app/tivi/inject/Annotations.kt
+++ b/base/src/main/java/app/tivi/inject/Annotations.kt
@@ -31,11 +31,6 @@ annotation class Tmdb
 @Retention(AnnotationRetention.RUNTIME)
 @Qualifier
 @MustBeDocumented
-annotation class ForStore
-
-@Retention(AnnotationRetention.RUNTIME)
-@Qualifier
-@MustBeDocumented
 annotation class MediumDate
 
 @Retention(AnnotationRetention.RUNTIME)

--- a/buildSrc/src/main/java/app/tivi/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/app/tivi/buildsrc/dependencies.kt
@@ -77,7 +77,7 @@ object Libs {
     }
 
     object Coroutines {
-        private const val version = "1.3.5"
+        private const val version = "1.3.7"
         const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
         const val android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$version"
         const val test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:$version"

--- a/common-ui-view/build.gradle
+++ b/common-ui-view/build.gradle
@@ -48,6 +48,8 @@ dependencies {
     api Libs.AndroidX.Lifecycle.livedata
     implementation Libs.AndroidX.Lifecycle.viewmodel
 
+    implementation Libs.Coroutines.core
+
     api Libs.AndroidX.appcompat
     implementation Libs.AndroidX.recyclerview
     implementation Libs.AndroidX.constraintlayout

--- a/common-ui-view/src/main/java/app/tivi/ReduxViewModel.kt
+++ b/common-ui-view/src/main/java/app/tivi/ReduxViewModel.kt
@@ -22,13 +22,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import app.tivi.common.ui.BuildConfig
-import app.tivi.extensions.observable
-import kotlinx.coroutines.channels.ConflatedBroadcastChannel
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -38,40 +36,25 @@ import kotlin.reflect.KProperty1
 abstract class ReduxViewModel<S>(
     initialState: S
 ) : ViewModel() {
-    private val stateChannel = ConflatedBroadcastChannel(initialState)
-
+    private val state = MutableStateFlow(initialState)
     private val stateMutex = Mutex()
-    private var state: S by observable(initialState) {
-        stateChannel.offer(state)
-    }
 
     /**
      * Returns a snapshot of the current state.
      */
-    fun currentState(): S = state
+    fun currentState(): S = state.value
 
     val liveData: LiveData<S>
-        get() = stateChannel.asFlow().asLiveData()
+        get() = state.asLiveData()
 
-    protected suspend fun <T> Flow<T>.execute(
-        reducer: S.(Async<T>) -> S
-    ) = execute({ it }, reducer)
-
-    protected suspend fun <T, V> Flow<T>.execute(
-        mapper: (T) -> V,
-        reducer: S.(Async<V>) -> S
-    ) {
+    protected suspend fun <T> Flow<T>.execute(reducer: S.(Async<T>) -> S) {
         setState { reducer(Loading()) }
 
         @Suppress("USELESS_CAST")
-        return map { Success(mapper(it)) as Async<V> }
+        return map { Success(it) as Async<T> }
             .catch { e ->
                 if (BuildConfig.DEBUG) {
-                    Log.e(
-                        this@ReduxViewModel::class.java.simpleName,
-                        "Exception during observe",
-                        e
-                    )
+                    Log.e(this@ReduxViewModel::class.java.simpleName, "Exception during execute", e)
                 }
                 emit(Fail(e))
             }
@@ -82,13 +65,9 @@ abstract class ReduxViewModel<S>(
         return selectSubscribe(prop1).asLiveData()
     }
 
-    protected fun subscribe(): Flow<S> {
-        return stateChannel.asFlow().distinctUntilChanged()
-    }
-
     protected fun subscribe(block: (S) -> Unit) {
         viewModelScope.launch {
-            subscribe().collect { block(it) }
+            state.collect { block(it) }
         }
     }
 
@@ -99,30 +78,26 @@ abstract class ReduxViewModel<S>(
     }
 
     private fun <A> selectSubscribe(prop1: KProperty1<S, A>): Flow<A> {
-        return stateChannel.asFlow()
-            .map { prop1.get(it) }
-            .distinctUntilChanged()
+        return state.map { prop1.get(it) }
     }
 
-    protected suspend fun setStateMutexed(reducer: S.() -> S) {
+    protected suspend fun setState(reducer: S.() -> S) {
         stateMutex.withLock {
-            state = reducer(state)
+            state.value = reducer(state.value)
         }
     }
 
-    protected fun setState(reducer: S.() -> S) {
-        viewModelScope.launch { setStateMutexed(reducer) }
+    protected fun CoroutineScope.setState(reducer: S.() -> S) {
+        launch { this@ReduxViewModel.setState(reducer) }
     }
 
-    protected suspend fun withStateMutexed(block: (S) -> Unit) {
-        stateMutex.withLock { block(state) }
+    protected suspend fun withState(block: (S) -> Unit) {
+        stateMutex.withLock {
+            block(state.value)
+        }
     }
 
-    protected fun withState(block: (S) -> Unit) {
-        viewModelScope.launch { withStateMutexed(block) }
-    }
-
-    override fun onCleared() {
-        stateChannel.close()
+    protected fun CoroutineScope.withState(block: (S) -> Unit) {
+        launch { this@ReduxViewModel.withState(block) }
     }
 }

--- a/common-ui-view/src/main/java/app/tivi/ui/SnackbarManager.kt
+++ b/common-ui-view/src/main/java/app/tivi/ui/SnackbarManager.kt
@@ -18,43 +18,54 @@ package app.tivi.ui
 
 import app.tivi.api.UiError
 import app.tivi.extensions.delayFlow
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
 import org.threeten.bp.Duration
+import javax.inject.Inject
 
-class SnackbarManager {
+class SnackbarManager @Inject constructor() {
     // We want a maximum of 3 errors queued
     private val pendingErrors = Channel<UiError>(3)
     private val removeErrorSignal = Channel<Unit>(1)
 
-    suspend fun launch(onErrorVisibilityChanged: (UiError, Boolean) -> Unit) {
-        for (error in pendingErrors) {
-            // Set the error
-            onErrorVisibilityChanged(error, true)
+    fun launchInScope(
+        scope: CoroutineScope,
+        onErrorVisibilityChanged: (UiError, Boolean) -> Unit
+    ) {
+        scope.launch {
+            pendingErrors.consumeAsFlow().collect { error ->
+                // Set the error
+                onErrorVisibilityChanged(error, true)
 
-            merge(
-                delayFlow(Duration.ofSeconds(6).toMillis(), Unit),
-                removeErrorSignal.receiveAsFlow()
-            ).firstOrNull()
+                merge(
+                    delayFlow(Duration.ofSeconds(6).toMillis(), Unit),
+                    removeErrorSignal.receiveAsFlow()
+                ).firstOrNull()
 
-            // Now remove the error
-            onErrorVisibilityChanged(error, false)
-            // Delay to allow the current error to disappear
-            delay(200)
+                // Now remove the error
+                onErrorVisibilityChanged(error, false)
+                // Delay to allow the current error to disappear
+                delay(200)
+            }
         }
     }
 
-    fun sendError(error: UiError) = pendingErrors.offer(error)
-
-    fun removeCurrentError() {
-        removeErrorSignal.offer(Unit)
+    fun sendError(error: UiError) {
+        if (!pendingErrors.isClosedForSend) {
+            pendingErrors.offer(error)
+        }
     }
 
-    fun close() {
-        removeErrorSignal.close()
-        pendingErrors.close()
+    fun removeCurrentError() {
+        if (!removeErrorSignal.isClosedForSend) {
+            removeErrorSignal.offer(Unit)
+        }
     }
 }

--- a/common-ui-view/src/main/java/app/tivi/util/ObservableLoadingCounter.kt
+++ b/common-ui-view/src/main/java/app/tivi/util/ObservableLoadingCounter.kt
@@ -20,9 +20,8 @@ import app.tivi.base.InvokeError
 import app.tivi.base.InvokeStarted
 import app.tivi.base.InvokeStatus
 import app.tivi.base.InvokeSuccess
-import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -30,19 +29,17 @@ import java.util.concurrent.atomic.AtomicInteger
 
 class ObservableLoadingCounter {
     private val count = AtomicInteger()
-    private val loadingState = ConflatedBroadcastChannel(count.get())
+    private val loadingState = MutableStateFlow(count.get())
 
     val observable: Flow<Boolean>
-        get() = loadingState.asFlow()
-            .map { it > 0 }
-            .distinctUntilChanged()
+        get() = loadingState.map { it > 0 }.distinctUntilChanged()
 
     fun addLoader() {
-        loadingState.offer(count.incrementAndGet())
+        loadingState.value = count.incrementAndGet()
     }
 
     fun removeLoader() {
-        loadingState.offer(count.decrementAndGet())
+        loadingState.value = count.decrementAndGet()
     }
 }
 

--- a/data-android/src/main/java/app/tivi/data/DatabaseInject.kt
+++ b/data-android/src/main/java/app/tivi/data/DatabaseInject.kt
@@ -19,31 +19,13 @@ package app.tivi.data
 import android.content.Context
 import android.os.Debug
 import androidx.room.Room
-import app.tivi.inject.ForStore
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ApplicationComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineScope
 import javax.inject.Singleton
-import kotlin.coroutines.EmptyCoroutineContext
-
-/**
- * Dummy modules which includes [DataModule]. We can't `@InstallIn` that module
- * directly because it is not an Android module.
- */
-@InstallIn(ApplicationComponent::class)
-@Module
-object DataModule {
-    @ForStore
-    @Singleton
-    @Provides
-    fun providesStoreDispatcher(): CoroutineScope {
-        return CoroutineScope(EmptyCoroutineContext)
-    }
-}
 
 @InstallIn(ApplicationComponent::class)
 @Module

--- a/data-android/src/main/java/app/tivi/data/repositories/popularshows/PopularShowsModule.kt
+++ b/data-android/src/main/java/app/tivi/data/repositories/popularshows/PopularShowsModule.kt
@@ -20,14 +20,12 @@ import app.tivi.data.daos.PopularDao
 import app.tivi.data.daos.TiviShowDao
 import app.tivi.data.entities.PopularShowEntry
 import app.tivi.data.entities.Success
-import app.tivi.inject.ForStore
 import com.dropbox.android.external.store4.Store
 import com.dropbox.android.external.store4.StoreBuilder
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ApplicationComponent
-import kotlinx.coroutines.CoroutineScope
 import javax.inject.Singleton
 
 typealias PopularShowsStore = Store<Int, List<PopularShowEntry>>
@@ -41,8 +39,7 @@ internal object PopularShowsModule {
         traktPopularShows: TraktPopularShowsDataSource,
         popularShowsDao: PopularDao,
         showDao: TiviShowDao,
-        lastRequestStore: PopularShowsLastRequestStore,
-        @ForStore scope: CoroutineScope
+        lastRequestStore: PopularShowsLastRequestStore
     ): PopularShowsStore {
         return StoreBuilder.fromNonFlow { page: Int ->
             val response = traktPopularShows(page, 20)
@@ -68,6 +65,6 @@ internal object PopularShowsModule {
             },
             delete = popularShowsDao::deletePage,
             deleteAll = popularShowsDao::deleteAll
-        ).scope(scope).build()
+        ).build()
     }
 }

--- a/data-android/src/main/java/app/tivi/data/repositories/recommendedshows/RecommendedShowsModule.kt
+++ b/data-android/src/main/java/app/tivi/data/repositories/recommendedshows/RecommendedShowsModule.kt
@@ -20,14 +20,12 @@ import app.tivi.data.daos.RecommendedDao
 import app.tivi.data.daos.TiviShowDao
 import app.tivi.data.entities.RecommendedShowEntry
 import app.tivi.data.entities.Success
-import app.tivi.inject.ForStore
 import com.dropbox.android.external.store4.Store
 import com.dropbox.android.external.store4.StoreBuilder
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ApplicationComponent
-import kotlinx.coroutines.CoroutineScope
 import javax.inject.Singleton
 
 typealias RecommendedShowsStore = Store<Int, List<RecommendedShowEntry>>
@@ -41,8 +39,7 @@ internal object RecommendedShowsModule {
         traktRecommendedShows: TraktRecommendedShowsDataSource,
         recommendedDao: RecommendedDao,
         showDao: TiviShowDao,
-        lastRequestStore: RecommendedShowsLastRequestStore,
-        @ForStore scope: CoroutineScope
+        lastRequestStore: RecommendedShowsLastRequestStore
     ): RecommendedShowsStore {
         return StoreBuilder.fromNonFlow { page: Int ->
             val response = traktRecommendedShows(page, 20)
@@ -69,6 +66,6 @@ internal object RecommendedShowsModule {
             },
             delete = recommendedDao::deletePage,
             deleteAll = recommendedDao::deleteAll
-        ).scope(scope).build()
+        ).build()
     }
 }

--- a/data-android/src/main/java/app/tivi/data/repositories/relatedshows/RelatedShowsModule.kt
+++ b/data-android/src/main/java/app/tivi/data/repositories/relatedshows/RelatedShowsModule.kt
@@ -20,14 +20,12 @@ import app.tivi.data.daos.RelatedShowsDao
 import app.tivi.data.daos.TiviShowDao
 import app.tivi.data.entities.RelatedShowEntry
 import app.tivi.data.entities.Success
-import app.tivi.inject.ForStore
 import com.dropbox.android.external.store4.Store
 import com.dropbox.android.external.store4.StoreBuilder
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ApplicationComponent
-import kotlinx.coroutines.CoroutineScope
 import javax.inject.Singleton
 
 typealias RelatedShowsStore = Store<Long, List<RelatedShowEntry>>
@@ -41,8 +39,7 @@ internal object RelatedShowsModule {
         tmdbRelatedShows: TmdbRelatedShowsDataSource,
         relatedShowsDao: RelatedShowsDao,
         showDao: TiviShowDao,
-        lastRequestStore: RelatedShowsLastRequestStore,
-        @ForStore scope: CoroutineScope
+        lastRequestStore: RelatedShowsLastRequestStore
     ): RelatedShowsStore {
         return StoreBuilder.fromNonFlow { showId: Long ->
             val response = tmdbRelatedShows(showId)
@@ -66,6 +63,6 @@ internal object RelatedShowsModule {
             },
             delete = relatedShowsDao::deleteWithShowId,
             deleteAll = relatedShowsDao::deleteAll
-        ).scope(scope).build()
+        ).build()
     }
 }

--- a/data-android/src/main/java/app/tivi/data/repositories/showimages/ShowsImagesModule.kt
+++ b/data-android/src/main/java/app/tivi/data/repositories/showimages/ShowsImagesModule.kt
@@ -20,7 +20,6 @@ import app.tivi.data.daos.ShowImagesDao
 import app.tivi.data.daos.TiviShowDao
 import app.tivi.data.entities.ShowTmdbImage
 import app.tivi.data.entities.Success
-import app.tivi.inject.ForStore
 import app.tivi.inject.Tmdb
 import com.dropbox.android.external.store4.Store
 import com.dropbox.android.external.store4.StoreBuilder
@@ -29,7 +28,6 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ApplicationComponent
-import kotlinx.coroutines.CoroutineScope
 import javax.inject.Singleton
 
 typealias ShowImagesStore = Store<Long, List<ShowTmdbImage>>
@@ -51,8 +49,7 @@ object ShowImagesStoreModule {
         showImagesDao: ShowImagesDao,
         showDao: TiviShowDao,
         lastRequestStore: ShowImagesLastRequestStore,
-        @Tmdb tmdbShowImagesDataSource: ShowImagesDataSource,
-        @ForStore scope: CoroutineScope
+        @Tmdb tmdbShowImagesDataSource: ShowImagesDataSource
     ): ShowImagesStore {
         return StoreBuilder.fromNonFlow { showId: Long ->
             val show = showDao.getShowWithId(showId)
@@ -71,6 +68,6 @@ object ShowImagesStoreModule {
             writer = showImagesDao::saveImages,
             delete = showImagesDao::deleteForShowId,
             deleteAll = showImagesDao::deleteAll
-        ).scope(scope).build()
+        ).build()
     }
 }

--- a/data-android/src/main/java/app/tivi/data/repositories/shows/ShowsModule.kt
+++ b/data-android/src/main/java/app/tivi/data/repositories/shows/ShowsModule.kt
@@ -19,7 +19,6 @@ package app.tivi.data.repositories.shows
 import app.tivi.data.daos.TiviShowDao
 import app.tivi.data.entities.Success
 import app.tivi.data.entities.TiviShow
-import app.tivi.inject.ForStore
 import app.tivi.inject.Tmdb
 import app.tivi.inject.Trakt
 import com.dropbox.android.external.store4.Store
@@ -29,7 +28,6 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ApplicationComponent
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import javax.inject.Singleton
@@ -59,8 +57,7 @@ object ShowStoreModule {
         showDao: TiviShowDao,
         lastRequestStore: ShowLastRequestStore,
         @Trakt traktShowDataSource: ShowDataSource,
-        @Tmdb tmdbShowDataSource: ShowDataSource,
-        @ForStore scope: CoroutineScope
+        @Tmdb tmdbShowDataSource: ShowDataSource
     ): ShowStore {
         return StoreBuilder.fromNonFlow { showId: Long ->
             val localShow = showDao.getShowWithId(showId)
@@ -94,6 +91,6 @@ object ShowStoreModule {
             },
             delete = showDao::delete,
             deleteAll = showDao::deleteAll
-        ).scope(scope).build()
+        ).build()
     }
 }

--- a/data-android/src/main/java/app/tivi/data/repositories/trendingshows/TrendingShowsModule.kt
+++ b/data-android/src/main/java/app/tivi/data/repositories/trendingshows/TrendingShowsModule.kt
@@ -20,14 +20,12 @@ import app.tivi.data.daos.TiviShowDao
 import app.tivi.data.daos.TrendingDao
 import app.tivi.data.entities.Success
 import app.tivi.data.entities.TrendingShowEntry
-import app.tivi.inject.ForStore
 import com.dropbox.android.external.store4.Store
 import com.dropbox.android.external.store4.StoreBuilder
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ApplicationComponent
-import kotlinx.coroutines.CoroutineScope
 import javax.inject.Singleton
 
 typealias TrendingShowsStore = Store<Int, List<TrendingShowEntry>>
@@ -41,8 +39,7 @@ object TrendingShowsModule {
         traktTrendingShows: TraktTrendingShowsDataSource,
         trendingShowsDao: TrendingDao,
         showDao: TiviShowDao,
-        lastRequestStore: TrendingShowsLastRequestStore,
-        @ForStore scope: CoroutineScope
+        lastRequestStore: TrendingShowsLastRequestStore
     ): TrendingShowsStore {
         return StoreBuilder.fromNonFlow { page: Int ->
             val response = traktTrendingShows(page, 20)
@@ -68,6 +65,6 @@ object TrendingShowsModule {
             },
             delete = trendingShowsDao::deletePage,
             deleteAll = trendingShowsDao::deleteAll
-        ).scope(scope).build()
+        ).build()
     }
 }

--- a/data-android/src/main/java/app/tivi/data/repositories/watchedshows/WatchedShowsModule.kt
+++ b/data-android/src/main/java/app/tivi/data/repositories/watchedshows/WatchedShowsModule.kt
@@ -20,14 +20,12 @@ import app.tivi.data.daos.TiviShowDao
 import app.tivi.data.daos.WatchedShowDao
 import app.tivi.data.entities.Success
 import app.tivi.data.entities.WatchedShowEntry
-import app.tivi.inject.ForStore
 import com.dropbox.android.external.store4.Store
 import com.dropbox.android.external.store4.StoreBuilder
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ApplicationComponent
-import kotlinx.coroutines.CoroutineScope
 import javax.inject.Singleton
 
 typealias WatchedShowsStore = Store<Unit, List<WatchedShowEntry>>
@@ -41,8 +39,7 @@ internal object WatchedShowsModule {
         traktWatchedShows: TraktWatchedShowsDataSource,
         watchedShowsDao: WatchedShowDao,
         showDao: TiviShowDao,
-        lastRequestStore: WatchedShowsLastRequestStore,
-        @ForStore scope: CoroutineScope
+        lastRequestStore: WatchedShowsLastRequestStore
     ): WatchedShowsStore {
         return StoreBuilder.fromNonFlow { _: Unit ->
             traktWatchedShows().also {
@@ -66,6 +63,6 @@ internal object WatchedShowsModule {
                 watchedShowsDao.deleteAll()
             },
             deleteAll = watchedShowsDao::deleteAll
-        ).scope(scope).build()
+        ).build()
     }
 }

--- a/tmdb/src/main/java/app/tivi/tmdb/TmdbManager.kt
+++ b/tmdb/src/main/java/app/tivi/tmdb/TmdbManager.kt
@@ -20,9 +20,7 @@ import app.tivi.extensions.fetchBodyWithRetry
 import app.tivi.util.AppCoroutineDispatchers
 import com.uwetrottmann.tmdb2.Tmdb
 import com.uwetrottmann.tmdb2.entities.Configuration
-import kotlinx.coroutines.channels.ConflatedBroadcastChannel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -32,10 +30,9 @@ class TmdbManager @Inject constructor(
     private val dispatchers: AppCoroutineDispatchers,
     private val tmdbClient: Tmdb
 ) {
-    private val imageProviderSubject = ConflatedBroadcastChannel(TmdbImageUrlProvider())
-    val imageProviderFlow: Flow<TmdbImageUrlProvider> = imageProviderSubject.asFlow()
+    private val imageProvider = MutableStateFlow(TmdbImageUrlProvider())
 
-    fun getLatestImageProvider() = imageProviderSubject.value
+    fun getLatestImageProvider() = imageProvider.value
 
     suspend fun refreshConfiguration() {
         try {
@@ -56,7 +53,7 @@ class TmdbManager @Inject constructor(
                 images.backdrop_sizes ?: emptyList(),
                 images.logo_sizes ?: emptyList()
             )
-            imageProviderSubject.offer(newProvider)
+            imageProvider.value = newProvider
         }
     }
 }

--- a/ui-account/src/main/java/app/tivi/account/AccountUiFragment.kt
+++ b/ui-account/src/main/java/app/tivi/account/AccountUiFragment.kt
@@ -30,7 +30,8 @@ import app.tivi.util.TiviDateFormatter
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.sendBlocking
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -55,7 +56,7 @@ class AccountUiFragment : BottomSheetDialogFragment() {
             this,
             viewModel.liveData,
             observeWindowInsets(),
-            { pendingActions.sendBlocking(it) },
+            { pendingActions.offer(it) },
             tiviDateFormatter!!
         )
     }
@@ -63,8 +64,8 @@ class AccountUiFragment : BottomSheetDialogFragment() {
     override fun onStart() {
         super.onStart()
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            for (action in pendingActions) {
+        lifecycleScope.launch {
+            pendingActions.consumeAsFlow().collect { action ->
                 when (action) {
                     is Close -> requireView().post(::dismiss)
                     is OpenSettings -> {

--- a/ui-account/src/main/java/app/tivi/account/AccountUiViewModel.kt
+++ b/ui-account/src/main/java/app/tivi/account/AccountUiViewModel.kt
@@ -26,6 +26,8 @@ import app.tivi.domain.observers.ObserveUserDetails
 import app.tivi.trakt.TraktAuthState
 import app.tivi.trakt.TraktManager
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import javax.inject.Provider
@@ -55,7 +57,7 @@ class AccountUiViewModel @ViewModelInject constructor(
         observeUserDetails(ObserveUserDetails.Params("me"))
 
         viewModelScope.launch {
-            for (action in pendingActions) {
+            pendingActions.consumeAsFlow().collect { action ->
                 when (action) {
                     Login -> appNavigator.get().login()
                     Logout -> logout()
@@ -66,7 +68,9 @@ class AccountUiViewModel @ViewModelInject constructor(
 
     fun submitAction(action: AccountUiAction) {
         viewModelScope.launch {
-            pendingActions.send(action)
+            if (!pendingActions.isClosedForSend) {
+                pendingActions.send(action)
+            }
         }
     }
 

--- a/ui-followed/src/main/java/app/tivi/home/followed/FollowedViewModel.kt
+++ b/ui-followed/src/main/java/app/tivi/home/followed/FollowedViewModel.kt
@@ -55,15 +55,15 @@ internal class FollowedViewModel @ViewModelInject constructor(
 ) {
     private val boundaryCallback = object : PagedList.BoundaryCallback<FollowedShowEntryWithShow>() {
         override fun onZeroItemsLoaded() {
-            setState { copy(isEmpty = filter.isNullOrEmpty()) }
+            viewModelScope.setState { copy(isEmpty = filter.isNullOrEmpty()) }
         }
 
         override fun onItemAtEndLoaded(itemAtEnd: FollowedShowEntryWithShow) {
-            setState { copy(isEmpty = false) }
+            viewModelScope.setState { copy(isEmpty = false) }
         }
 
         override fun onItemAtFrontLoaded(itemAtFront: FollowedShowEntryWithShow) {
-            setState { copy(isEmpty = false) }
+            viewModelScope.setState { copy(isEmpty = false) }
         }
     }
 
@@ -110,7 +110,7 @@ internal class FollowedViewModel @ViewModelInject constructor(
         observeUserDetails(ObserveUserDetails.Params("me"))
 
         // Set the available sorting options
-        setState {
+        viewModelScope.setState {
             copy(
                 availableSorts = listOf(
                     SortOption.SUPER_SORT,
@@ -149,10 +149,10 @@ internal class FollowedViewModel @ViewModelInject constructor(
     }
 
     fun setFilter(filter: String) {
-        setState { copy(filter = filter, filterActive = filter.isNotEmpty()) }
+        viewModelScope.setState { copy(filter = filter, filterActive = filter.isNotEmpty()) }
     }
 
-    fun setSort(sort: SortOption) = setState {
+    fun setSort(sort: SortOption) = viewModelScope.setState {
         require(availableSorts.contains(sort))
         copy(sort = sort)
     }

--- a/ui-search/src/main/java/app/tivi/home/search/SearchViewModel.kt
+++ b/ui-search/src/main/java/app/tivi/home/search/SearchViewModel.kt
@@ -21,8 +21,7 @@ import androidx.lifecycle.viewModelScope
 import app.tivi.ReduxViewModel
 import app.tivi.domain.interactors.SearchShows
 import app.tivi.util.ObservableLoadingCounter
-import kotlinx.coroutines.channels.ConflatedBroadcastChannel
-import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
@@ -33,13 +32,12 @@ internal class SearchViewModel @ViewModelInject constructor(
 ) : ReduxViewModel<SearchViewState>(
     SearchViewState()
 ) {
-    private val searchQuery = ConflatedBroadcastChannel<String>()
+    private val searchQuery = MutableStateFlow("")
     private val loadingState = ObservableLoadingCounter()
 
     init {
         viewModelScope.launch {
-            searchQuery.asFlow()
-                .debounce(300)
+            searchQuery.debounce(300)
                 .collectLatest { query ->
                     val job = launch {
                         loadingState.addLoader()
@@ -61,7 +59,7 @@ internal class SearchViewModel @ViewModelInject constructor(
     }
 
     fun setSearchQuery(query: String) {
-        searchQuery.offer(query)
+        searchQuery.value = query
     }
 
     fun clearQuery() = setSearchQuery("")

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragment.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsFragment.kt
@@ -35,7 +35,8 @@ import app.tivi.extensions.viewModelProviderFactoryOf
 import app.tivi.util.TiviDateFormatter
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.sendBlocking
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -72,7 +73,7 @@ class ShowDetailsFragment : Fragment() {
                 viewModel.liveData,
                 viewModel.selectObserve(ShowDetailsViewState::pendingUiEffects),
                 observeWindowInsets(),
-                { pendingActions.sendBlocking(it) },
+                { pendingActions.offer(it) },
                 tiviDateFormatter!!,
                 textCreator!!
             )
@@ -86,8 +87,8 @@ class ShowDetailsFragment : Fragment() {
 
         viewModel.liveData.observe(this, ::render)
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            for (action in pendingActions) {
+        lifecycleScope.launch {
+            pendingActions.consumeAsFlow().collect { action ->
                 when (action) {
                     NavigateUp -> {
                         findNavController().navigateUp() || requireActivity().onNavigateUp()

--- a/ui-watched/src/main/java/app/tivi/home/watched/WatchedViewModel.kt
+++ b/ui-watched/src/main/java/app/tivi/home/watched/WatchedViewModel.kt
@@ -54,15 +54,15 @@ internal class WatchedViewModel @ViewModelInject constructor(
 ) {
     private val boundaryCallback = object : PagedList.BoundaryCallback<WatchedShowEntryWithShow>() {
         override fun onZeroItemsLoaded() {
-            setState { copy(isEmpty = filter.isNullOrEmpty()) }
+            viewModelScope.setState { copy(isEmpty = filter.isNullOrEmpty()) }
         }
 
         override fun onItemAtEndLoaded(itemAtEnd: WatchedShowEntryWithShow) {
-            setState { copy(isEmpty = false) }
+            viewModelScope.setState { copy(isEmpty = false) }
         }
 
         override fun onItemAtFrontLoaded(itemAtFront: WatchedShowEntryWithShow) {
-            setState { copy(isEmpty = false) }
+            viewModelScope.setState { copy(isEmpty = false) }
         }
     }
 
@@ -107,7 +107,7 @@ internal class WatchedViewModel @ViewModelInject constructor(
         observeUserDetails(ObserveUserDetails.Params("me"))
 
         // Set the available sorting options
-        setState {
+        viewModelScope.setState {
             copy(availableSorts = listOf(SortOption.LAST_WATCHED, SortOption.ALPHABETICAL))
         }
 
@@ -143,11 +143,13 @@ internal class WatchedViewModel @ViewModelInject constructor(
     }
 
     fun setFilter(filter: String) {
-        setState { copy(filter = filter, filterActive = filter.isNotEmpty()) }
+        viewModelScope.setState {
+            copy(filter = filter, filterActive = filter.isNotEmpty())
+        }
     }
 
     fun setSort(sort: SortOption) {
-        setState { copy(sort = sort) }
+        viewModelScope.setState { copy(sort = sort) }
     }
 
     fun clearSelection() {


### PR DESCRIPTION
- Updated to Coroutines 1.3.7
- Replaced all usage of `ConflatedBroadcastChannel` with `StateFlow`
- Started consuming `pendingAction` Channels in ViewModels via `consumeAsFlow()` to ensure the channels get closed.
- Started checking for closed channels before `offer()`ing
- Tidied up some of the internals of `ReduxViewModel` since we can now rely on `StateFlow`
- Removed `Store`'s explicit `CoroutineScope`