### PR TITLE
Remove redundant rules in shrinker configuration

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -2,22 +2,13 @@
 
 -verbose
 -allowaccessmodification
--repackageclasses 'tivi'
+-repackageclasses
 
 # Note that you cannot just include these flags in your own
 # configuration file; if you are including this file, optimization
 # will be turned off. You'll need to either edit this file, or
 # duplicate the contents of this file and remove the include of this
 # file from your project's proguard.config path property.
-
--keep public class * extends android.app.Activity
--keep public class * extends android.app.Application
--keep public class * extends android.app.Service
--keep public class * extends android.content.BroadcastReceiver
--keep public class * extends android.content.ContentProvider
--keep public class * extends android.app.backup.BackupAgent
--keep public class * extends android.preference.Preference
--keep public class * extends androidx.fragment.app.Fragment
 
 # For native methods, see http://proguard.sourceforge.net/manual/examples.html#native
 -keepclasseswithmembernames class * {
@@ -31,17 +22,12 @@
 
 # For enumeration classes
 -keepclassmembers enum * {
-    <fields>;
     public static **[] values();
     public static ** valueOf(java.lang.String);
 }
 
 -keep class * implements android.os.Parcelable {
   public static final android.os.Parcelable$Creator *;
-}
-
--keepclassmembers class **.R$* {
-    public static <fields>;
 }
 
 # AndroidX + support library contains references to newer platform versions.


### PR DESCRIPTION
This reduces uncompressed dex size by ~4%.