### PR TITLE
Fix Chucker not working with R8 full mode enabled

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -139,6 +139,7 @@ android {
             // This is a release build with Chucker enabled
             initWith release
             matchingFallbacks = [ 'release' ]
+            proguardFiles += 'proguard-rules-chucker.pro'
         }
     }
 }

--- a/app/proguard-rules-chucker.pro
+++ b/app/proguard-rules-chucker.pro
@@ -1,0 +1,5 @@
+# Chucker uses GSON and TypeToken:
+# https://r8.googlesource.com/r8/+/refs/heads/main/compatibility-faq.md#gson-with-full-mode
+-keepattributes Signature
+-keep class com.google.gson.reflect.TypeToken { *; }
+-keep class * extends com.google.gson.reflect.TypeToken

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ import app.tivi.buildsrc.ReleaseType
 buildscript {
     ext.buildConfig = [
             'compileSdk': 31,
-            'minSdk'    : 24, // https://issuetracker.google.com/issues/194289155
+            'minSdk'    : 23,
             'targetSdk' : 31,
     ]
 


### PR DESCRIPTION
Chucker uses GSON and TypeToken so we need to keep various classes: https://r8.googlesource.com/r8/+/refs/heads/main/compatibility-faq.md#gson-with-full-mode