### PR TITLE
Stop generating the baseline profile on commit

### DIFF
--- a/.github/workflows/baseline-profile.yml
+++ b/.github/workflows/baseline-profile.yml
@@ -4,7 +4,6 @@ on:
   # every day at 00:43
   schedule:
     - cron: '43 0 * * *'
-  push: # remove this once verified that it runs!
 
 jobs:
   baseline-profile:


### PR DESCRIPTION
It was enabled just for testing purposes. We now rely on the nightly schedule.