### PR TITLE
Add 'track episode' quick action from 'Up Next'

### DIFF
--- a/app/src/main/java/app/tivi/AppNavigation.kt
+++ b/app/src/main/java/app/tivi/AppNavigation.kt
@@ -283,6 +283,9 @@ private fun NavGraphBuilder.addUpNext(
             openUser = {
                 navController.navigate(Screen.Account.createRoute(root))
             },
+            openTrackEpisode = { episodeId ->
+                navController.navigate(Screen.EpisodeTrack.createRoute(root, episodeId))
+            },
         )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -142,6 +142,8 @@ retrofit-mock = { module = "com.squareup.retrofit2:retrofit-mock", version.ref =
 
 robolectric = "org.robolectric:robolectric:4.9.2"
 
+swipe = "me.saket.swipe:swipe:1.1.1"
+
 store = "org.mobilenativefoundation.store:store5:5.0.0-alpha03"
 
 threeTenAbp = "com.jakewharton.threetenabp:threetenabp:1.4.4"

--- a/ui/upnext/build.gradle.kts
+++ b/ui/upnext/build.gradle.kts
@@ -45,6 +45,8 @@ dependencies {
     implementation(libs.androidx.paging.runtime)
     implementation(libs.androidx.paging.compose)
 
+    implementation(libs.swipe)
+
     implementation(libs.androidx.core)
 
     implementation(libs.compose.foundation.foundation)


### PR DESCRIPTION
Opens the new 'track episode' UI added in #1118, triggering from a swipe quick action from the 'Up Next' list. Uses @saket's Swipe library: https://github.com/saket/swipe

https://user-images.githubusercontent.com/227486/219864700-f1c171dc-7768-47de-953d-3603061fd368.mp4

