### PR TITLE
Migrate to app.cash.paging:paging

### DIFF
--- a/common/ui/compose/build.gradle.kts
+++ b/common/ui/compose/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(libs.compose.animation.animation)
     implementation(libs.compose.ui.tooling)
 
+    implementation(libs.androidx.paging.runtime)
     implementation(libs.androidx.paging.compose)
 
     implementation(libs.coil.compose)

--- a/data/db-room/build.gradle.kts
+++ b/data/db-room/build.gradle.kts
@@ -20,7 +20,6 @@ plugins {
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.kapt)
-    alias(libs.plugins.ksp)
 }
 
 android {
@@ -31,9 +30,8 @@ android {
     }
 }
 
-ksp {
-    arg("room.schemaLocation", "$projectDir/schemas")
-    arg("room.incremental", "true")
+room {
+    schemaLocationDir.set(file("$projectDir/schemas"))
 }
 
 dependencies {
@@ -43,9 +41,11 @@ dependencies {
     api(libs.androidx.room.runtime)
     api(libs.androidx.room.ktx)
     api(libs.androidx.room.paging)
-    ksp(libs.androidx.room.compiler)
+    // Need to use kapt rather than ksp currently. KSP doesn't like app.cash.paging:paging-common's
+    // typealiases
+    kapt(libs.androidx.room.compiler)
 
-    implementation(libs.androidx.paging.runtime)
+    api(libs.androidx.paging.runtime)
 
     implementation(libs.hilt.library)
     kapt(libs.hilt.compiler)

--- a/data/db-room/src/main/java/app/tivi/data/daos/RoomFollowedShowsDao.kt
+++ b/data/db-room/src/main/java/app/tivi/data/daos/RoomFollowedShowsDao.kt
@@ -16,11 +16,11 @@
 
 package app.tivi.data.daos
 
-import androidx.paging.PagingSource
 import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.RewriteQueriesToDropUnusedColumns
 import androidx.room.Transaction
+import app.cash.paging.PagingSource
 import app.tivi.data.compoundmodels.FollowedShowEntryWithShow
 import app.tivi.data.compoundmodels.UpNextEntry
 import app.tivi.data.models.FollowedShowEntry

--- a/data/db-room/src/main/java/app/tivi/data/daos/RoomLibraryShowsDao.kt
+++ b/data/db-room/src/main/java/app/tivi/data/daos/RoomLibraryShowsDao.kt
@@ -16,10 +16,10 @@
 
 package app.tivi.data.daos
 
-import androidx.paging.PagingSource
 import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Transaction
+import app.cash.paging.PagingSource
 import app.tivi.data.compoundmodels.LibraryShow
 import app.tivi.data.models.Season
 import app.tivi.data.models.SortOption

--- a/data/db-room/src/main/java/app/tivi/data/daos/RoomPopularDao.kt
+++ b/data/db-room/src/main/java/app/tivi/data/daos/RoomPopularDao.kt
@@ -16,10 +16,10 @@
 
 package app.tivi.data.daos
 
-import androidx.paging.PagingSource
 import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Transaction
+import app.cash.paging.PagingSource
 import app.tivi.data.compoundmodels.PopularEntryWithShow
 import app.tivi.data.models.PopularShowEntry
 import kotlinx.coroutines.flow.Flow

--- a/data/db-room/src/main/java/app/tivi/data/daos/RoomRecommendedDao.kt
+++ b/data/db-room/src/main/java/app/tivi/data/daos/RoomRecommendedDao.kt
@@ -16,10 +16,10 @@
 
 package app.tivi.data.daos
 
-import androidx.paging.PagingSource
 import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Transaction
+import app.cash.paging.PagingSource
 import app.tivi.data.compoundmodels.RecommendedEntryWithShow
 import app.tivi.data.models.RecommendedShowEntry
 import kotlinx.coroutines.flow.Flow

--- a/data/db-room/src/main/java/app/tivi/data/daos/RoomTrendingDao.kt
+++ b/data/db-room/src/main/java/app/tivi/data/daos/RoomTrendingDao.kt
@@ -16,10 +16,10 @@
 
 package app.tivi.data.daos
 
-import androidx.paging.PagingSource
 import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Transaction
+import app.cash.paging.PagingSource
 import app.tivi.data.compoundmodels.TrendingEntryWithShow
 import app.tivi.data.models.TrendingShowEntry
 import kotlinx.coroutines.flow.Flow

--- a/data/db/build.gradle.kts
+++ b/data/db/build.gradle.kts
@@ -20,8 +20,13 @@ plugins {
     alias(libs.plugins.android.lint)
 }
 
+// https://github.com/cashapp/multiplatform-paging/issues/6
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask<*>> {
+    compilerOptions.freeCompilerArgs.add("-opt-in=androidx.paging.ExperimentalPagingApi")
+}
+
 dependencies {
     implementation(projects.base)
     api(projects.data.models)
-    api(libs.androidx.paging.common)
+    api(libs.cashapp.paging.common)
 }

--- a/data/db/src/main/java/app/tivi/data/daos/FollowedShowsDao.kt
+++ b/data/db/src/main/java/app/tivi/data/daos/FollowedShowsDao.kt
@@ -16,7 +16,7 @@
 
 package app.tivi.data.daos
 
-import androidx.paging.PagingSource
+import app.cash.paging.PagingSource
 import app.tivi.data.compoundmodels.FollowedShowEntryWithShow
 import app.tivi.data.compoundmodels.UpNextEntry
 import app.tivi.data.models.FollowedShowEntry

--- a/data/db/src/main/java/app/tivi/data/daos/LibraryShowsDao.kt
+++ b/data/db/src/main/java/app/tivi/data/daos/LibraryShowsDao.kt
@@ -16,7 +16,7 @@
 
 package app.tivi.data.daos
 
-import androidx.paging.PagingSource
+import app.cash.paging.PagingSource
 import app.tivi.data.compoundmodels.LibraryShow
 import app.tivi.data.models.SortOption
 import app.tivi.data.models.TiviShow

--- a/data/db/src/main/java/app/tivi/data/daos/PopularDao.kt
+++ b/data/db/src/main/java/app/tivi/data/daos/PopularDao.kt
@@ -16,7 +16,7 @@
 
 package app.tivi.data.daos
 
-import androidx.paging.PagingSource
+import app.cash.paging.PagingSource
 import app.tivi.data.compoundmodels.PopularEntryWithShow
 import app.tivi.data.models.PopularShowEntry
 import kotlinx.coroutines.flow.Flow

--- a/data/db/src/main/java/app/tivi/data/daos/RecommendedDao.kt
+++ b/data/db/src/main/java/app/tivi/data/daos/RecommendedDao.kt
@@ -16,7 +16,7 @@
 
 package app.tivi.data.daos
 
-import androidx.paging.PagingSource
+import app.cash.paging.PagingSource
 import app.tivi.data.compoundmodels.RecommendedEntryWithShow
 import app.tivi.data.models.RecommendedShowEntry
 import kotlinx.coroutines.flow.Flow

--- a/data/db/src/main/java/app/tivi/data/daos/TrendingDao.kt
+++ b/data/db/src/main/java/app/tivi/data/daos/TrendingDao.kt
@@ -16,7 +16,7 @@
 
 package app.tivi.data.daos
 
-import androidx.paging.PagingSource
+import app.cash.paging.PagingSource
 import app.tivi.data.compoundmodels.TrendingEntryWithShow
 import app.tivi.data.models.TrendingShowEntry
 import kotlinx.coroutines.flow.Flow

--- a/data/test/build.gradle.kts
+++ b/data/test/build.gradle.kts
@@ -20,7 +20,6 @@ plugins {
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.kapt)
-    alias(libs.plugins.ksp)
 }
 
 android {
@@ -40,11 +39,6 @@ android {
             }
         }
     }
-}
-
-ksp {
-    arg("room.schemaLocation", "$projectDir/schemas")
-    arg("room.incremental", "true")
 }
 
 dependencies {
@@ -69,7 +63,7 @@ dependencies {
     testImplementation(libs.kotlin.coroutines.test)
     testImplementation(libs.hilt.testing)
 
-    kspTest(libs.androidx.room.compiler)
+    kaptTest(libs.androidx.room.compiler)
     kaptTest(libs.hilt.compiler)
 
     // Needed for Tzdb

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -26,6 +26,11 @@ android {
     namespace = "app.tivi.domain"
 }
 
+// https://github.com/cashapp/multiplatform-paging/issues/6
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask<*>> {
+    compilerOptions.freeCompilerArgs.add("-opt-in=androidx.paging.ExperimentalPagingApi")
+}
+
 dependencies {
     implementation(projects.base)
 
@@ -52,6 +57,5 @@ dependencies {
     implementation(libs.hilt.library)
     kapt(libs.hilt.compiler)
 
-    api(libs.androidx.paging.common)
-    implementation(libs.androidx.paging.runtime)
+    api(libs.cashapp.paging.common)
 }

--- a/domain/src/main/java/app/tivi/domain/Interactor.kt
+++ b/domain/src/main/java/app/tivi/domain/Interactor.kt
@@ -16,8 +16,8 @@
 
 package app.tivi.domain
 
-import androidx.paging.PagingConfig
-import androidx.paging.PagingData
+import app.cash.paging.PagingConfig
+import app.cash.paging.PagingData
 import app.tivi.base.InvokeError
 import app.tivi.base.InvokeStarted
 import app.tivi.base.InvokeStatus

--- a/domain/src/main/java/app/tivi/domain/PaginatedEntryRemoteMediator.kt
+++ b/domain/src/main/java/app/tivi/domain/PaginatedEntryRemoteMediator.kt
@@ -16,10 +16,9 @@
 
 package app.tivi.domain
 
-import androidx.paging.ExperimentalPagingApi
-import androidx.paging.LoadType
-import androidx.paging.PagingState
-import androidx.paging.RemoteMediator
+import app.cash.paging.LoadType
+import app.cash.paging.PagingState
+import app.cash.paging.RemoteMediator
 import app.tivi.data.compoundmodels.EntryWithShow
 import app.tivi.data.models.PaginatedEntry
 
@@ -27,7 +26,7 @@ import app.tivi.data.models.PaginatedEntry
  * A [RemoteMediator] which works on [PaginatedEntry] entities. [fetch] will be called with the
  * next page to load.
  */
-@OptIn(ExperimentalPagingApi::class)
+
 internal class PaginatedEntryRemoteMediator<LI, ET>(
     private val fetch: suspend (page: Int) -> Unit,
 ) : RemoteMediator<Int, LI>() where ET : PaginatedEntry, LI : EntryWithShow<ET> {

--- a/domain/src/main/java/app/tivi/domain/RefreshOnlyRemoteMediator.kt
+++ b/domain/src/main/java/app/tivi/domain/RefreshOnlyRemoteMediator.kt
@@ -16,10 +16,9 @@
 
 package app.tivi.domain
 
-import androidx.paging.ExperimentalPagingApi
-import androidx.paging.LoadType
-import androidx.paging.PagingState
-import androidx.paging.RemoteMediator
+import app.cash.paging.LoadType
+import app.cash.paging.PagingState
+import app.cash.paging.RemoteMediator
 import app.tivi.data.compoundmodels.EntryWithShow
 import app.tivi.data.models.PaginatedEntry
 
@@ -27,7 +26,6 @@ import app.tivi.data.models.PaginatedEntry
  * A [RemoteMediator] which works on [PaginatedEntry] entities, but only calls
  * [fetch] for [LoadType.REFRESH] events.
  */
-@OptIn(ExperimentalPagingApi::class)
 internal class RefreshOnlyRemoteMediator<LI, ET>(
     private val fetch: suspend () -> Unit,
 ) : RemoteMediator<Int, LI>() where ET : PaginatedEntry, LI : EntryWithShow<ET> {

--- a/domain/src/main/java/app/tivi/domain/observers/ObservePagedLibraryShows.kt
+++ b/domain/src/main/java/app/tivi/domain/observers/ObservePagedLibraryShows.kt
@@ -16,9 +16,9 @@
 
 package app.tivi.domain.observers
 
-import androidx.paging.Pager
-import androidx.paging.PagingConfig
-import androidx.paging.PagingData
+import app.cash.paging.Pager
+import app.cash.paging.PagingConfig
+import app.cash.paging.PagingData
 import app.tivi.data.compoundmodels.LibraryShow
 import app.tivi.data.daos.LibraryShowsDao
 import app.tivi.data.models.SortOption

--- a/domain/src/main/java/app/tivi/domain/observers/ObservePagedPopularShows.kt
+++ b/domain/src/main/java/app/tivi/domain/observers/ObservePagedPopularShows.kt
@@ -16,10 +16,9 @@
 
 package app.tivi.domain.observers
 
-import androidx.paging.ExperimentalPagingApi
-import androidx.paging.Pager
-import androidx.paging.PagingConfig
-import androidx.paging.PagingData
+import app.cash.paging.Pager
+import app.cash.paging.PagingConfig
+import app.cash.paging.PagingData
 import app.tivi.data.compoundmodels.PopularEntryWithShow
 import app.tivi.data.daos.PopularDao
 import app.tivi.domain.PaginatedEntryRemoteMediator
@@ -28,7 +27,6 @@ import app.tivi.domain.interactors.UpdatePopularShows
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 
-@OptIn(ExperimentalPagingApi::class)
 class ObservePagedPopularShows @Inject constructor(
     private val PopularShowsDao: PopularDao,
     private val updatePopularShows: UpdatePopularShows,

--- a/domain/src/main/java/app/tivi/domain/observers/ObservePagedRecommendedShows.kt
+++ b/domain/src/main/java/app/tivi/domain/observers/ObservePagedRecommendedShows.kt
@@ -16,10 +16,9 @@
 
 package app.tivi.domain.observers
 
-import androidx.paging.ExperimentalPagingApi
-import androidx.paging.Pager
-import androidx.paging.PagingConfig
-import androidx.paging.PagingData
+import app.cash.paging.Pager
+import app.cash.paging.PagingConfig
+import app.cash.paging.PagingData
 import app.tivi.data.compoundmodels.RecommendedEntryWithShow
 import app.tivi.data.daos.RecommendedDao
 import app.tivi.domain.PagingInteractor
@@ -28,7 +27,6 @@ import app.tivi.domain.interactors.UpdateRecommendedShows
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 
-@OptIn(ExperimentalPagingApi::class)
 class ObservePagedRecommendedShows @Inject constructor(
     private val RecommendedShowsDao: RecommendedDao,
     private val updateRecommendedShows: UpdateRecommendedShows,

--- a/domain/src/main/java/app/tivi/domain/observers/ObservePagedTrendingShows.kt
+++ b/domain/src/main/java/app/tivi/domain/observers/ObservePagedTrendingShows.kt
@@ -16,10 +16,9 @@
 
 package app.tivi.domain.observers
 
-import androidx.paging.ExperimentalPagingApi
-import androidx.paging.Pager
-import androidx.paging.PagingConfig
-import androidx.paging.PagingData
+import app.cash.paging.Pager
+import app.cash.paging.PagingConfig
+import app.cash.paging.PagingData
 import app.tivi.data.compoundmodels.TrendingEntryWithShow
 import app.tivi.data.daos.TrendingDao
 import app.tivi.domain.PaginatedEntryRemoteMediator
@@ -28,7 +27,6 @@ import app.tivi.domain.interactors.UpdateTrendingShows
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 
-@OptIn(ExperimentalPagingApi::class)
 class ObservePagedTrendingShows @Inject constructor(
     private val trendingShowsDao: TrendingDao,
     private val updateTrendingShows: UpdateTrendingShows,

--- a/domain/src/main/java/app/tivi/domain/observers/ObservePagedUpNextShows.kt
+++ b/domain/src/main/java/app/tivi/domain/observers/ObservePagedUpNextShows.kt
@@ -16,9 +16,9 @@
 
 package app.tivi.domain.observers
 
-import androidx.paging.Pager
-import androidx.paging.PagingConfig
-import androidx.paging.PagingData
+import app.cash.paging.Pager
+import app.cash.paging.PagingConfig
+import app.cash.paging.PagingData
 import app.tivi.data.compoundmodels.UpNextEntry
 import app.tivi.data.daos.FollowedShowsDao
 import app.tivi.data.models.SortOption

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,7 @@ androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-view
 
 androidx-navigation-compose = "androidx.navigation:navigation-compose:2.6.0-alpha05"
 
-androidx-paging-common = { module = "androidx.paging:paging-common-ktx", version.ref = "paging" }
+cashapp-paging-common = "app.cash.paging:paging-common:3.1.1-0.1.1"
 androidx-paging-runtime = { module = "androidx.paging:paging-runtime-ktx", version.ref = "paging" }
 androidx-paging-compose = "androidx.paging:paging-compose:1.0.0-alpha18"
 

--- a/ui/popular/build.gradle.kts
+++ b/ui/popular/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
 
+    implementation(libs.androidx.paging.runtime)
     implementation(libs.androidx.paging.compose)
 
     implementation(libs.compose.foundation.foundation)

--- a/ui/recommended/build.gradle.kts
+++ b/ui/recommended/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
 
+    implementation(libs.androidx.paging.runtime)
     implementation(libs.androidx.paging.compose)
 
     implementation(libs.compose.foundation.foundation)

--- a/ui/trending/build.gradle.kts
+++ b/ui/trending/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
 
+    implementation(libs.androidx.paging.runtime)
     implementation(libs.androidx.paging.compose)
 
     implementation(libs.compose.foundation.foundation)


### PR DESCRIPTION
This is with the future goal of migrating most of the data layer to use KMP. Had to migrate back to kapt for room-compiler due to issues with KSP

https://github.com/cashapp/multiplatform-paging

Fixes #1090