### PR TITLE
Minor flags tweak

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,6 @@ org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 # https://docs.gradle.org/7.5/userguide/configuration_cache.html
 org.gradle.unsafe.configuration-cache=true
-# https://blog.gradle.org/introducing-file-system-watching
-org.gradle.vfs.watch=true
 
 # AndroidX
 android.useAndroidX=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 
 org.gradle.caching=true
 org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 # https://docs.gradle.org/7.5/userguide/configuration_cache.html
 org.gradle.unsafe.configuration-cache=true
 # https://blog.gradle.org/introducing-file-system-watching


### PR DESCRIPTION
- Remove -XX:+UseParallelGC and use the default garbage collector as the improvements are minimal on JDK 17+
- https://docs.gradle.org/7.0.1/release-notes.html#file-system-watching