### PR TITLE
Improvements across composability in show details 

### DIFF
--- a/data/src/main/java/app/tivi/data/entities/Episode.kt
+++ b/data/src/main/java/app/tivi/data/entities/Episode.kt
@@ -19,6 +19,7 @@ package app.tivi.data.entities
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.Ignore
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.threeten.bp.OffsetDateTime
@@ -56,8 +57,6 @@ data class Episode(
         val EMPTY = Episode(seasonId = 0)
     }
 
-    fun isAired() = when {
-        firstAired != null -> firstAired.isBefore(OffsetDateTime.now())
-        else -> false
-    }
+    @delegate:Ignore
+    val isAired by lazy { firstAired?.isBefore(OffsetDateTime.now()) ?: false }
 }

--- a/data/src/main/java/app/tivi/data/resultentities/EpisodeWithWatches.kt
+++ b/data/src/main/java/app/tivi/data/resultentities/EpisodeWithWatches.kt
@@ -17,6 +17,7 @@
 package app.tivi.data.resultentities
 
 import androidx.room.Embedded
+import androidx.room.Ignore
 import androidx.room.Relation
 import app.tivi.data.entities.Episode
 import app.tivi.data.entities.EpisodeWatchEntry
@@ -26,28 +27,33 @@ import java.util.Objects
 
 class EpisodeWithWatches {
     @Embedded
-    var episode: Episode? = null
+    lateinit var episode: Episode
 
     @Relation(parentColumn = "id", entityColumn = "episode_id")
-    var watches: List<EpisodeWatchEntry> = emptyList()
+    lateinit var watches: List<EpisodeWatchEntry>
 
-    fun hasWatches() = watches.isNotEmpty()
+    @delegate:Ignore
+    val hasWatches by lazy { watches.isNotEmpty() }
 
-    fun isWatched() = watches.any {
-        it.pendingAction != PendingAction.DELETE
+    @delegate:Ignore
+    val isWatched by lazy {
+        watches.any { it.pendingAction != PendingAction.DELETE }
     }
 
-    fun hasPending() = watches.any {
-        it.pendingAction != PendingAction.NOTHING
+    @delegate:Ignore
+    val hasPending by lazy {
+        watches.any { it.pendingAction != PendingAction.NOTHING }
     }
 
-    fun onlyPendingDeletes() = watches.all {
-        it.pendingAction == PendingAction.DELETE
+    @delegate:Ignore
+    val onlyPendingDeletes by lazy {
+        watches.all { it.pendingAction == PendingAction.DELETE }
     }
 
-    fun hasAired(): Boolean {
-        val aired = episode?.firstAired
-        return aired != null && aired.isBefore(OffsetDateTime.now())
+    @delegate:Ignore
+    val hasAired by lazy {
+        val aired = episode.firstAired
+        aired != null && aired.isBefore(OffsetDateTime.now())
     }
 
     override fun equals(other: Any?): Boolean = when {

--- a/data/src/main/java/app/tivi/data/resultentities/SeasonWithEpisodesAndWatches.kt
+++ b/data/src/main/java/app/tivi/data/resultentities/SeasonWithEpisodesAndWatches.kt
@@ -39,18 +39,18 @@ class SeasonWithEpisodesAndWatches {
 }
 
 val List<EpisodeWithWatches>.numberAiredToWatch: Int
-    get() = count { !it.isWatched() && it.episode?.isAired() == true }
+    get() = count { !it.isWatched && it.episode.isAired }
 
 val List<EpisodeWithWatches>.numberWatched: Int
-    get() = count { it.isWatched() }
+    get() = count { it.isWatched }
 
 val List<EpisodeWithWatches>.numberToAir: Int
     get() = size - numberAired
 
 val List<EpisodeWithWatches>.numberAired: Int
-    get() = count { it.episode?.isAired() == true }
+    get() = count { it.episode.isAired }
 
 val List<EpisodeWithWatches>.nextToAir: Episode?
-    get() = firstOrNull {
-        it.episode?.let { ep -> !ep.isAired() && ep.firstAired != null } ?: false
-    }?.episode
+    get() = first {
+        it.episode.let { ep -> !ep.isAired && ep.firstAired != null }
+    }.episode


### PR DESCRIPTION
Currently we pass down entire data classes to composable functions. These classes are backed by a changing data source
(Room) which means that if any field changes, all composable functions which have a data class param which re-compose.

We can help with that by deconstructing the params and only passing in the bare minimum each composable needs