### PR TITLE
Fix dialog widths (Account UI)

### DIFF
--- a/app/src/main/java/app/tivi/AppNavigation.kt
+++ b/app/src/main/java/app/tivi/AppNavigation.kt
@@ -24,7 +24,9 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
@@ -35,6 +37,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import app.tivi.account.AccountUi
+import app.tivi.common.compose.ui.androidMinWidthDialogSize
 import app.tivi.episodedetails.EpisodeDetails
 import app.tivi.home.discover.Discover
 import app.tivi.home.library.Library
@@ -394,7 +397,7 @@ private fun NavGraphBuilder.addPopularShows(
     }
 }
 
-@ExperimentalAnimationApi
+@OptIn(ExperimentalComposeUiApi::class)
 private fun NavGraphBuilder.addAccount(
     root: RootScreen,
     onOpenSettings: () -> Unit,
@@ -402,9 +405,14 @@ private fun NavGraphBuilder.addAccount(
     dialog(
         route = Screen.Account.createRoute(root),
         debugLabel = "AccountUi()",
+        // Required due to https://issuetracker.google.com/issues/221643630
+        dialogProperties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
         AccountUi(
             openSettings = onOpenSettings,
+            modifier = Modifier
+                // Required due to `usePlatformDefaultWidth = false` above
+                .androidMinWidthDialogSize(clampMaxWidth = true),
         )
     }
 }

--- a/common/ui/compose/src/main/java/app/tivi/common/compose/ui/AndroidDialog.kt
+++ b/common/ui/compose/src/main/java/app/tivi/common/compose/ui/AndroidDialog.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.tivi.common.compose.ui
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+
+/**
+ * Implements a suitable min-width for Android dialog content.
+ *
+ * Matches the values used in the platform default dialog themes `Theme.Material.Dialog.MinWidth`
+ * and `Theme.Material.Dialog.Alert`. Unfortunately the necessary attributes used in the themes
+ * are private, so we can't read them from the theme (and AppCompat duplicates them too).
+ *
+ * The values in question can be found here:
+ * https://cs.android.com/search?q=dialog_min_width%20file:dimens.xml&sq=&ss=android%2Fplatform%2Fsuperproject:frameworks%2Fbase%2F
+ *
+ * This primarily exists to workaround https://issuetracker.google.com/issues/221643630, which
+ * requires the workaround of using `DialogProperties(usePlatformDefaultWidth = false)`.
+ *
+ * @param clampMaxWidth Whether to clamp the maximum width to the same value. This is useful for
+ * Compose content as fillMaxWidth() (or similar) is frequently used, which then stretches the
+ * dialog to fill the screen width.
+ */
+fun Modifier.androidMinWidthDialogSize(
+    clampMaxWidth: Boolean = false,
+): Modifier = composed {
+    val configuration = LocalConfiguration.current
+    val density = LocalContext.current.resources.displayMetrics.density
+
+    val displayWidth = (configuration.screenWidthDp * density).roundToInt()
+    val displayHeight = (configuration.screenHeightDp * density).roundToInt()
+
+    val minWidthRatio: Float = when {
+        configuration.isLayoutSizeAtLeast(Configuration.SCREENLAYOUT_SIZE_XLARGE) -> {
+            if (displayWidth > displayHeight) 0.45f else 0.72f
+        }
+        configuration.isLayoutSizeAtLeast(Configuration.SCREENLAYOUT_SIZE_LARGE) -> {
+            if (displayWidth > displayHeight) 0.55f else 0.8f
+        }
+        else -> {
+            if (displayWidth > displayHeight) 0.65f else 0.95f
+        }
+    }
+
+    if (clampMaxWidth) {
+        Modifier.width(((displayWidth * minWidthRatio) / density).dp)
+    } else {
+        Modifier.widthIn(min = ((displayWidth * minWidthRatio) / density).dp)
+    }
+}

--- a/ui/account/src/main/java/app/tivi/account/AccountUi.kt
+++ b/ui/account/src/main/java/app/tivi/account/AccountUi.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -63,10 +62,12 @@ import org.threeten.bp.ZoneOffset
 @Composable
 fun AccountUi(
     openSettings: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     AccountUi(
         viewModel = hiltViewModel(),
         openSettings = openSettings,
+        modifier = modifier,
     )
 }
 
@@ -74,6 +75,7 @@ fun AccountUi(
 internal fun AccountUi(
     viewModel: AccountUiViewModel,
     openSettings: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val viewState by viewModel.state.collectAsState()
 
@@ -90,6 +92,7 @@ internal fun AccountUi(
         openSettings = openSettings,
         login = { loginLauncher.launch(Unit) },
         logout = { viewModel.logout() },
+        modifier = modifier,
     )
 }
 
@@ -100,11 +103,12 @@ internal fun AccountUi(
     openSettings: () -> Unit,
     login: () -> Unit,
     logout: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Surface(
         color = MaterialTheme.colorScheme.surfaceVariant,
         shape = MaterialTheme.shapes.medium,
-        modifier = Modifier.defaultMinSize(minHeight = 200.dp),
+        modifier = modifier,
     ) {
         Column {
             Spacer(modifier = Modifier.height(16.dp))


### PR DESCRIPTION
Due to https://issuetracker.google.com/issues/221643630, the standard dialogs do not support content which changes height. As a workaround, we can turn off platform width support, but that then means that there is no sensible default dialog size.

This PR includes `Modifier.androidMinWidthDialogSize` which implements some sensible defaults based on platform values.