### PR TITLE
Add a Spacer in EpisodeDetails.kt

### DIFF
--- a/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetails.kt
+++ b/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetails.kt
@@ -232,6 +232,7 @@ internal fun EpisodeDetails(
 
                         Spacer(Modifier.height(8.dp))
                         Spacer(Modifier.navigationBarsHeight())
+                        Spacer(Modifier.navigationBarsHeight())
                     }
                 }
             }


### PR DESCRIPTION
When episode watches fill over the (bottom)`navigationBar`, even it has a`Spacer(Modifer.navigationBarsHeight())` , last watch is hide  behind `navigationBar`. 
After add a `Spacer(Modifer.navigationBarsHeight())`, watches fit right.
But I don't know why a `Spacer(Modifer.navigationBarsHeight())` have not effect well.
I think there is a more clear way than this.