### PR TITLE
Move to SharedFlow in SubjectInteractor

### DIFF
--- a/buildSrc/src/main/java/app/tivi/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/app/tivi/buildsrc/dependencies.kt
@@ -87,7 +87,7 @@ object Libs {
     }
 
     object Coroutines {
-        private const val version = "1.3.9"
+        private const val version = "1.4.0"
         const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
         const val android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$version"
         const val test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:$version"


### PR DESCRIPTION
Reverts the behavior to what we had previously with `BroadcastChannel`s.

Closes #721