### PR TITLE
rememberStateWithLifecycle utility

### DIFF
--- a/common-ui-compose/src/main/java/app/tivi/common/compose/FlowWithLifecycle.kt
+++ b/common-ui-compose/src/main/java/app/tivi/common/compose/FlowWithLifecycle.kt
@@ -19,11 +19,15 @@
 package app.tivi.common.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 fun <T> rememberFlowWithLifecycle(
@@ -35,4 +39,23 @@ fun <T> rememberFlowWithLifecycle(
         lifecycle = lifecycle,
         minActiveState = minActiveState
     )
+}
+
+@Composable
+fun <T> rememberStateWithLifecycle(
+    stateFlow: StateFlow<T>,
+    lifecycle: Lifecycle = LocalLifecycleOwner.current.lifecycle,
+    minActiveState: Lifecycle.State = Lifecycle.State.STARTED
+): State<T> {
+    val initialValue = remember(stateFlow) { stateFlow.value }
+    return produceState(
+        key1 = stateFlow, key2 = lifecycle, key3 = minActiveState,
+        initialValue = initialValue
+    ) {
+        lifecycle.repeatOnLifecycle(minActiveState) {
+            stateFlow.collect {
+                this@produceState.value = it
+            }
+        }
+    }
 }

--- a/ui-account/src/main/java/app/tivi/account/AccountUi.kt
+++ b/ui-account/src/main/java/app/tivi/account/AccountUi.kt
@@ -43,7 +43,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,7 +53,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import app.tivi.common.compose.rememberFlowWithLifecycle
+import app.tivi.common.compose.rememberStateWithLifecycle
 import app.tivi.common.compose.theme.foregroundColor
 import app.tivi.data.entities.TraktUser
 import app.tivi.trakt.TraktAuthState
@@ -79,8 +78,7 @@ internal fun AccountUi(
     viewModel: AccountUiViewModel,
     openSettings: () -> Unit,
 ) {
-    val viewState by rememberFlowWithLifecycle(viewModel.state)
-        .collectAsState(initial = AccountUiViewState.Empty)
+    val viewState by rememberStateWithLifecycle(viewModel.state)
 
     val loginLauncher = rememberLauncherForActivityResult(
         viewModel.buildLoginActivityResult()

--- a/ui-discover/src/main/java/app/tivi/home/discover/Discover.kt
+++ b/ui-discover/src/main/java/app/tivi/home/discover/Discover.kt
@@ -49,7 +49,6 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -62,7 +61,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import app.tivi.common.compose.Layout
 import app.tivi.common.compose.LocalTiviTextCreator
 import app.tivi.common.compose.bodyWidth
-import app.tivi.common.compose.rememberFlowWithLifecycle
+import app.tivi.common.compose.rememberStateWithLifecycle
 import app.tivi.common.compose.theme.AppBarAlphas
 import app.tivi.common.compose.ui.AutoSizedCircularProgressIndicator
 import app.tivi.common.compose.ui.PosterCard
@@ -114,8 +113,7 @@ internal fun Discover(
     openShowDetails: (showId: Long, seasonId: Long?, episodeId: Long?) -> Unit,
     openUser: () -> Unit,
 ) {
-    val viewState by rememberFlowWithLifecycle(viewModel.state)
-        .collectAsState(initial = DiscoverViewState.Empty)
+    val viewState by rememberStateWithLifecycle(viewModel.state)
 
     Discover(
         state = viewState,

--- a/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetails.kt
+++ b/ui-episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetails.kt
@@ -63,7 +63,6 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -86,7 +85,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import app.tivi.common.compose.Layout
 import app.tivi.common.compose.LocalTiviDateFormatter
-import app.tivi.common.compose.rememberFlowWithLifecycle
+import app.tivi.common.compose.rememberStateWithLifecycle
 import app.tivi.common.compose.ui.AutoSizedCircularProgressIndicator
 import app.tivi.common.compose.ui.ExpandingText
 import app.tivi.common.compose.ui.SwipeDismissSnackbarHost
@@ -120,8 +119,7 @@ internal fun EpisodeDetails(
     viewModel: EpisodeDetailsViewModel,
     navigateUp: () -> Unit,
 ) {
-    val viewState by rememberFlowWithLifecycle(viewModel.state)
-        .collectAsState(initial = EpisodeDetailsViewState.Empty)
+    val viewState by rememberStateWithLifecycle(viewModel.state)
 
     EpisodeDetails(
         viewState = viewState,

--- a/ui-followed/src/main/java/app/tivi/home/followed/Followed.kt
+++ b/ui-followed/src/main/java/app/tivi/home/followed/Followed.kt
@@ -42,7 +42,6 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -62,6 +61,7 @@ import app.tivi.common.compose.bodyWidth
 import app.tivi.common.compose.itemSpacer
 import app.tivi.common.compose.itemsInGrid
 import app.tivi.common.compose.rememberFlowWithLifecycle
+import app.tivi.common.compose.rememberStateWithLifecycle
 import app.tivi.common.compose.theme.AppBarAlphas
 import app.tivi.common.compose.ui.PosterCard
 import app.tivi.common.compose.ui.RefreshButton
@@ -101,8 +101,7 @@ internal fun Followed(
     openShowDetails: (showId: Long) -> Unit,
     openUser: () -> Unit,
 ) {
-    val viewState by rememberFlowWithLifecycle(viewModel.state)
-        .collectAsState(initial = FollowedViewState.Empty)
+    val viewState by rememberStateWithLifecycle(viewModel.state)
     val pagingItems = rememberFlowWithLifecycle(viewModel.pagedList)
         .collectAsLazyPagingItems()
 

--- a/ui-search/src/main/java/app/tivi/home/search/Search.kt
+++ b/ui-search/src/main/java/app/tivi/home/search/Search.kt
@@ -38,7 +38,6 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -53,7 +52,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import app.tivi.common.compose.Layout
 import app.tivi.common.compose.bodyWidth
 import app.tivi.common.compose.itemsInGrid
-import app.tivi.common.compose.rememberFlowWithLifecycle
+import app.tivi.common.compose.rememberStateWithLifecycle
 import app.tivi.common.compose.ui.PosterCard
 import app.tivi.common.compose.ui.SearchTextField
 import app.tivi.common.compose.ui.SwipeDismissSnackbarHost
@@ -78,8 +77,7 @@ internal fun Search(
     viewModel: SearchViewModel,
     openShowDetails: (showId: Long) -> Unit,
 ) {
-    val viewState by rememberFlowWithLifecycle(viewModel.state)
-        .collectAsState(initial = SearchViewState.Empty)
+    val viewState by rememberStateWithLifecycle(viewModel.state)
 
     Search(
         state = viewState,

--- a/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetails.kt
+++ b/ui-showdetails/src/main/java/app/tivi/showdetails/details/ShowDetails.kt
@@ -71,7 +71,6 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -102,7 +101,7 @@ import app.tivi.common.compose.bodyWidth
 import app.tivi.common.compose.gutterSpacer
 import app.tivi.common.compose.itemSpacer
 import app.tivi.common.compose.itemsInGrid
-import app.tivi.common.compose.rememberFlowWithLifecycle
+import app.tivi.common.compose.rememberStateWithLifecycle
 import app.tivi.common.compose.theme.foregroundColor
 import app.tivi.common.compose.ui.AutoSizedCircularProgressIndicator
 import app.tivi.common.compose.ui.ExpandableFloatingActionButton
@@ -165,24 +164,22 @@ internal fun ShowDetails(
     openEpisodeDetails: (episodeId: Long) -> Unit,
     openSeasons: (showId: Long, seasonId: Long) -> Unit,
 ) {
-    val viewState by rememberFlowWithLifecycle(viewModel.state).collectAsState(null)
-    viewState?.let { state ->
-        ShowDetails(
-            viewState = state,
-            navigateUp = navigateUp,
-            openShowDetails = openShowDetails,
-            openEpisodeDetails = openEpisodeDetails,
-            refresh = { viewModel.refresh() },
-            onMessageShown = { viewModel.clearMessage(it) },
-            openSeason = { openSeasons(state.show.id, it) },
-            onSeasonFollowed = { viewModel.setSeasonFollowed(it, true) },
-            onSeasonUnfollowed = { viewModel.setSeasonFollowed(it, false) },
-            unfollowPreviousSeasons = { viewModel.unfollowPreviousSeasons(it) },
-            onMarkSeasonWatched = { viewModel.setSeasonWatched(it, onlyAired = true) },
-            onMarkSeasonUnwatched = { viewModel.setSeasonUnwatched(it) },
-            onToggleShowFollowed = { viewModel.toggleFollowShow() },
-        )
-    }
+    val viewState by rememberStateWithLifecycle(viewModel.state)
+    ShowDetails(
+        viewState = viewState,
+        navigateUp = navigateUp,
+        openShowDetails = openShowDetails,
+        openEpisodeDetails = openEpisodeDetails,
+        refresh = { viewModel.refresh() },
+        onMessageShown = { viewModel.clearMessage(it) },
+        openSeason = { openSeasons(viewState.show.id, it) },
+        onSeasonFollowed = { viewModel.setSeasonFollowed(it, true) },
+        onSeasonUnfollowed = { viewModel.setSeasonFollowed(it, false) },
+        unfollowPreviousSeasons = { viewModel.unfollowPreviousSeasons(it) },
+        onMarkSeasonWatched = { viewModel.setSeasonWatched(it, onlyAired = true) },
+        onMarkSeasonUnwatched = { viewModel.setSeasonUnwatched(it) },
+        onToggleShowFollowed = { viewModel.toggleFollowShow() },
+    )
 }
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -985,7 +982,7 @@ private fun SeasonRow(
             }
 
             // Season number starts from 1, rather than 0
-            if (season.number ?: -100 >= 2) {
+            if ((season.number ?: -100) >= 2) {
                 DropdownMenuItem(
                     onClick = {
                         unfollowPreviousSeasons(season.id)

--- a/ui-showseasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasons.kt
+++ b/ui-showseasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasons.kt
@@ -51,7 +51,6 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -66,7 +65,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import app.tivi.common.compose.Layout
 import app.tivi.common.compose.LocalTiviTextCreator
 import app.tivi.common.compose.bodyWidth
-import app.tivi.common.compose.rememberFlowWithLifecycle
+import app.tivi.common.compose.rememberStateWithLifecycle
 import app.tivi.common.compose.theme.AppBarAlphas
 import app.tivi.common.compose.ui.RefreshButton
 import app.tivi.common.compose.ui.SwipeDismissSnackbarHost
@@ -107,8 +106,7 @@ internal fun ShowSeasons(
     openEpisodeDetails: (episodeId: Long) -> Unit,
     initialSeasonId: Long?,
 ) {
-    val viewState by rememberFlowWithLifecycle(viewModel.state)
-        .collectAsState(ShowSeasonsViewState.Empty)
+    val viewState by rememberStateWithLifecycle(viewModel.state)
 
     ShowSeasons(
         viewState = viewState,

--- a/ui-watched/src/main/java/app/tivi/home/watched/Watched.kt
+++ b/ui-watched/src/main/java/app/tivi/home/watched/Watched.kt
@@ -41,7 +41,6 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -62,6 +61,7 @@ import app.tivi.common.compose.bodyWidth
 import app.tivi.common.compose.itemSpacer
 import app.tivi.common.compose.itemsInGrid
 import app.tivi.common.compose.rememberFlowWithLifecycle
+import app.tivi.common.compose.rememberStateWithLifecycle
 import app.tivi.common.compose.theme.AppBarAlphas
 import app.tivi.common.compose.ui.PosterCard
 import app.tivi.common.compose.ui.RefreshButton
@@ -102,8 +102,7 @@ internal fun Watched(
     openShowDetails: (showId: Long) -> Unit,
     openUser: () -> Unit,
 ) {
-    val viewState by rememberFlowWithLifecycle(viewModel.state)
-        .collectAsState(initial = WatchedViewState.Empty)
+    val viewState by rememberStateWithLifecycle(viewModel.state)
     val pagingItems = rememberFlowWithLifecycle(viewModel.pagedList)
         .collectAsLazyPagingItems()
 


### PR DESCRIPTION
Minor cleanup and simplification of initial value which exists from StateFlow.

I was using your implementation, but wanted to avoid passing in an extra initial value,
and figured worth pushing back to here.  No problem if not desired, but I'd love to here your
take if so.