### PR TITLE
Migrate to collectStableBaselineProfile()

### DIFF
--- a/benchmark/src/main/java/app/tivi/benchmark/BaselineProfileGenerator.kt
+++ b/benchmark/src/main/java/app/tivi/benchmark/BaselineProfileGenerator.kt
@@ -17,7 +17,7 @@
 package app.tivi.benchmark
 
 import android.os.SystemClock
-import androidx.benchmark.macro.ExperimentalBaselineProfilesApi
+import androidx.benchmark.macro.ExperimentalStableBaselineProfilesApi
 import androidx.benchmark.macro.junit4.BaselineProfileRule
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.BySelector
@@ -28,39 +28,42 @@ import androidx.test.uiautomator.Until
 import org.junit.Rule
 import org.junit.Test
 
-@OptIn(ExperimentalBaselineProfilesApi::class)
 class BaselineProfileGenerator {
 
     @get:Rule
     val rule = BaselineProfileRule()
 
+    @OptIn(ExperimentalStableBaselineProfilesApi::class)
     @Test
-    fun generateBaselineProfile() = rule.collectBaselineProfile("app.tivi") {
+    fun generateBaselineProfile() = rule.collectStableBaselineProfile(
+        packageName = "app.tivi",
+        maxIterations = 15, // What @tikurahul said
+    ) {
         startActivityAndWait()
         device.waitForIdle()
 
         // -------------
         // Discover
         // -------------
-        device.testDiscover() || return@collectBaselineProfile
+        device.testDiscover() || return@collectStableBaselineProfile
         device.navigateFromDiscoverToShowDetails()
 
         // -------------
         // Show Details
         // -------------
-        device.testShowDetails() || return@collectBaselineProfile
+        device.testShowDetails() || return@collectStableBaselineProfile
         device.navigateFromShowDetailsToSeasons()
 
         // -------------
         // Seasons
         // -------------
-        device.testSeasons() || return@collectBaselineProfile
+        device.testSeasons() || return@collectStableBaselineProfile
         device.navigateFromSeasonsToEpisodeDetails()
 
         // -------------
         // Episode details
         // -------------
-        device.testEpisodeDetails() || return@collectBaselineProfile
+        device.testEpisodeDetails() || return@collectStableBaselineProfile
     }
 
     private fun UiDevice.testDiscover(): Boolean {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,7 +71,7 @@ androidx-test-core = "androidx.test:core-ktx:1.5.0"
 androidx-test-junit = "androidx.test.ext:junit-ktx:1.1.5"
 androidx-test-rules = "androidx.test:rules:1.5.0"
 androidx-test-runner = "androidx.test:runner:1.5.2"
-androidx-benchmark-macro = "androidx.benchmark:benchmark-macro-junit4:1.1.1"
+androidx-benchmark-macro = "androidx.benchmark:benchmark-macro-junit4:1.2.0-alpha09"
 androidx-uiautomator = "androidx.test.uiautomator:uiautomator:2.2.0"
 
 androidx-work-runtime = "androidx.work:work-runtime-ktx:2.7.1"


### PR DESCRIPTION
Hopefully we'll now see more consistent baseline profiles across runs 🎉. Local testing points to the baseline profiles containing much more profiled content (~15k lines to 27k lines).