### PR TITLE
Fix AccountUi lag

### DIFF
--- a/trakt-auth/src/main/java/app/tivi/trakt/ActivityTraktAuthManager.kt
+++ b/trakt-auth/src/main/java/app/tivi/trakt/ActivityTraktAuthManager.kt
@@ -34,9 +34,7 @@ internal class ActivityTraktAuthManager @Inject constructor(
     private val clientAuth: Lazy<ClientAuthentication>,
     private val logger: Logger
 ) : TraktAuthManager {
-    private val authService by lazy(LazyThreadSafetyMode.NONE) {
-        AuthorizationService(context)
-    }
+    private val authService = AuthorizationService(context)
 
     override fun buildLoginIntent(): Intent {
         return authService.getAuthorizationRequestIntent(requestProvider.get())

--- a/trakt-auth/src/main/java/app/tivi/trakt/TraktAuthManager.kt
+++ b/trakt-auth/src/main/java/app/tivi/trakt/TraktAuthManager.kt
@@ -23,15 +23,15 @@ import net.openid.appauth.AuthorizationException
 import net.openid.appauth.AuthorizationResponse
 
 interface TraktAuthManager {
-    fun buildLoginActivityResult(): LoginTrakt = LoginTrakt(buildLoginIntent())
+    fun buildLoginActivityResult(): LoginTrakt = LoginTrakt { buildLoginIntent() }
     fun buildLoginIntent(): Intent
     fun onLoginResult(result: LoginTrakt.Result)
 }
 
 class LoginTrakt internal constructor(
-    private val loginIntent: Intent,
+    private val intentBuilder: () -> Intent,
 ) : ActivityResultContract<Unit, LoginTrakt.Result?>() {
-    override fun createIntent(context: Context, input: Unit?): Intent = loginIntent
+    override fun createIntent(context: Context, input: Unit?): Intent = intentBuilder()
 
     override fun parseResult(
         resultCode: Int,


### PR DESCRIPTION
There is a massive UI lag when opening the AccountUi dialog, which is caused by the AppAuth's `AuthorizationService`:

> AuthorizationService will create a bound service connection to the browser in order to perform a "warm up" that makes the custom tab load faster. As such, you should create your AuthorizationService instance early in your activity's lifecycle to benefit from this warmup, and not at the moment at which you click "sign in".\
 [https://github.com/openid/AppAuth-Android/issues/328](https://github.com/openid/AppAuth-Android/issues/328)

As of now, `ActivityTraktAuthManager::buildLoginIntent` is called right after AccountUi dialog is opened.\
I modified `LoginTrakt` and `TraktAuthManager` such that `buildLoginIntent` is only called after user clicks the login button and the `ActivityTraktAuthManager` such that `AuthorizationService` is not initialized lazily.