### PR TITLE
Migrate network calls away from Result wrapper class

### DIFF
--- a/base-android/src/main/java/app/tivi/util/TiviLogger.kt
+++ b/base-android/src/main/java/app/tivi/util/TiviLogger.kt
@@ -161,10 +161,6 @@ private class CrashlyticsTree(
     }
 
     override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
-        if (t != null) {
-            firebaseCrashlytics.recordException(t)
-        } else {
-            firebaseCrashlytics.log(message)
-        }
+        firebaseCrashlytics.log(message)
     }
 }

--- a/data-android/src/main/java/app/tivi/data/repositories/popularshows/PopularShowsModule.kt
+++ b/data-android/src/main/java/app/tivi/data/repositories/popularshows/PopularShowsModule.kt
@@ -19,7 +19,6 @@ package app.tivi.data.repositories.popularshows
 import app.tivi.data.daos.PopularDao
 import app.tivi.data.daos.TiviShowDao
 import app.tivi.data.entities.PopularShowEntry
-import app.tivi.data.entities.Success
 import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.SourceOfTruth
 import com.dropbox.android.external.store4.Store
@@ -48,10 +47,8 @@ internal object PopularShowsModule {
         fetcher = Fetcher.of { page: Int ->
             traktPopularShows(page, 20)
                 .also {
-                    if (page == 0 && it is Success) {
-                        lastRequestStore.updateLastRequest()
-                    }
-                }.getOrThrow()
+                    if (page == 0) lastRequestStore.updateLastRequest()
+                }
         },
         sourceOfTruth = SourceOfTruth.of(
             reader = { page ->

--- a/data-android/src/main/java/app/tivi/data/repositories/recommendedshows/RecommendedShowsModule.kt
+++ b/data-android/src/main/java/app/tivi/data/repositories/recommendedshows/RecommendedShowsModule.kt
@@ -19,7 +19,6 @@ package app.tivi.data.repositories.recommendedshows
 import app.tivi.data.daos.RecommendedDao
 import app.tivi.data.daos.TiviShowDao
 import app.tivi.data.entities.RecommendedShowEntry
-import app.tivi.data.entities.Success
 import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.SourceOfTruth
 import com.dropbox.android.external.store4.Store
@@ -48,10 +47,10 @@ internal object RecommendedShowsModule {
         fetcher = Fetcher.of { page: Int ->
             traktRecommendedShows(page, 20)
                 .also {
-                    if (page == 0 && it is Success) {
+                    if (page == 0) {
                         lastRequestStore.updateLastRequest()
                     }
-                }.getOrThrow()
+                }
         },
         sourceOfTruth = SourceOfTruth.of(
             reader = { page ->

--- a/data-android/src/main/java/app/tivi/data/repositories/relatedshows/RelatedShowsModule.kt
+++ b/data-android/src/main/java/app/tivi/data/repositories/relatedshows/RelatedShowsModule.kt
@@ -19,7 +19,6 @@ package app.tivi.data.repositories.relatedshows
 import app.tivi.data.daos.RelatedShowsDao
 import app.tivi.data.daos.TiviShowDao
 import app.tivi.data.entities.RelatedShowEntry
-import app.tivi.data.entities.Success
 import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.SourceOfTruth
 import com.dropbox.android.external.store4.Store
@@ -47,11 +46,7 @@ internal object RelatedShowsModule {
     ): RelatedShowsStore = StoreBuilder.from(
         fetcher = Fetcher.of { showId: Long ->
             tmdbRelatedShows(showId)
-                .also {
-                    if (it is Success) {
-                        lastRequestStore.updateLastRequest(showId)
-                    }
-                }.getOrThrow()
+                .also { lastRequestStore.updateLastRequest(showId) }
         },
         sourceOfTruth = SourceOfTruth.of(
             reader = { showId ->

--- a/data-android/src/main/java/app/tivi/data/repositories/showimages/ShowsImagesModule.kt
+++ b/data-android/src/main/java/app/tivi/data/repositories/showimages/ShowsImagesModule.kt
@@ -19,7 +19,6 @@ package app.tivi.data.repositories.showimages
 import app.tivi.data.daos.ShowTmdbImagesDao
 import app.tivi.data.daos.TiviShowDao
 import app.tivi.data.entities.ShowTmdbImage
-import app.tivi.data.entities.Success
 import app.tivi.inject.Tmdb
 import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.SourceOfTruth
@@ -58,15 +57,10 @@ object ShowImagesStoreModule {
         fetcher = Fetcher.of { showId: Long ->
             val show = showDao.getShowWithId(showId)
                 ?: throw IllegalArgumentException("Show with ID $showId does not exist")
-            val result = tmdbShowImagesDataSource.getShowImages(show)
 
-            if (result is Success) {
-                lastRequestStore.updateLastRequest(showId)
-            }
-
-            result.getOrThrow().map {
-                it.copy(showId = showId)
-            }
+            tmdbShowImagesDataSource.getShowImages(show)
+                .also { lastRequestStore.updateLastRequest(showId) }
+                .map { it.copy(showId = showId) }
         },
         sourceOfTruth = SourceOfTruth.of(
             reader = { showId ->

--- a/data-android/src/main/java/app/tivi/data/repositories/shows/ShowsModule.kt
+++ b/data-android/src/main/java/app/tivi/data/repositories/shows/ShowsModule.kt
@@ -17,7 +17,6 @@
 package app.tivi.data.repositories.shows
 
 import app.tivi.data.daos.TiviShowDao
-import app.tivi.data.entities.Success
 import app.tivi.data.entities.TiviShow
 import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.SourceOfTruth
@@ -45,11 +44,7 @@ object ShowStoreModule {
     ): ShowStore = StoreBuilder.from(
         fetcher = Fetcher.of { id: Long ->
             traktShowDataSource.getShow(showDao.getShowWithIdOrThrow(id))
-                .also {
-                    if (it is Success<*>) {
-                        lastRequestStore.updateLastRequest(id)
-                    }
-                }.getOrThrow()
+                .also { lastRequestStore.updateLastRequest(id) }
         },
         sourceOfTruth = SourceOfTruth.of(
             reader = { showId ->

--- a/data-android/src/main/java/app/tivi/data/repositories/trendingshows/TrendingShowsModule.kt
+++ b/data-android/src/main/java/app/tivi/data/repositories/trendingshows/TrendingShowsModule.kt
@@ -18,7 +18,6 @@ package app.tivi.data.repositories.trendingshows
 
 import app.tivi.data.daos.TiviShowDao
 import app.tivi.data.daos.TrendingDao
-import app.tivi.data.entities.Success
 import app.tivi.data.entities.TrendingShowEntry
 import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.SourceOfTruth
@@ -48,10 +47,10 @@ object TrendingShowsModule {
         fetcher = Fetcher.of { page: Int ->
             traktTrendingShows(page, 20)
                 .also {
-                    if (page == 0 && it is Success) {
+                    if (page == 0) {
                         lastRequestStore.updateLastRequest()
                     }
-                }.getOrThrow()
+                }
         },
         sourceOfTruth = SourceOfTruth.of(
             reader = { page ->

--- a/data-android/src/main/java/app/tivi/data/repositories/watchedshows/WatchedShowsModule.kt
+++ b/data-android/src/main/java/app/tivi/data/repositories/watchedshows/WatchedShowsModule.kt
@@ -18,7 +18,6 @@ package app.tivi.data.repositories.watchedshows
 
 import app.tivi.data.daos.TiviShowDao
 import app.tivi.data.daos.WatchedShowDao
-import app.tivi.data.entities.Success
 import app.tivi.data.entities.WatchedShowEntry
 import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.SourceOfTruth
@@ -45,13 +44,11 @@ internal object WatchedShowsModule {
         showDao: TiviShowDao,
         lastRequestStore: WatchedShowsLastRequestStore
     ): WatchedShowsStore = StoreBuilder.from(
-        fetcher = Fetcher.of { _: Unit ->
+        fetcher = Fetcher.of {
             traktWatchedShows()
                 .also {
-                    if (it is Success) {
-                        lastRequestStore.updateLastRequest()
-                    }
-                }.getOrThrow()
+                    lastRequestStore.updateLastRequest()
+                }
         },
         sourceOfTruth = SourceOfTruth.of(
             reader = {

--- a/data-android/src/test/java/app/tivi/data/repositories/FollowedShowRepositoryTest.kt
+++ b/data-android/src/test/java/app/tivi/data/repositories/FollowedShowRepositoryTest.kt
@@ -20,8 +20,6 @@ import app.tivi.data.DatabaseModuleBinds
 import app.tivi.data.DatabaseTest
 import app.tivi.data.TiviDatabase
 import app.tivi.data.daos.FollowedShowsDao
-import app.tivi.data.entities.ErrorResult
-import app.tivi.data.entities.Success
 import app.tivi.data.repositories.episodes.EpisodeDataSourceBinds
 import app.tivi.data.repositories.followedshows.FollowedShowsRepository
 import app.tivi.data.repositories.followedshows.TraktFollowedShowsDataSource
@@ -68,12 +66,10 @@ class FollowedShowRepositoryTest : DatabaseTest() {
 
     @Test
     fun testSync() = testScope.runBlockingTest {
-        coEvery { traktDataSource.getFollowedListId() } returns Success(
-            TraktList().apply {
-                ids = ListIds().apply { trakt = 0 }
-            }
-        )
-        coEvery { traktDataSource.getListShows(0) } returns Success(listOf(followedShow1Network to show))
+        coEvery { traktDataSource.getFollowedListId() } returns TraktList().apply {
+            ids = ListIds().apply { trakt = 0 }
+        }
+        coEvery { traktDataSource.getListShows(0) } returns listOf(followedShow1Network to show)
 
         repository.syncFollowedShows()
 
@@ -85,12 +81,11 @@ class FollowedShowRepositoryTest : DatabaseTest() {
     fun testSync_emptyResponse() = testScope.runBlockingTest {
         insertFollowedShow(database)
 
-        coEvery { traktDataSource.getFollowedListId() } returns Success(
-            TraktList().apply {
-                ids = ListIds().apply { trakt = 0 }
-            }
-        )
-        coEvery { traktDataSource.getListShows(0) } returns Success(emptyList())
+        coEvery { traktDataSource.getFollowedListId() } returns TraktList().apply {
+            ids = ListIds().apply { trakt = 0 }
+        }
+
+        coEvery { traktDataSource.getListShows(0) } returns emptyList()
 
         repository.syncFollowedShows()
 
@@ -101,12 +96,10 @@ class FollowedShowRepositoryTest : DatabaseTest() {
     fun testSync_responseDifferentShow() = testScope.runBlockingTest {
         insertFollowedShow(database)
 
-        coEvery { traktDataSource.getFollowedListId() } returns Success(
-            TraktList().apply {
-                ids = ListIds().apply { trakt = 0 }
-            }
-        )
-        coEvery { traktDataSource.getListShows(0) } returns Success(listOf(followedShow2Network to show2))
+        coEvery { traktDataSource.getFollowedListId() } returns TraktList().apply {
+            ids = ListIds().apply { trakt = 0 }
+        }
+        coEvery { traktDataSource.getListShows(0) } returns listOf(followedShow2Network to show2)
 
         repository.syncFollowedShows()
 
@@ -119,12 +112,11 @@ class FollowedShowRepositoryTest : DatabaseTest() {
         followShowsDao.insert(followedShow1PendingDelete)
 
         // Return error for the list ID so that we disable syncing
-        coEvery { traktDataSource.getFollowedListId() } returns ErrorResult(IllegalArgumentException())
+        coEvery { traktDataSource.getFollowedListId() } throws IllegalArgumentException()
 
         repository.syncFollowedShows()
 
-        assertThat(repository.getFollowedShows())
-            .isEmpty()
+        assertThat(repository.getFollowedShows()).isEmpty()
     }
 
     @Test
@@ -132,7 +124,7 @@ class FollowedShowRepositoryTest : DatabaseTest() {
         followShowsDao.insert(followedShow1PendingUpload)
 
         // Return an error for the list ID so that we disable syncing
-        coEvery { traktDataSource.getFollowedListId() } returns ErrorResult(IllegalArgumentException())
+        coEvery { traktDataSource.getFollowedListId() } throws IllegalArgumentException()
 
         repository.syncFollowedShows()
 

--- a/data-android/src/test/java/app/tivi/data/repositories/SeasonsEpisodesRepositoryTest.kt
+++ b/data-android/src/test/java/app/tivi/data/repositories/SeasonsEpisodesRepositoryTest.kt
@@ -22,7 +22,6 @@ import app.tivi.data.TiviDatabase
 import app.tivi.data.daos.EpisodeWatchEntryDao
 import app.tivi.data.daos.EpisodesDao
 import app.tivi.data.daos.SeasonsDao
-import app.tivi.data.entities.Success
 import app.tivi.data.repositories.episodes.EpisodeDataSourceBinds
 import app.tivi.data.repositories.episodes.EpisodeWatchStore
 import app.tivi.data.repositories.episodes.SeasonsEpisodesDataSource
@@ -83,7 +82,7 @@ class SeasonsEpisodesRepositoryTest : DatabaseTest() {
 
         // Return a response with 2 items
         coEvery { seasonsDataSource.getShowEpisodeWatches(showId) } returns
-            Success(listOf(s1e1 to s1e1w, s1e1 to s1e1w2))
+            listOf(s1e1 to s1e1w, s1e1 to s1e1w2)
         // Sync
         repository.syncEpisodeWatchesForShow(showId)
         // Assert that both are in the db
@@ -100,7 +99,7 @@ class SeasonsEpisodesRepositoryTest : DatabaseTest() {
         episodeWatchDao.insertAll(s1e1w, s1e1w2)
         // Return a response with the same items
         coEvery { seasonsDataSource.getShowEpisodeWatches(showId) } returns
-            Success(listOf(s1e1 to s1e1w, s1e1 to s1e1w2))
+            listOf(s1e1 to s1e1w, s1e1 to s1e1w2)
         // Now re-sync with the same response
         repository.syncEpisodeWatchesForShow(showId)
         // Assert that both are in the db
@@ -117,7 +116,7 @@ class SeasonsEpisodesRepositoryTest : DatabaseTest() {
         episodeWatchDao.insertAll(s1e1w, s1e1w2)
         // Return a response with just the second item
         coEvery { seasonsDataSource.getShowEpisodeWatches(showId) } returns
-            Success(listOf(s1e1 to s1e1w2))
+            listOf(s1e1 to s1e1w2)
         // Now re-sync
         repository.syncEpisodeWatchesForShow(showId)
         // Assert that only the second is in the db
@@ -132,8 +131,7 @@ class SeasonsEpisodesRepositoryTest : DatabaseTest() {
         // Insert both the watches
         episodeWatchDao.insertAll(s1e1w, s1e1w2)
         // Return a empty response
-        coEvery { seasonsDataSource.getShowEpisodeWatches(showId) } returns
-            Success(emptyList())
+        coEvery { seasonsDataSource.getShowEpisodeWatches(showId) } returns emptyList()
         // Now re-sync
         repository.syncEpisodeWatchesForShow(showId)
         // Assert that the database is empty
@@ -143,8 +141,7 @@ class SeasonsEpisodesRepositoryTest : DatabaseTest() {
     @Test
     fun testSyncSeasonsEpisodes() = testScope.runBlockingTest {
         // Return a response with 2 items
-        coEvery { seasonsDataSource.getSeasonsEpisodes(showId) } returns
-            Success(listOf(s1 to s1_episodes))
+        coEvery { seasonsDataSource.getSeasonsEpisodes(showId) } returns listOf(s1 to s1_episodes)
         repository.updateSeasonsEpisodes(showId)
 
         // Assert that both are in the db
@@ -158,8 +155,7 @@ class SeasonsEpisodesRepositoryTest : DatabaseTest() {
         episodesDao.insertAll(s1_episodes)
 
         // Return a response with the same items
-        coEvery { seasonsDataSource.getSeasonsEpisodes(showId) } returns
-            Success(listOf(s1 to s1_episodes))
+        coEvery { seasonsDataSource.getSeasonsEpisodes(showId) } returns listOf(s1 to s1_episodes)
         repository.updateSeasonsEpisodes(showId)
 
         // Assert that both are in the db
@@ -173,8 +169,7 @@ class SeasonsEpisodesRepositoryTest : DatabaseTest() {
         episodesDao.insertAll(s1_episodes)
 
         // Return an empty response
-        coEvery { seasonsDataSource.getSeasonsEpisodes(showId) } returns
-            Success(emptyList())
+        coEvery { seasonsDataSource.getSeasonsEpisodes(showId) } returns emptyList()
         repository.updateSeasonsEpisodes(showId)
 
         // Assert the database is empty
@@ -189,8 +184,7 @@ class SeasonsEpisodesRepositoryTest : DatabaseTest() {
         episodesDao.insertAll(s2_episodes)
 
         // Return a response with just the first season
-        coEvery { seasonsDataSource.getSeasonsEpisodes(showId) } returns
-            Success(listOf(s1 to s1_episodes))
+        coEvery { seasonsDataSource.getSeasonsEpisodes(showId) } returns listOf(s1 to s1_episodes)
         repository.updateSeasonsEpisodes(showId)
 
         // Assert that both are in the db
@@ -205,8 +199,7 @@ class SeasonsEpisodesRepositoryTest : DatabaseTest() {
         episodesDao.insertAll(s2_episodes)
 
         // Return a response with both seasons, but just a single episodes in each
-        coEvery { seasonsDataSource.getSeasonsEpisodes(showId) } returns
-            Success(listOf(s1 to listOf(s1e1), s2 to listOf(s2e1)))
+        coEvery { seasonsDataSource.getSeasonsEpisodes(showId) } returns listOf(s1 to listOf(s1e1), s2 to listOf(s2e1))
         repository.updateSeasonsEpisodes(showId)
 
         // Assert that both are in the db
@@ -228,8 +221,8 @@ class SeasonsEpisodesRepositoryTest : DatabaseTest() {
         }
 
         // Now mark s1e1 as watched
-        coEvery { seasonsDataSource.addEpisodeWatches(any()) } returns Success(Unit)
-        coEvery { seasonsDataSource.getEpisodeWatches(s1e1.id, any()) } returns Success(listOf(s1e1w))
+        coEvery { seasonsDataSource.addEpisodeWatches(any()) } returns Unit
+        coEvery { seasonsDataSource.getEpisodeWatches(s1e1.id, any()) } returns listOf(s1e1w)
         repository.addEpisodeWatch(s1e1.id, OffsetDateTime.now())
 
         // Receive the second emission

--- a/data-android/src/test/java/app/tivi/utils/fakeDataSources.kt
+++ b/data-android/src/test/java/app/tivi/utils/fakeDataSources.kt
@@ -16,21 +16,17 @@
 
 package app.tivi.utils
 
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.ShowTmdbImage
-import app.tivi.data.entities.Success
 import app.tivi.data.entities.TiviShow
 import app.tivi.data.repositories.showimages.ShowImagesDataSource
 import app.tivi.data.repositories.shows.ShowDataSource
 
 object SuccessFakeShowDataSource : ShowDataSource {
-    override suspend fun getShow(show: TiviShow): Result<TiviShow> {
-        return Success(show)
-    }
+    override suspend fun getShow(show: TiviShow): TiviShow = show
 }
 
 object SuccessFakeShowImagesDataSource : ShowImagesDataSource {
-    override suspend fun getShowImages(show: TiviShow): Result<List<ShowTmdbImage>> {
-        return Success(listOf(showPoster))
+    override suspend fun getShowImages(show: TiviShow): List<ShowTmdbImage> {
+        return listOf(showPoster)
     }
 }

--- a/data/src/main/java/app/tivi/data/repositories/episodes/EpisodeDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/episodes/EpisodeDataSource.kt
@@ -17,8 +17,7 @@
 package app.tivi.data.repositories.episodes
 
 import app.tivi.data.entities.Episode
-import app.tivi.data.entities.Result
 
 interface EpisodeDataSource {
-    suspend fun getEpisode(showId: Long, seasonNumber: Int, episodeNumber: Int): Result<Episode>
+    suspend fun getEpisode(showId: Long, seasonNumber: Int, episodeNumber: Int): Episode
 }

--- a/data/src/main/java/app/tivi/data/repositories/episodes/SeasonsEpisodesDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/episodes/SeasonsEpisodesDataSource.kt
@@ -18,27 +18,26 @@ package app.tivi.data.repositories.episodes
 
 import app.tivi.data.entities.Episode
 import app.tivi.data.entities.EpisodeWatchEntry
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.Season
 import org.threeten.bp.OffsetDateTime
 
 interface SeasonsEpisodesDataSource {
-    suspend fun getSeasonsEpisodes(showId: Long): Result<List<Pair<Season, List<Episode>>>>
+    suspend fun getSeasonsEpisodes(showId: Long): List<Pair<Season, List<Episode>>>
     suspend fun getShowEpisodeWatches(
         showId: Long,
         since: OffsetDateTime? = null
-    ): Result<List<Pair<Episode, EpisodeWatchEntry>>>
+    ): List<Pair<Episode, EpisodeWatchEntry>>
 
     suspend fun getEpisodeWatches(
         episodeId: Long,
         since: OffsetDateTime? = null
-    ): Result<List<EpisodeWatchEntry>>
+    ): List<EpisodeWatchEntry>
 
     suspend fun getSeasonWatches(
         seasonId: Long,
         since: OffsetDateTime? = null
-    ): Result<List<Pair<Episode, EpisodeWatchEntry>>>
+    ): List<Pair<Episode, EpisodeWatchEntry>>
 
-    suspend fun addEpisodeWatches(watches: List<EpisodeWatchEntry>): Result<Unit>
-    suspend fun removeEpisodeWatches(watches: List<EpisodeWatchEntry>): Result<Unit>
+    suspend fun addEpisodeWatches(watches: List<EpisodeWatchEntry>)
+    suspend fun removeEpisodeWatches(watches: List<EpisodeWatchEntry>)
 }

--- a/data/src/main/java/app/tivi/data/repositories/episodes/TmdbEpisodeDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/episodes/TmdbEpisodeDataSource.kt
@@ -17,12 +17,12 @@
 package app.tivi.data.repositories.episodes
 
 import app.tivi.data.entities.Episode
-import app.tivi.data.entities.Result
 import app.tivi.data.mappers.ShowIdToTmdbIdMapper
 import app.tivi.data.mappers.TmdbEpisodeToEpisode
-import app.tivi.extensions.awaitResult
+import app.tivi.extensions.bodyOrThrow
 import app.tivi.extensions.withRetry
 import com.uwetrottmann.tmdb2.Tmdb
+import retrofit2.awaitResponse
 import javax.inject.Inject
 
 class TmdbEpisodeDataSource @Inject constructor(
@@ -34,9 +34,10 @@ class TmdbEpisodeDataSource @Inject constructor(
         showId: Long,
         seasonNumber: Int,
         episodeNumber: Int
-    ): Result<Episode> = withRetry {
+    ): Episode = withRetry {
         tmdb.tvEpisodesService()
             .episode(tmdbIdMapper.map(showId), seasonNumber, episodeNumber, null)
-            .awaitResult { episodeMapper.map(it) }
+            .awaitResponse()
+            .let { episodeMapper.map(it.bodyOrThrow()) }
     }
 }

--- a/data/src/main/java/app/tivi/data/repositories/followedshows/FollowedShowsDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/followedshows/FollowedShowsDataSource.kt
@@ -17,13 +17,12 @@
 package app.tivi.data.repositories.followedshows
 
 import app.tivi.data.entities.FollowedShowEntry
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.TiviShow
 import com.uwetrottmann.trakt5.entities.TraktList
 
 interface FollowedShowsDataSource {
-    suspend fun getListShows(listId: Int): Result<List<Pair<FollowedShowEntry, TiviShow>>>
-    suspend fun addShowIdsToList(listId: Int, shows: List<TiviShow>): Result<Unit>
-    suspend fun removeShowIdsFromList(listId: Int, shows: List<TiviShow>): Result<Unit>
-    suspend fun getFollowedListId(): Result<TraktList>
+    suspend fun getListShows(listId: Int): List<Pair<FollowedShowEntry, TiviShow>>
+    suspend fun addShowIdsToList(listId: Int, shows: List<TiviShow>)
+    suspend fun removeShowIdsFromList(listId: Int, shows: List<TiviShow>)
+    suspend fun getFollowedListId(): TraktList
 }

--- a/data/src/main/java/app/tivi/data/repositories/popularshows/TraktPopularShowsDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/popularshows/TraktPopularShowsDataSource.kt
@@ -17,16 +17,16 @@
 package app.tivi.data.repositories.popularshows
 
 import app.tivi.data.entities.PopularShowEntry
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.TiviShow
 import app.tivi.data.mappers.IndexedMapper
 import app.tivi.data.mappers.TraktShowToTiviShow
 import app.tivi.data.mappers.pairMapperOf
-import app.tivi.extensions.awaitResult
+import app.tivi.extensions.bodyOrThrow
 import app.tivi.extensions.withRetry
 import com.uwetrottmann.trakt5.entities.Show
 import com.uwetrottmann.trakt5.enums.Extended
 import com.uwetrottmann.trakt5.services.Shows
+import retrofit2.awaitResponse
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -43,8 +43,9 @@ class TraktPopularShowsDataSource @Inject constructor(
     suspend operator fun invoke(
         page: Int,
         pageSize: Int
-    ): Result<List<Pair<TiviShow, PopularShowEntry>>> = withRetry {
+    ): List<Pair<TiviShow, PopularShowEntry>> = withRetry {
         showService.get().popular(page + 1, pageSize, Extended.NOSEASONS)
-            .awaitResult(resultsMapper)
+            .awaitResponse()
+            .let { resultsMapper.invoke(it.bodyOrThrow()) }
     }
 }

--- a/data/src/main/java/app/tivi/data/repositories/relatedshows/TmdbRelatedShowsDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/relatedshows/TmdbRelatedShowsDataSource.kt
@@ -17,17 +17,17 @@
 package app.tivi.data.repositories.relatedshows
 
 import app.tivi.data.entities.RelatedShowEntry
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.TiviShow
 import app.tivi.data.mappers.IndexedMapper
 import app.tivi.data.mappers.ShowIdToTmdbIdMapper
 import app.tivi.data.mappers.TmdbBaseShowToTiviShow
 import app.tivi.data.mappers.pairMapperOf
 import app.tivi.data.mappers.unwrapTmdbShowResults
-import app.tivi.extensions.awaitResult
+import app.tivi.extensions.bodyOrThrow
 import app.tivi.extensions.withRetry
 import com.uwetrottmann.tmdb2.Tmdb
 import com.uwetrottmann.tmdb2.entities.BaseTvShow
+import retrofit2.awaitResponse
 import javax.inject.Inject
 
 class TmdbRelatedShowsDataSource @Inject constructor(
@@ -42,9 +42,10 @@ class TmdbRelatedShowsDataSource @Inject constructor(
 
     suspend operator fun invoke(
         showId: Long
-    ): Result<List<Pair<TiviShow, RelatedShowEntry>>> = withRetry {
+    ): List<Pair<TiviShow, RelatedShowEntry>> = withRetry {
         tmdb.tvService()
             .recommendations(tmdbIdMapper.map(showId), 1, null)
-            .awaitResult(resultMapper)
+            .awaitResponse()
+            .let { resultMapper.invoke(it.bodyOrThrow()) }
     }
 }

--- a/data/src/main/java/app/tivi/data/repositories/search/SearchDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/search/SearchDataSource.kt
@@ -16,10 +16,9 @@
 
 package app.tivi.data.repositories.search
 
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.ShowTmdbImage
 import app.tivi.data.entities.TiviShow
 
 interface SearchDataSource {
-    suspend fun search(query: String): Result<List<Pair<TiviShow, List<ShowTmdbImage>>>>
+    suspend fun search(query: String): List<Pair<TiviShow, List<ShowTmdbImage>>>
 }

--- a/data/src/main/java/app/tivi/data/repositories/search/TmdbSearchDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/search/TmdbSearchDataSource.kt
@@ -16,13 +16,13 @@
 
 package app.tivi.data.repositories.search
 
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.ShowTmdbImage
 import app.tivi.data.entities.TiviShow
 import app.tivi.data.mappers.TmdbShowResultsPageToTiviShows
-import app.tivi.extensions.awaitResult
+import app.tivi.extensions.bodyOrThrow
 import app.tivi.extensions.withRetry
 import com.uwetrottmann.tmdb2.Tmdb
+import retrofit2.awaitResponse
 import javax.inject.Inject
 
 class TmdbSearchDataSource @Inject constructor(
@@ -31,9 +31,10 @@ class TmdbSearchDataSource @Inject constructor(
 ) : SearchDataSource {
     override suspend fun search(
         query: String,
-    ): Result<List<Pair<TiviShow, List<ShowTmdbImage>>>> = withRetry {
+    ): List<Pair<TiviShow, List<ShowTmdbImage>>> = withRetry {
         tmdb.searchService()
             .tv(query, 1, null, null, false)
-            .awaitResult { mapper.map(it) }
+            .awaitResponse()
+            .let { mapper.map(it.bodyOrThrow()) }
     }
 }

--- a/data/src/main/java/app/tivi/data/repositories/showimages/ShowImagesDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/showimages/ShowImagesDataSource.kt
@@ -16,10 +16,9 @@
 
 package app.tivi.data.repositories.showimages
 
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.ShowTmdbImage
 import app.tivi.data.entities.TiviShow
 
 interface ShowImagesDataSource {
-    suspend fun getShowImages(show: TiviShow): Result<List<ShowTmdbImage>>
+    suspend fun getShowImages(show: TiviShow): List<ShowTmdbImage>
 }

--- a/data/src/main/java/app/tivi/data/repositories/showimages/TmdbShowImagesDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/showimages/TmdbShowImagesDataSource.kt
@@ -16,28 +16,28 @@
 
 package app.tivi.data.repositories.showimages
 
-import app.tivi.data.entities.ErrorResult
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.ShowTmdbImage
 import app.tivi.data.entities.TiviShow
 import app.tivi.data.mappers.TmdbImagesToShowImages
-import app.tivi.extensions.awaitResult
+import app.tivi.extensions.bodyOrThrow
 import app.tivi.extensions.withRetry
 import com.uwetrottmann.tmdb2.Tmdb
+import retrofit2.awaitResponse
 import javax.inject.Inject
 
 class TmdbShowImagesDataSource @Inject constructor(
     private val tmdb: Tmdb,
     private val mapper: TmdbImagesToShowImages
 ) : ShowImagesDataSource {
-    override suspend fun getShowImages(show: TiviShow): Result<List<ShowTmdbImage>> {
+    override suspend fun getShowImages(show: TiviShow): List<ShowTmdbImage> {
         val tmdbId = show.tmdbId
-            ?: return ErrorResult(IllegalArgumentException("TmdbId for show does not exist [$show]"))
+            ?: throw IllegalArgumentException("TmdbId for show does not exist [$show]")
 
         return withRetry {
             tmdb.tvService()
                 .tv(tmdbId, null)
-                .awaitResult { mapper.map(it) }
+                .awaitResponse()
+                .let { mapper.map(it.bodyOrThrow()) }
         }
     }
 }

--- a/data/src/main/java/app/tivi/data/repositories/shows/ShowDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/shows/ShowDataSource.kt
@@ -16,9 +16,8 @@
 
 package app.tivi.data.repositories.shows
 
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.TiviShow
 
 interface ShowDataSource {
-    suspend fun getShow(show: TiviShow): Result<TiviShow>
+    suspend fun getShow(show: TiviShow): TiviShow
 }

--- a/data/src/main/java/app/tivi/data/repositories/shows/TmdbShowDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/shows/TmdbShowDataSource.kt
@@ -16,27 +16,27 @@
 
 package app.tivi.data.repositories.shows
 
-import app.tivi.data.entities.ErrorResult
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.TiviShow
 import app.tivi.data.mappers.TmdbShowToTiviShow
-import app.tivi.extensions.awaitResult
+import app.tivi.extensions.bodyOrThrow
 import app.tivi.extensions.withRetry
 import com.uwetrottmann.tmdb2.Tmdb
+import retrofit2.awaitResponse
 import javax.inject.Inject
 
 class TmdbShowDataSource @Inject constructor(
     private val tmdb: Tmdb,
     private val mapper: TmdbShowToTiviShow
 ) : ShowDataSource {
-    override suspend fun getShow(show: TiviShow): Result<TiviShow> {
+    override suspend fun getShow(show: TiviShow): TiviShow {
         val tmdbId = show.tmdbId
-            ?: return ErrorResult(IllegalArgumentException("TmdbId for show does not exist [$show]"))
+            ?: throw IllegalArgumentException("TmdbId for show does not exist [$show]")
 
         return withRetry {
             tmdb.tvService()
                 .tv(tmdbId, null)
-                .awaitResult { mapper.map(it) }
+                .awaitResponse()
+                .let { mapper.map(it.bodyOrThrow()) }
         }
     }
 }

--- a/data/src/main/java/app/tivi/data/repositories/traktusers/TraktUsersDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/traktusers/TraktUsersDataSource.kt
@@ -16,14 +16,14 @@
 
 package app.tivi.data.repositories.traktusers
 
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.TraktUser
 import app.tivi.data.mappers.UserToTraktUser
-import app.tivi.extensions.awaitResult
+import app.tivi.extensions.bodyOrThrow
 import app.tivi.extensions.withRetry
 import com.uwetrottmann.trakt5.entities.UserSlug
 import com.uwetrottmann.trakt5.enums.Extended
 import com.uwetrottmann.trakt5.services.Users
+import retrofit2.awaitResponse
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -31,9 +31,10 @@ class TraktUsersDataSource @Inject constructor(
     private val usersService: Provider<Users>,
     private val mapper: UserToTraktUser
 ) {
-    suspend fun getUser(slug: String): Result<TraktUser> = withRetry {
+    suspend fun getUser(slug: String): TraktUser = withRetry {
         usersService.get()
             .profile(UserSlug(slug), Extended.FULL)
-            .awaitResult { mapper.map(it) }
+            .awaitResponse()
+            .let { mapper.map(it.bodyOrThrow()) }
     }
 }

--- a/data/src/main/java/app/tivi/data/repositories/trendingshows/TraktTrendingShowsDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/trendingshows/TraktTrendingShowsDataSource.kt
@@ -16,16 +16,16 @@
 
 package app.tivi.data.repositories.trendingshows
 
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.TiviShow
 import app.tivi.data.entities.TrendingShowEntry
 import app.tivi.data.mappers.TraktTrendingShowToTiviShow
 import app.tivi.data.mappers.TraktTrendingShowToTrendingShowEntry
 import app.tivi.data.mappers.pairMapperOf
-import app.tivi.extensions.awaitResult
+import app.tivi.extensions.bodyOrThrow
 import app.tivi.extensions.withRetry
 import com.uwetrottmann.trakt5.enums.Extended
 import com.uwetrottmann.trakt5.services.Shows
+import retrofit2.awaitResponse
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -39,10 +39,11 @@ class TraktTrendingShowsDataSource @Inject constructor(
     suspend operator fun invoke(
         page: Int,
         pageSize: Int
-    ): Result<List<Pair<TiviShow, TrendingShowEntry>>> = withRetry {
+    ): List<Pair<TiviShow, TrendingShowEntry>> = withRetry {
         showService.get()
             // We add 1 because Trakt uses a 1-based index whereas we use a 0-based index
             .trending(page + 1, pageSize, Extended.NOSEASONS)
-            .awaitResult(responseMapper)
+            .awaitResponse()
+            .let { responseMapper.invoke(it.bodyOrThrow()) }
     }
 }

--- a/data/src/main/java/app/tivi/data/repositories/watchedshows/TraktWatchedShowsDataSource.kt
+++ b/data/src/main/java/app/tivi/data/repositories/watchedshows/TraktWatchedShowsDataSource.kt
@@ -16,15 +16,15 @@
 
 package app.tivi.data.repositories.watchedshows
 
-import app.tivi.data.entities.Result
 import app.tivi.data.entities.TiviShow
 import app.tivi.data.entities.WatchedShowEntry
 import app.tivi.data.mappers.TraktBaseShowToTiviShow
 import app.tivi.data.mappers.pairMapperOf
-import app.tivi.extensions.awaitResult
+import app.tivi.extensions.bodyOrThrow
 import app.tivi.extensions.withRetry
 import com.uwetrottmann.trakt5.enums.Extended
 import com.uwetrottmann.trakt5.services.Sync
+import retrofit2.awaitResponse
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -36,9 +36,10 @@ class TraktWatchedShowsDataSource @Inject constructor(
         WatchedShowEntry(showId = 0, lastWatched = from.last_watched_at!!)
     }
 
-    suspend operator fun invoke(): Result<List<Pair<TiviShow, WatchedShowEntry>>> = withRetry {
+    suspend operator fun invoke(): List<Pair<TiviShow, WatchedShowEntry>> = withRetry {
         syncService.get()
             .watchedShows(Extended.NOSEASONS)
-            .awaitResult(responseMapper)
+            .awaitResponse()
+            .let { responseMapper.invoke(it.bodyOrThrow()) }
     }
 }


### PR DESCRIPTION
We now rely on normal exception handling, which feels clearer and forces us to handle errors.