### PR TITLE
Fix flipped fav icon (UX)

### DIFF
--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetails.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetails.kt
@@ -1045,8 +1045,8 @@ private fun ToggleShowFollowFloatingActionButton(
         icon = {
             Icon(
                 imageVector = when {
-                    isFollowed -> Icons.Default.FavoriteBorder
-                    else -> Icons.Default.Favorite
+                    isFollowed -> Icons.Default.Favorite
+                    else -> Icons.Default.FavoriteBorder
                 },
                 contentDescription = when {
                     isFollowed -> stringResource(R.string.cd_follow_show_remove)
@@ -1063,8 +1063,8 @@ private fun ToggleShowFollowFloatingActionButton(
             )
         },
         backgroundColor = when {
-            isFollowed -> MaterialTheme.colors.surface
-            else -> MaterialTheme.colors.primary
+            isFollowed -> MaterialTheme.colors.primary
+            else -> MaterialTheme.colors.surface
         },
         expanded = expanded(),
         modifier = modifier


### PR DESCRIPTION
I've noticed the favorite icon behaves differently (showing enabled state for disabled and vice versa)