### PR TITLE
Apply changes regarding Gradle v7.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,21 +34,21 @@ buildscript {
     }
 
     dependencies {
-        classpath libs.android.gradlePlugin
-        classpath libs.kotlin.gradlePlugin
+        classpath libs.android.pluginGradle
+        classpath libs.kotlin.pluginGradle
 
         classpath libs.kotlin.extensions
 
         classpath libs.google.gmsGoogleServices
         classpath libs.google.crashlyticsGradle
 
-        classpath libs.hilt.gradlePlugin
+        classpath libs.hilt.pluginGradle
     }
 }
 
 plugins {
-    id 'com.diffplug.spotless' version '5.14.3'
-    id 'com.github.ben-manes.versions' version '0.39.0'
+    alias(libs.plugins.spotless)
+    alias(libs.plugins.gradleDependencyUpdate)
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,12 @@ paging = "3.1.0-alpha03"
 retrofit = "2.9.0"
 room = "2.4.0-alpha04"
 threetenbp = "1.5.1"
+spotless = "5.14.3"
+gradleDependencyUpdate = "0.39.0"
+
+[plugins]
+spotless = { id = "com.diffplug.spotless", version.ref="spotless" }
+gradleDependencyUpdate = { id = "com.github.ben-manes.versions", version.ref="gradleDependencyUpdate" }
 
 [libraries]
 accompanist-flowlayout = { module = "com.google.accompanist:accompanist-flowlayout", version.ref = "accompanist" }
@@ -25,7 +31,7 @@ accompanist-swiperefresh = { module = "com.google.accompanist:accompanist-swiper
 accompanist-pager-pager = { module = "com.google.accompanist:accompanist-pager", version.ref = "accompanist" }
 accompanist-pager-indicators = { module = "com.google.accompanist:accompanist-pager-indicators", version.ref = "accompanist" }
 
-android-gradlePlugin = "com.android.tools.build:gradle:7.1.0-alpha08"
+android-pluginGradle = "com.android.tools.build:gradle:7.1.0-alpha09"
 
 androidx-activity-compose = "androidx.activity:activity-compose:1.3.1"
 androidx-archCoreTesting = "androidx.arch.core:core-testing:2.1.0"
@@ -89,7 +95,7 @@ google-crashlyticsGradle = "com.google.firebase:firebase-crashlytics-gradle:2.7.
 google-gmsGoogleServices = "com.google.gms:google-services:4.3.8"
 
 hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
-hilt-gradlePlugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
+hilt-pluginGradle = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
 hilt-library = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 
@@ -99,7 +105,7 @@ kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines
 kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlin-extensions = { module = "org.jetbrains.kotlin:kotlin-android-extensions", version.ref = "kotlin" }
-kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-pluginGradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 
 leakCanary = "com.squareup.leakcanary:leakcanary-android:2.7"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle 7.2 introduces [reserved names](https://docs.gradle.org/7.2/userguide/version_catalog_problems.html#reserved_alias_name). Alias ends with `plugin` is no longer usable. Also gradle plugins(not classpath ones) [can be declared](https://docs.gradle.org/7.2/release-notes.html) in the `.toml` file now.