### PR TITLE
Try out Molecule on Show Details

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ buildscript {
         classpath libs.google.crashlyticsGradle
 
         classpath libs.hilt.pluginGradle
+
+        classpath libs.molecule.gradle
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -125,6 +125,8 @@ leakCanary = "com.squareup.leakcanary:leakcanary-android:2.8.1"
 
 mockK = "io.mockk:mockk:1.12.2"
 
+molecule-gradle = "app.cash.molecule:molecule-gradle-plugin:0.2.0"
+
 okhttp-loggingInterceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 

--- a/ui-showdetails/build.gradle
+++ b/ui-showdetails/build.gradle
@@ -27,6 +27,8 @@ kapt {
 
 apply plugin: 'dagger.hilt.android.plugin'
 
+apply plugin: 'app.cash.molecule'
+
 android {
     compileSdkVersion buildConfig.compileSdk
 


### PR DESCRIPTION
`ShowDetailsViewModel` already follows an MVI-ish architecture so migrating to Molecule was pretty trivial. I love how the 'ViewModel' becomes a pretty empty shell for the `launchMolecule` call, mostly there for DI.

See here if you're interested in reading more: https://code.cash.app/the-state-of-managing-state-with-compose