### PR TITLE
UIs now only receive a single UiMessage to display

### DIFF
--- a/common-ui-view/src/main/java/app/tivi/api/UiMessage.kt
+++ b/common-ui-view/src/main/java/app/tivi/api/UiMessage.kt
@@ -16,9 +16,10 @@
 
 package app.tivi.api
 
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.util.UUID
@@ -40,7 +41,11 @@ class UiMessageManager {
     private val mutex = Mutex()
 
     private val _messages = MutableStateFlow(emptyList<UiMessage>())
-    val messages: StateFlow<List<UiMessage>> = _messages.asStateFlow()
+
+    /**
+     * A flow emitting the current message to display.
+     */
+    val message: Flow<UiMessage?> = _messages.map { it.firstOrNull() }.distinctUntilChanged()
 
     suspend fun emitMessage(message: UiMessage) {
         mutex.withLock {

--- a/ui-discover/src/main/java/app/tivi/home/discover/Discover.kt
+++ b/ui-discover/src/main/java/app/tivi/home/discover/Discover.kt
@@ -142,7 +142,7 @@ internal fun Discover(
 ) {
     val scaffoldState = rememberScaffoldState()
 
-    state.messages.firstOrNull()?.let { message ->
+    state.message?.let { message ->
         LaunchedEffect(message) {
             scaffoldState.snackbarHostState.showSnackbar(message.message)
             // Notify the view model that the message has been dismissed

--- a/ui-discover/src/main/java/app/tivi/home/discover/DiscoverViewModel.kt
+++ b/ui-discover/src/main/java/app/tivi/home/discover/DiscoverViewModel.kt
@@ -68,10 +68,10 @@ internal class DiscoverViewModel @Inject constructor(
         observeNextShowEpisodeToWatch.flow,
         observeTraktAuthState.flow,
         observeUserDetails.flow,
-        uiMessageManager.messages,
+        uiMessageManager.message,
     ) {
         trendingLoad, popularLoad, recommendLoad, trending, popular, recommended,
-        nextShow, authState, user, messages,
+        nextShow, authState, user, message,
         ->
         DiscoverViewState(
             user = user,
@@ -83,7 +83,7 @@ internal class DiscoverViewModel @Inject constructor(
             recommendedItems = recommended,
             recommendedRefreshing = recommendLoad,
             nextEpisodeWithShowToWatched = nextShow,
-            messages = messages,
+            message = message,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/ui-discover/src/main/java/app/tivi/home/discover/DiscoverViewState.kt
+++ b/ui-discover/src/main/java/app/tivi/home/discover/DiscoverViewState.kt
@@ -36,9 +36,9 @@ internal data class DiscoverViewState(
     val recommendedItems: List<RecommendedEntryWithShow> = emptyList(),
     val recommendedRefreshing: Boolean = false,
     val nextEpisodeWithShowToWatched: EpisodeWithSeasonWithShow? = null,
-    val messages: List<UiMessage> = emptyList(),
+    val message: UiMessage? = null,
 ) {
-    val refreshing
+    val refreshing: Boolean
         get() = trendingRefreshing || popularRefreshing || recommendedRefreshing
 
     companion object {

--- a/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetails.kt
+++ b/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetails.kt
@@ -130,7 +130,7 @@ internal fun EpisodeDetails(
         onRemoveAllWatches = { viewModel.removeAllWatches() },
         onRemoveWatch = { viewModel.removeWatchEntry(it) },
         onAddWatch = { viewModel.addWatch() },
-        clearMessage = { viewModel.clearMessage(it) },
+        onMessageShown = { viewModel.clearMessage(it) },
     )
 }
 
@@ -143,15 +143,15 @@ internal fun EpisodeDetails(
     onRemoveAllWatches: () -> Unit,
     onRemoveWatch: (id: Long) -> Unit,
     onAddWatch: () -> Unit,
-    clearMessage: (id: Long) -> Unit,
+    onMessageShown: (id: Long) -> Unit,
 ) {
     val scaffoldState = rememberScaffoldState()
 
-    viewState.messages.firstOrNull()?.let { message ->
+    viewState.message?.let { message ->
         LaunchedEffect(message) {
             scaffoldState.snackbarHostState.showSnackbar(message.message)
             // Notify the view model that the message has been dismissed
-            clearMessage(message.id)
+            onMessageShown(message.id)
         }
     }
 
@@ -635,6 +635,6 @@ fun PreviewEpisodeDetails() {
         onRemoveAllWatches = {},
         onRemoveWatch = {},
         onAddWatch = {},
-        clearMessage = {},
+        onMessageShown = {},
     )
 }

--- a/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsViewModel.kt
+++ b/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsViewModel.kt
@@ -58,8 +58,8 @@ internal class EpisodeDetailsViewModel @Inject constructor(
         observeEpisodeDetails.flow,
         observeEpisodeWatches.flow,
         loadingState.observable,
-        uiMessageManager.messages,
-    ) { episodeDetails, episodeWatches, refreshing, messages ->
+        uiMessageManager.message,
+    ) { episodeDetails, episodeWatches, refreshing, message ->
         EpisodeDetailsViewState(
             episode = episodeDetails.episode,
             season = episodeDetails.season,
@@ -67,7 +67,7 @@ internal class EpisodeDetailsViewModel @Inject constructor(
             canAddEpisodeWatch = episodeDetails.episode?.firstAired?.isBefore(OffsetDateTime.now())
                 ?: true,
             refreshing = refreshing,
-            messages = messages,
+            message = message,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsViewState.kt
+++ b/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsViewState.kt
@@ -29,7 +29,7 @@ internal data class EpisodeDetailsViewState(
     val watches: List<EpisodeWatchEntry> = emptyList(),
     val canAddEpisodeWatch: Boolean = false,
     val refreshing: Boolean = false,
-    val messages: List<UiMessage> = emptyList(),
+    val message: UiMessage? = null,
 ) {
     companion object {
         val Empty = EpisodeDetailsViewState()

--- a/ui-followed/src/main/java/app/tivi/home/followed/Followed.kt
+++ b/ui-followed/src/main/java/app/tivi/home/followed/Followed.kt
@@ -131,7 +131,7 @@ internal fun Followed(
 ) {
     val scaffoldState = rememberScaffoldState()
 
-    state.messages.firstOrNull()?.let { message ->
+    state.message?.let { message ->
         LaunchedEffect(message) {
             scaffoldState.snackbarHostState.showSnackbar(message.message)
             // Notify the view model that the message has been dismissed

--- a/ui-followed/src/main/java/app/tivi/home/followed/FollowedViewModel.kt
+++ b/ui-followed/src/main/java/app/tivi/home/followed/FollowedViewModel.kt
@@ -84,8 +84,8 @@ internal class FollowedViewModel @Inject constructor(
         observeUserDetails.flow,
         filter,
         sort,
-        uiMessageManager.messages,
-    ) { loading, selectedShowIds, isSelectionOpen, authState, user, filter, sort, messages, ->
+        uiMessageManager.message,
+    ) { loading, selectedShowIds, isSelectionOpen, authState, user, filter, sort, message ->
         FollowedViewState(
             user = user,
             authState = authState,
@@ -96,7 +96,7 @@ internal class FollowedViewModel @Inject constructor(
             filterActive = !filter.isNullOrEmpty(),
             availableSorts = availableSorts,
             sort = sort,
-            messages = messages,
+            message = message,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/ui-followed/src/main/java/app/tivi/home/followed/FollowedViewState.kt
+++ b/ui-followed/src/main/java/app/tivi/home/followed/FollowedViewState.kt
@@ -31,7 +31,7 @@ internal data class FollowedViewState(
     val filter: String? = null,
     val availableSorts: List<SortOption> = emptyList(),
     val sort: SortOption = SortOption.SUPER_SORT,
-    val messages: List<UiMessage> = emptyList(),
+    val message: UiMessage? = null,
 ) {
     companion object {
         val Empty = FollowedViewState()

--- a/ui-search/src/main/java/app/tivi/home/search/Search.kt
+++ b/ui-search/src/main/java/app/tivi/home/search/Search.kt
@@ -99,7 +99,7 @@ internal fun Search(
 ) {
     val scaffoldState = rememberScaffoldState()
 
-    state.messages.firstOrNull()?.let { message ->
+    state.message?.let { message ->
         LaunchedEffect(message) {
             scaffoldState.snackbarHostState.showSnackbar(message.message)
             onMessageShown(message.id)

--- a/ui-search/src/main/java/app/tivi/home/search/SearchViewModel.kt
+++ b/ui-search/src/main/java/app/tivi/home/search/SearchViewModel.kt
@@ -47,7 +47,7 @@ internal class SearchViewModel @Inject constructor(
         searchQuery,
         searchShows.flow,
         loadingState.observable,
-        uiMessageManager.messages,
+        uiMessageManager.message,
         ::SearchViewState
     ).stateIn(
         scope = viewModelScope,

--- a/ui-search/src/main/java/app/tivi/home/search/SearchViewState.kt
+++ b/ui-search/src/main/java/app/tivi/home/search/SearchViewState.kt
@@ -23,7 +23,7 @@ internal data class SearchViewState(
     val query: String = "",
     val searchResults: List<ShowDetailed> = emptyList(),
     val refreshing: Boolean = false,
-    val messages: List<UiMessage> = emptyList(),
+    val message: UiMessage? = null,
 ) {
     companion object {
         val Empty = SearchViewState()

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetails.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetails.kt
@@ -173,7 +173,7 @@ internal fun ShowDetails(
             openShowDetails = openShowDetails,
             openEpisodeDetails = openEpisodeDetails,
             refresh = { viewModel.refresh() },
-            clearMessage = { viewModel.clearMessage(it) },
+            onMessageShown = { viewModel.clearMessage(it) },
             openSeason = { openSeasons(state.show.id, it) },
             onSeasonFollowed = { viewModel.setSeasonFollowed(it, true) },
             onSeasonUnfollowed = { viewModel.setSeasonFollowed(it, false) },
@@ -193,7 +193,7 @@ internal fun ShowDetails(
     openShowDetails: (showId: Long) -> Unit,
     openEpisodeDetails: (episodeId: Long) -> Unit,
     refresh: () -> Unit,
-    clearMessage: (id: Long) -> Unit,
+    onMessageShown: (id: Long) -> Unit,
     openSeason: (seasonId: Long) -> Unit,
     onSeasonFollowed: (seasonId: Long) -> Unit,
     onSeasonUnfollowed: (seasonId: Long) -> Unit,
@@ -205,11 +205,11 @@ internal fun ShowDetails(
     val scaffoldState = rememberScaffoldState()
     val listState = rememberLazyListState()
 
-    viewState.messages.firstOrNull()?.let { message ->
+    viewState.message?.let { message ->
         LaunchedEffect(message) {
             scaffoldState.snackbarHostState.showSnackbar(message.message)
             // Notify the view model that the message has been dismissed
-            clearMessage(message.id)
+            onMessageShown(message.id)
         }
     }
 

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsViewModel.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsViewModel.kt
@@ -81,9 +81,9 @@ internal class ShowDetailsViewModel @Inject constructor(
         observeNextEpisodeToWatch.flow,
         observeShowSeasons.flow,
         observeShowViewStats.flow,
-        uiMessageManager.messages,
+        uiMessageManager.message,
     ) { isFollowed, show, showImages, refreshing, relatedShows, nextEpisode, seasons, stats,
-        messages ->
+        message ->
         ShowDetailsViewState(
             isFollowed = isFollowed,
             show = show,
@@ -94,7 +94,7 @@ internal class ShowDetailsViewModel @Inject constructor(
             seasons = seasons,
             watchStats = stats,
             refreshing = refreshing,
-            messages = messages,
+            message = message,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsViewState.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsViewState.kt
@@ -36,7 +36,7 @@ internal data class ShowDetailsViewState(
     val watchStats: FollowedShowsWatchStats? = null,
     val seasons: List<SeasonWithEpisodesAndWatches> = emptyList(),
     val refreshing: Boolean = false,
-    val messages: List<UiMessage> = emptyList(),
+    val message: UiMessage? = null,
 ) {
     companion object {
         val Empty = ShowDetailsViewState()

--- a/ui-showseasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasons.kt
+++ b/ui-showseasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasons.kt
@@ -132,7 +132,7 @@ internal fun ShowSeasons(
 ) {
     val scaffoldState = rememberScaffoldState()
 
-    viewState.messages.firstOrNull()?.let { message ->
+    viewState.message?.let { message ->
         LaunchedEffect(message) {
             scaffoldState.snackbarHostState.showSnackbar(message.message)
             // Notify the view model that the message has been dismissed

--- a/ui-showseasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasonsViewModel.kt
+++ b/ui-showseasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasonsViewModel.kt
@@ -51,13 +51,13 @@ internal class ShowSeasonsViewModel @Inject constructor(
         observeShowSeasons.flow,
         observeShowDetails.flow,
         loadingState.observable,
-        uiMessageManager.messages,
-    ) { seasons, show, refreshing, messages ->
+        uiMessageManager.message,
+    ) { seasons, show, refreshing, message ->
         ShowSeasonsViewState(
             show = show,
             seasons = seasons,
             refreshing = refreshing,
-            messages = messages,
+            message = message,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/ui-showseasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasonsViewState.kt
+++ b/ui-showseasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasonsViewState.kt
@@ -26,7 +26,7 @@ internal data class ShowSeasonsViewState(
     val show: TiviShow = TiviShow.EMPTY_SHOW,
     val seasons: List<SeasonWithEpisodesAndWatches> = emptyList(),
     val refreshing: Boolean = false,
-    val messages: List<UiMessage> = emptyList(),
+    val message: UiMessage? = null,
 ) {
     companion object {
         val Empty = ShowSeasonsViewState()

--- a/ui-watched/src/main/java/app/tivi/home/watched/Watched.kt
+++ b/ui-watched/src/main/java/app/tivi/home/watched/Watched.kt
@@ -132,7 +132,7 @@ internal fun Watched(
 ) {
     val scaffoldState = rememberScaffoldState()
 
-    state.messages.firstOrNull()?.let { message ->
+    state.message?.let { message ->
         LaunchedEffect(message) {
             scaffoldState.snackbarHostState.showSnackbar(message.message)
             // Notify the view model that the message has been dismissed

--- a/ui-watched/src/main/java/app/tivi/home/watched/WatchedViewModel.kt
+++ b/ui-watched/src/main/java/app/tivi/home/watched/WatchedViewModel.kt
@@ -79,8 +79,8 @@ class WatchedViewModel @Inject constructor(
         observeUserDetails.flow,
         filter,
         sort,
-        uiMessageManager.messages,
-    ) { loading, selectedShowIds, isSelectionOpen, authState, user, filter, sort, messages, ->
+        uiMessageManager.message,
+    ) { loading, selectedShowIds, isSelectionOpen, authState, user, filter, sort, message ->
         WatchedViewState(
             user = user,
             authState = authState,
@@ -91,7 +91,7 @@ class WatchedViewModel @Inject constructor(
             filterActive = !filter.isNullOrEmpty(),
             availableSorts = availableSorts,
             sort = sort,
-            messages = messages,
+            message = message,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/ui-watched/src/main/java/app/tivi/home/watched/WatchedViewState.kt
+++ b/ui-watched/src/main/java/app/tivi/home/watched/WatchedViewState.kt
@@ -32,7 +32,7 @@ data class WatchedViewState(
     val filter: String? = null,
     val availableSorts: List<SortOption> = emptyList(),
     val sort: SortOption = SortOption.LAST_WATCHED,
-    val messages: List<UiMessage> = emptyList(),
+    val message: UiMessage? = null,
 ) {
     companion object {
         val Empty = WatchedViewState()


### PR DESCRIPTION
Follow on from #889. 

Previously each view state would contain a list of the queued up messages. This means that the UI is responsible for deciding what message to display, which is a bit too much logic in the UI for my liking.

This PR changes this so each view state contains a single `UiMessage?`. The queuing is moved to `UiMessageManager` which means that all of the logic is still in the VM. We could later add some kind of message prioritisation, skip messages, etc later without any changes to the UI.

WDYT @manuelvicnt?