### PR TITLE
Use Gradle Play Publisher SNAPSHOT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         run: ./gradlew spotlessCheck assembleDebug assembleRelease app:lintDebug testDebug -Ptivi.versioncode=$BUILD_NUMBER --scan --stacktrace
 
       - name: Publish to Play Store
-        if: github.ref == 'refs/heads/main'
+        #if: github.ref == 'refs/heads/main'
         # Need to invoke bundleRelease too for Crashlytics.
         # See https://github.com/Triple-T/gradle-play-publisher/issues/859
         run: ./gradlew bundleRelease publishRelease -Ptivi.versioncode=$BUILD_NUMBER --scan --stacktrace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         run: ./gradlew spotlessCheck assembleDebug assembleRelease app:lintDebug testDebug -Ptivi.versioncode=$BUILD_NUMBER --scan --stacktrace
 
       - name: Publish to Play Store
-        #if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         # Need to invoke bundleRelease too for Crashlytics.
         # See https://github.com/Triple-T/gradle-play-publisher/issues/859
         run: ./gradlew bundleRelease publishRelease -Ptivi.versioncode=$BUILD_NUMBER --scan --stacktrace

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ buildscript {
         google()
         mavenCentral()
         jcenter()
+
+        // Used for Gradle Play Publisher snapshots
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
     }
 
     dependencies {

--- a/buildSrc/src/main/java/app/tivi/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/app/tivi/buildsrc/dependencies.kt
@@ -21,9 +21,9 @@ object Versions {
 }
 
 object Libs {
-    const val androidGradlePlugin = "com.android.tools.build:gradle:4.2.0-alpha11"
+    const val androidGradlePlugin = "com.android.tools.build:gradle:4.2.0-alpha13"
 
-    const val gradlePlayPublisher = "com.github.triplet.gradle:play-publisher:3.0.0"
+    const val gradlePlayPublisher = "com.github.triplet.gradle:play-publisher:3.2.0-SNAPSHOT"
 
     const val threeTenBp = "org.threeten:threetenbp:1.4.4"
     const val threeTenBpNoTzdb = "$threeTenBp:no-tzdb"


### PR DESCRIPTION
Includes workaround for https://github.com/Triple-T/gradle-play-publisher/issues/864, which means we can upgrade AGP to 4.2.0-alpha13