### PR TITLE
Simplify ViewModel state subscriptions

### DIFF
--- a/ui/account/src/main/java/app/tivi/account/AccountUi.kt
+++ b/ui/account/src/main/java/app/tivi/account/AccountUi.kt
@@ -43,6 +43,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,7 +55,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.tivi.common.compose.theme.foregroundColor
 import app.tivi.common.compose.ui.AsyncImage
 import app.tivi.data.entities.TraktUser
@@ -81,7 +81,7 @@ internal fun AccountUi(
     viewModel: AccountUiViewModel,
     openSettings: () -> Unit
 ) {
-    val viewState by viewModel.state.collectAsStateWithLifecycle()
+    val viewState by viewModel.state.collectAsState()
 
     val loginLauncher = rememberLauncherForActivityResult(
         viewModel.buildLoginActivityResult()

--- a/ui/account/src/main/java/app/tivi/account/AccountUiViewModel.kt
+++ b/ui/account/src/main/java/app/tivi/account/AccountUiViewModel.kt
@@ -51,7 +51,7 @@ internal class AccountUiViewModel @Inject constructor(
         )
     }.stateIn(
         scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
+        started = SharingStarted.WhileSubscribed(),
         initialValue = AccountUiViewState.Empty
     )
 

--- a/ui/discover/src/main/java/app/tivi/home/discover/Discover.kt
+++ b/ui/discover/src/main/java/app/tivi/home/discover/Discover.kt
@@ -53,6 +53,7 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -62,7 +63,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.tivi.common.compose.Layout
 import app.tivi.common.compose.LocalTiviTextCreator
 import app.tivi.common.compose.bodyWidth
@@ -117,7 +117,7 @@ internal fun Discover(
     openShowDetails: (showId: Long, seasonId: Long?, episodeId: Long?) -> Unit,
     openUser: () -> Unit
 ) {
-    val viewState by viewModel.state.collectAsStateWithLifecycle()
+    val viewState by viewModel.state.collectAsState()
 
     Discover(
         state = viewState,

--- a/ui/discover/src/main/java/app/tivi/home/discover/DiscoverViewModel.kt
+++ b/ui/discover/src/main/java/app/tivi/home/discover/DiscoverViewModel.kt
@@ -85,7 +85,7 @@ internal class DiscoverViewModel @Inject constructor(
         )
     }.stateIn(
         scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
+        started = SharingStarted.WhileSubscribed(),
         initialValue = DiscoverViewState.Empty
     )
 

--- a/ui/episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetails.kt
+++ b/ui/episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetails.kt
@@ -66,6 +66,7 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -86,7 +87,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.tivi.common.compose.Layout
 import app.tivi.common.compose.LocalTiviDateFormatter
 import app.tivi.common.compose.theme.TiviTheme
@@ -130,7 +130,7 @@ internal fun EpisodeDetails(
     expandedValue: ModalBottomSheetValue,
     navigateUp: () -> Unit
 ) {
-    val viewState by viewModel.state.collectAsStateWithLifecycle()
+    val viewState by viewModel.state.collectAsState()
 
     EpisodeDetails(
         viewState = viewState,

--- a/ui/episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsViewModel.kt
+++ b/ui/episodedetails/src/main/java/app/tivi/episodedetails/EpisodeDetailsViewModel.kt
@@ -71,7 +71,7 @@ internal class EpisodeDetailsViewModel @Inject constructor(
         )
     }.stateIn(
         scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
+        started = SharingStarted.WhileSubscribed(),
         initialValue = EpisodeDetailsViewState.Empty
     )
 

--- a/ui/followed/src/main/java/app/tivi/home/followed/Followed.kt
+++ b/ui/followed/src/main/java/app/tivi/home/followed/Followed.kt
@@ -47,6 +47,7 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -55,7 +56,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import app.tivi.common.compose.Layout
@@ -102,7 +102,7 @@ internal fun Followed(
     openShowDetails: (showId: Long) -> Unit,
     openUser: () -> Unit
 ) {
-    val viewState by viewModel.state.collectAsStateWithLifecycle()
+    val viewState by viewModel.state.collectAsState()
     val pagingItems = viewModel.pagedList.collectAsLazyPagingItems()
 
     Followed(

--- a/ui/followed/src/main/java/app/tivi/home/followed/FollowedViewModel.kt
+++ b/ui/followed/src/main/java/app/tivi/home/followed/FollowedViewModel.kt
@@ -99,7 +99,7 @@ internal class FollowedViewModel @Inject constructor(
         )
     }.stateIn(
         scope = viewModelScope,
-        started = WhileSubscribed(5000),
+        started = WhileSubscribed(),
         initialValue = FollowedViewState.Empty
     )
 

--- a/ui/search/src/main/java/app/tivi/home/search/Search.kt
+++ b/ui/search/src/main/java/app/tivi/home/search/Search.kt
@@ -41,6 +41,7 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -53,7 +54,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.tivi.common.compose.Layout
 import app.tivi.common.compose.bodyWidth
 import app.tivi.common.compose.ui.PosterCard
@@ -82,7 +82,7 @@ internal fun Search(
     viewModel: SearchViewModel,
     openShowDetails: (showId: Long) -> Unit
 ) {
-    val viewState by viewModel.state.collectAsStateWithLifecycle()
+    val viewState by viewModel.state.collectAsState()
 
     Search(
         state = viewState,

--- a/ui/search/src/main/java/app/tivi/home/search/SearchViewModel.kt
+++ b/ui/search/src/main/java/app/tivi/home/search/SearchViewModel.kt
@@ -51,7 +51,7 @@ internal class SearchViewModel @Inject constructor(
         ::SearchViewState
     ).stateIn(
         scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
+        started = SharingStarted.WhileSubscribed(),
         initialValue = SearchViewState.Empty
     )
 

--- a/ui/showdetails/src/main/java/app/tivi/showdetails/details/ShowDetails.kt
+++ b/ui/showdetails/src/main/java/app/tivi/showdetails/details/ShowDetails.kt
@@ -75,6 +75,7 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -94,7 +95,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.tivi.common.compose.Layout
 import app.tivi.common.compose.LocalTiviTextCreator
 import app.tivi.common.compose.LogCompositions
@@ -165,7 +165,7 @@ internal fun ShowDetails(
     openEpisodeDetails: (episodeId: Long) -> Unit,
     openSeasons: (showId: Long, seasonId: Long) -> Unit
 ) {
-    val viewState by viewModel.state.collectAsStateWithLifecycle()
+    val viewState by viewModel.state.collectAsState()
     ShowDetails(
         viewState = viewState,
         navigateUp = navigateUp,

--- a/ui/showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsViewModel.kt
+++ b/ui/showdetails/src/main/java/app/tivi/showdetails/details/ShowDetailsViewModel.kt
@@ -98,7 +98,7 @@ internal class ShowDetailsViewModel @Inject constructor(
         )
     }.stateIn(
         scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
+        started = SharingStarted.WhileSubscribed(),
         initialValue = ShowDetailsViewState.Empty
     )
 

--- a/ui/showseasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasons.kt
+++ b/ui/showseasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasons.kt
@@ -56,6 +56,7 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -68,7 +69,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.tivi.common.compose.Layout
 import app.tivi.common.compose.LocalTiviTextCreator
 import app.tivi.common.compose.bodyWidth
@@ -112,7 +112,7 @@ internal fun ShowSeasons(
     openEpisodeDetails: (episodeId: Long) -> Unit,
     initialSeasonId: Long?
 ) {
-    val viewState by viewModel.state.collectAsStateWithLifecycle()
+    val viewState by viewModel.state.collectAsState()
 
     ShowSeasons(
         viewState = viewState,

--- a/ui/showseasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasonsViewModel.kt
+++ b/ui/showseasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasonsViewModel.kt
@@ -61,7 +61,7 @@ internal class ShowSeasonsViewModel @Inject constructor(
         )
     }.stateIn(
         scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
+        started = SharingStarted.WhileSubscribed(),
         initialValue = ShowSeasonsViewState.Empty
     )
 

--- a/ui/watched/src/main/java/app/tivi/home/watched/Watched.kt
+++ b/ui/watched/src/main/java/app/tivi/home/watched/Watched.kt
@@ -46,6 +46,7 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,7 +55,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import app.tivi.common.compose.Layout
@@ -103,7 +103,7 @@ internal fun Watched(
     openShowDetails: (showId: Long) -> Unit,
     openUser: () -> Unit
 ) {
-    val viewState by viewModel.state.collectAsStateWithLifecycle()
+    val viewState by viewModel.state.collectAsState()
     val pagingItems = viewModel.pagedList.collectAsLazyPagingItems()
 
     Watched(

--- a/ui/watched/src/main/java/app/tivi/home/watched/WatchedViewModel.kt
+++ b/ui/watched/src/main/java/app/tivi/home/watched/WatchedViewModel.kt
@@ -94,7 +94,7 @@ class WatchedViewModel @Inject constructor(
         )
     }.stateIn(
         scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
+        started = SharingStarted.WhileSubscribed(),
         initialValue = WatchedViewState.Empty
     )
 


### PR DESCRIPTION
As we're handling all config changes in Tivi, there's no need to keep the state flow alive for configuration changes (as described in this [blog post](https://medium.com/androiddevelopers/migrating-from-livedata-to-kotlins-flow-379292f419fb)).

We can simplify this, and remove the now unnecessary `collectAsStateWithLifecycle()` too.