### PR TITLE
Re-add screen view analytics events

### DIFF
--- a/app/src/main/java/app/tivi/home/Home.kt
+++ b/app/src/main/java/app/tivi/home/Home.kt
@@ -65,6 +65,7 @@ import app.tivi.AppNavigation
 import app.tivi.R
 import app.tivi.Screen
 import app.tivi.common.compose.theme.AppBarAlphas
+import app.tivi.util.Analytics
 import com.google.accompanist.insets.LocalWindowInsets
 import com.google.accompanist.insets.navigationBarsHeight
 import com.google.accompanist.insets.rememberInsetsPaddingValues
@@ -75,9 +76,22 @@ import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 @OptIn(ExperimentalAnimationApi::class, ExperimentalMaterialApi::class)
 @Composable
 internal fun Home(
+    analytics: Analytics,
     onOpenSettings: () -> Unit,
 ) {
     val navController = rememberAnimatedNavController()
+
+    DisposableEffect(navController, analytics) {
+        val listener = NavController.OnDestinationChangedListener { _, destination, arguments ->
+            analytics.trackScreenView(
+                label = destination.label?.toString() ?: destination.displayName,
+                route = destination.route,
+                arguments = arguments,
+            )
+        }
+        navController.addOnDestinationChangedListener(listener)
+        onDispose { navController.removeOnDestinationChangedListener(listener) }
+    }
 
     val configuration = LocalConfiguration.current
     val useBottomNavigation by remember {
@@ -129,7 +143,11 @@ internal fun Home(
                     modifier = Modifier.fillMaxHeight(),
                 )
 
-                Divider(Modifier.fillMaxHeight().width(1.dp))
+                Divider(
+                    Modifier
+                        .fillMaxHeight()
+                        .width(1.dp)
+                )
             }
 
             AppNavigation(

--- a/app/src/main/java/app/tivi/home/Home.kt
+++ b/app/src/main/java/app/tivi/home/Home.kt
@@ -84,7 +84,7 @@ internal fun Home(
     DisposableEffect(navController, analytics) {
         val listener = NavController.OnDestinationChangedListener { _, destination, arguments ->
             analytics.trackScreenView(
-                label = destination.label?.toString() ?: destination.displayName,
+                label = destination.label?.toString() ?: "Composable",
                 route = destination.route,
                 arguments = arguments,
             )

--- a/app/src/main/java/app/tivi/home/MainActivity.kt
+++ b/app/src/main/java/app/tivi/home/MainActivity.kt
@@ -29,6 +29,7 @@ import app.tivi.common.compose.shouldUseDarkColors
 import app.tivi.common.compose.theme.TiviTheme
 import app.tivi.settings.SettingsActivity
 import app.tivi.settings.TiviPreferences
+import app.tivi.util.Analytics
 import app.tivi.util.TiviDateFormatter
 import app.tivi.util.TiviTextCreator
 import com.google.accompanist.insets.ProvideWindowInsets
@@ -42,13 +43,14 @@ class MainActivity : TiviActivity() {
     @Inject internal lateinit var tiviDateFormatter: TiviDateFormatter
     @Inject internal lateinit var textCreator: TiviTextCreator
     @Inject internal lateinit var preferences: TiviPreferences
+    @Inject internal lateinit var analytics: Analytics
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
-        viewModel = ViewModelProvider(this).get(MainActivityViewModel::class.java)
+        viewModel = ViewModelProvider(this)[MainActivityViewModel::class.java]
 
         setContent {
             CompositionLocalProvider(
@@ -57,7 +59,10 @@ class MainActivity : TiviActivity() {
             ) {
                 ProvideWindowInsets(consumeWindowInsets = false) {
                     TiviTheme(useDarkColors = preferences.shouldUseDarkColors()) {
-                        Home(onOpenSettings = ::openSettings)
+                        Home(
+                            analytics = analytics,
+                            onOpenSettings = ::openSettings,
+                        )
                     }
                 }
             }

--- a/app/src/main/java/app/tivi/inject/AppModule.kt
+++ b/app/src/main/java/app/tivi/inject/AppModule.kt
@@ -24,6 +24,7 @@ import app.tivi.tmdb.TmdbModule
 import app.tivi.trakt.TraktModule
 import app.tivi.util.AppCoroutineDispatchers
 import com.chuckerteam.chucker.api.ChuckerInterceptor
+import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.Module
 import dagger.Provides
@@ -116,6 +117,12 @@ object AppModule {
     @Provides
     @Singleton
     fun provideFirebaseCrashlytics(): FirebaseCrashlytics = FirebaseCrashlytics.getInstance()
+
+    @Provides
+    @Singleton
+    fun provideFirebaseAnalytics(
+        @ApplicationContext context: Context
+    ): FirebaseAnalytics = FirebaseAnalytics.getInstance(context)
 
     @Provides
     @Named("chucker")

--- a/app/src/main/java/app/tivi/inject/AppModuleBinds.kt
+++ b/app/src/main/java/app/tivi/inject/AppModuleBinds.kt
@@ -23,25 +23,18 @@ import app.tivi.appinitializers.ThreeTenBpInitializer
 import app.tivi.appinitializers.TimberInitializer
 import app.tivi.appinitializers.TmdbInitializer
 import app.tivi.util.AndroidPowerController
-import app.tivi.util.Logger
 import app.tivi.util.PowerController
-import app.tivi.util.TiviLogger
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
-import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
 @Module
 abstract class AppModuleBinds {
     @Binds
     internal abstract fun providePowerController(bind: AndroidPowerController): PowerController
-
-    @Singleton
-    @Binds
-    abstract fun provideLogger(bind: TiviLogger): Logger
 
     @Binds
     @IntoSet

--- a/base-android/build.gradle
+++ b/base-android/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation project(':data')
 
     implementation libs.google.crashlytics
+    implementation libs.google.analytics
 
     implementation libs.androidx.core
 

--- a/base-android/src/main/java/app/tivi/BaseModule.kt
+++ b/base-android/src/main/java/app/tivi/BaseModule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,26 @@
  * limitations under the License.
  */
 
-package app.tivi.appinitializers
+package app.tivi
 
-import android.app.Application
-import app.tivi.BuildConfig
+import app.tivi.util.Analytics
 import app.tivi.util.Logger
-import javax.inject.Inject
+import app.tivi.util.TiviAnalytics
+import app.tivi.util.TiviLogger
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
-class TimberInitializer @Inject constructor(
-    private val logger: Logger
-) : AppInitializer {
-    override fun init(application: Application) = logger.setup(BuildConfig.DEBUG)
+@InstallIn(SingletonComponent::class)
+@Module
+abstract class BaseModule {
+    @Singleton
+    @Binds
+    internal abstract fun provideLogger(bind: TiviLogger): Logger
+
+    @Singleton
+    @Binds
+    internal abstract fun provideAnalytics(bind: TiviAnalytics): Analytics
 }

--- a/base-android/src/main/java/app/tivi/util/TiviAnalytics.kt
+++ b/base-android/src/main/java/app/tivi/util/TiviAnalytics.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.tivi.util
+
+import android.os.Bundle
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.analytics.ktx.logEvent
+import javax.inject.Inject
+import javax.inject.Provider
+
+internal class TiviAnalytics @Inject constructor(
+    private val firebaseAnalytics: Provider<FirebaseAnalytics>,
+) : Analytics {
+    override fun trackScreenView(
+        label: String,
+        route: String?,
+        arguments: Any?,
+    ) {
+        try {
+            firebaseAnalytics.get().logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+                param(FirebaseAnalytics.Param.SCREEN_NAME, label)
+                if (route != null) param("screen_route", route)
+                when {
+                    arguments is Bundle -> {
+                        for (key in arguments.keySet()) {
+                            param("screen_arg_$key", arguments.get(key).toString())
+                        }
+                    }
+                    arguments != null -> param("screen_arg", arguments.toString())
+                }
+            }
+        } catch (t: Throwable) {
+            // Ignore, Firebase might not be setup for this project
+        }
+    }
+}

--- a/base-android/src/main/java/app/tivi/util/TiviLogger.kt
+++ b/base-android/src/main/java/app/tivi/util/TiviLogger.kt
@@ -24,10 +24,10 @@ import java.util.regex.Pattern
 import javax.inject.Inject
 import javax.inject.Provider
 
-class TiviLogger @Inject constructor(
+internal class TiviLogger @Inject constructor(
     private val firebaseCrashlytics: Provider<FirebaseCrashlytics>,
 ) : Logger {
-    fun setup(debugMode: Boolean) {
+    override fun setup(debugMode: Boolean) {
         if (debugMode) {
             Timber.plant(TiviDebugTree())
         }

--- a/base/src/main/java/app/tivi/util/Analytics.kt
+++ b/base/src/main/java/app/tivi/util/Analytics.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-package app.tivi.appinitializers
+package app.tivi.util
 
-import android.app.Application
-import app.tivi.BuildConfig
-import app.tivi.util.Logger
-import javax.inject.Inject
-
-class TimberInitializer @Inject constructor(
-    private val logger: Logger
-) : AppInitializer {
-    override fun init(application: Application) = logger.setup(BuildConfig.DEBUG)
+interface Analytics {
+    fun trackScreenView(
+        label: String,
+        route: String?,
+        arguments: Any? = null,
+    )
 }

--- a/base/src/main/java/app/tivi/util/Logger.kt
+++ b/base/src/main/java/app/tivi/util/Logger.kt
@@ -18,6 +18,8 @@ package app.tivi.util
 
 interface Logger {
 
+    fun setup(debugMode: Boolean)
+
     fun setUserId(id: String)
 
     /** Log a verbose message with optional format args.  */

--- a/data-android/src/test/java/app/tivi/data/TestDatabaseInject.kt
+++ b/data-android/src/test/java/app/tivi/data/TestDatabaseInject.kt
@@ -18,6 +18,7 @@ package app.tivi.data
 
 import android.content.Context
 import androidx.room.Room
+import app.tivi.BaseModule
 import app.tivi.data.repositories.episodes.EpisodeDataSource
 import app.tivi.data.repositories.episodes.SeasonsEpisodesDataSource
 import app.tivi.data.repositories.followedshows.TraktFollowedShowsDataSource
@@ -25,6 +26,7 @@ import app.tivi.data.repositories.showimages.ShowImagesDataSource
 import app.tivi.data.repositories.shows.ShowDataSource
 import app.tivi.inject.Trakt
 import app.tivi.trakt.TraktAuthState
+import app.tivi.util.Analytics
 import app.tivi.util.Logger
 import app.tivi.utils.SuccessFakeShowDataSource
 import app.tivi.utils.SuccessFakeShowImagesDataSource
@@ -37,6 +39,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
 import io.mockk.mockk
 import javax.inject.Singleton
 
@@ -89,10 +92,6 @@ object TestDatabaseModule {
 
     @Provides
     fun provideTraktAuthState() = TraktAuthState.LOGGED_IN
-
-    @Singleton
-    @Provides
-    fun provideLogger(): Logger = mockk(relaxUnitFun = true)
 }
 
 @InstallIn(SingletonComponent::class)
@@ -109,4 +108,19 @@ object TestRoomDatabaseModule {
     @Singleton
     @Provides
     fun provideDatabaseTransactionRunner(): DatabaseTransactionRunner = TestTransactionRunner
+}
+
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [BaseModule::class]
+)
+@Module
+object TestBaseModule {
+    @Singleton
+    @Provides
+    fun provideLogger(): Logger = mockk(relaxUnitFun = true)
+
+    @Singleton
+    @Provides
+    fun provideAnalytics(): Analytics = mockk(relaxUnitFun = true)
 }


### PR DESCRIPTION
We currently don't have a way to set Destination labels in Compose
though unfortunately.