### PR TITLE
Re-enable hardware bitmaps

### DIFF
--- a/common-imageloading/src/main/java/app/tivi/common/imageloading/CoilAppInitializer.kt
+++ b/common-imageloading/src/main/java/app/tivi/common/imageloading/CoilAppInitializer.kt
@@ -40,11 +40,6 @@ class CoilAppInitializer @OptIn(ExperimentalCoilApi::class)
             .build()
         Coil.setImageLoader {
             ImageLoader.Builder(application)
-                // Hardware bitmaps break with our transitions, disable them for now
-                .allowHardware(false)
-                // Since we don't use hardware bitmaps, we can pool bitmaps and use a higher
-                // ratio of memory
-                .bitmapPoolPercentage(0.5)
                 .componentRegistry {
                     add(tmdbImageEntityInterceptor)
                     add(episodeEntityInterceptor)


### PR DESCRIPTION
Since we're not using transitions right now