### PR TITLE
Sync season/episodes data for all watched shows

### DIFF
--- a/common/imageloading/src/main/java/app/tivi/common/imageloading/EpisodeCoilInterceptor.kt
+++ b/common/imageloading/src/main/java/app/tivi/common/imageloading/EpisodeCoilInterceptor.kt
@@ -46,7 +46,7 @@ class EpisodeCoilInterceptor(
 
     private suspend fun handle(chain: Interceptor.Chain, model: EpisodeImageModel): ImageRequest {
         if (repository.needEpisodeUpdate(model.id, expiry = 180.days.inPast)) {
-            repository.updateEpisode(model.id)
+            runCatching { repository.updateEpisode(model.id) }
         }
 
         val episode = repository.getEpisode(model.id)

--- a/common/ui/resources/src/main/res/values/strings.xml
+++ b/common/ui/resources/src/main/res/values/strings.xml
@@ -43,7 +43,7 @@
     <string name="discover_popular_title">Popular</string>
     <string name="discover_keep_watching_title">Up next</string>
 
-    <string name="following_shows_title">Following</string>
+    <string name="following_shows_title">Followed</string>
     <string name="cd_following_shows_title">@string/following_shows_title</string>
     <string name="watched_shows_title">Watched</string>
     <string name="cd_watched_shows_title">@string/watched_shows_title</string>
@@ -51,6 +51,8 @@
     <string name="cd_library_title">@string/library_title</string>
     <string name="upnext_title">Up Next</string>
     <string name="cd_upnext_title">@string/library_title</string>
+
+    <string name="upnext_filter_followed_shows_only_title">Followed only</string>
 
     <string name="login">Login</string>
     <string name="refresh_credentials">Refresh credentials</string>

--- a/core/base/src/commonMain/kotlin/app/tivi/util/Collections.kt
+++ b/core/base/src/commonMain/kotlin/app/tivi/util/Collections.kt
@@ -16,12 +16,14 @@
 
 package app.tivi.util
 
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.DEFAULT_CONCURRENCY
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
 
+@OptIn(FlowPreview::class)
 suspend fun <T> Collection<T>.parallelForEach(
     concurrency: Int = DEFAULT_CONCURRENCY,
     block: suspend (value: T) -> Unit,

--- a/core/preferences/src/androidMain/kotlin/app/tivi/settings/TiviPreferencesImpl.kt
+++ b/core/preferences/src/androidMain/kotlin/app/tivi/settings/TiviPreferencesImpl.kt
@@ -51,6 +51,7 @@ class TiviPreferencesImpl(
         const val KEY_DATA_SAVER = "pref_data_saver"
         const val KEY_LIBRARY_FOLLOWED_ACTIVE = "pref_library_followed_active"
         const val KEY_LIBRARY_WATCHED_ACTIVE = "pref_library_watched_active"
+        const val KEY_UPNEXT_FOLLOWED_ONLY = "pref_upnext_followedonly_active"
     }
 
     override fun setup() {
@@ -107,6 +108,16 @@ class TiviPreferencesImpl(
         return createPreferenceFlow(KEY_LIBRARY_WATCHED_ACTIVE) {
             libraryWatchedActive
         }
+    }
+
+    override var upNextFollowedOnly: Boolean
+        get() = sharedPreferences.getBoolean(KEY_UPNEXT_FOLLOWED_ONLY, false)
+        set(value) = sharedPreferences.edit {
+            putBoolean(KEY_UPNEXT_FOLLOWED_ONLY, value)
+        }
+
+    override fun observeUpNextFollowedOnly(): Flow<Boolean> {
+        return createPreferenceFlow(KEY_UPNEXT_FOLLOWED_ONLY) { upNextFollowedOnly }
     }
 
     private inline fun <T> createPreferenceFlow(

--- a/core/preferences/src/commonMain/kotlin/app/tivi/settings/TiviPreferences.kt
+++ b/core/preferences/src/commonMain/kotlin/app/tivi/settings/TiviPreferences.kt
@@ -37,6 +37,9 @@ interface TiviPreferences {
     var libraryWatchedActive: Boolean
     fun observeLibraryWatchedActive(): Flow<Boolean>
 
+    var upNextFollowedOnly: Boolean
+    fun observeUpNextFollowedOnly(): Flow<Boolean>
+
     enum class Theme {
         LIGHT,
         DARK,

--- a/data/db-room/schemas/app.tivi.data.TiviRoomDatabase/32.json
+++ b/data/db-room/schemas/app.tivi.data.TiviRoomDatabase/32.json
@@ -1,0 +1,1134 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 32,
+    "identityHash": "475084588568ddf874727ed0cae5e370",
+    "entities": [
+      {
+        "tableName": "shows",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT, `original_title` TEXT, `trakt_id` INTEGER, `tmdb_id` INTEGER, `imdb_id` TEXT, `overview` TEXT, `homepage` TEXT, `trakt_rating` REAL, `trakt_votes` INTEGER, `certification` TEXT, `first_aired` TEXT, `country` TEXT, `network` TEXT, `network_logo_path` TEXT, `runtime` INTEGER, `genres` TEXT, `status` TEXT, `airs_day` INTEGER, `airs_time` TEXT, `airs_tz` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "originalTitle",
+            "columnName": "original_title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "traktId",
+            "columnName": "trakt_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tmdbId",
+            "columnName": "tmdb_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imdbId",
+            "columnName": "imdb_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "overview",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "homepage",
+            "columnName": "homepage",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "traktRating",
+            "columnName": "trakt_rating",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "traktVotes",
+            "columnName": "trakt_votes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "certification",
+            "columnName": "certification",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "firstAired",
+            "columnName": "first_aired",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "network",
+            "columnName": "network",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "networkLogoPath",
+            "columnName": "network_logo_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "runtime",
+            "columnName": "runtime",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "_genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "airsDay",
+            "columnName": "airs_day",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "airsTime",
+            "columnName": "airs_time",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "airsTimeZone",
+            "columnName": "airs_tz",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_shows_trakt_id",
+            "unique": true,
+            "columnNames": [
+              "trakt_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_shows_trakt_id` ON `${TABLE_NAME}` (`trakt_id`)"
+          },
+          {
+            "name": "index_shows_tmdb_id",
+            "unique": false,
+            "columnNames": [
+              "tmdb_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shows_tmdb_id` ON `${TABLE_NAME}` (`tmdb_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "shows",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_shows_fts_BEFORE_UPDATE BEFORE UPDATE ON `shows` BEGIN DELETE FROM `shows_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_shows_fts_BEFORE_DELETE BEFORE DELETE ON `shows` BEGIN DELETE FROM `shows_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_shows_fts_AFTER_UPDATE AFTER UPDATE ON `shows` BEGIN INSERT INTO `shows_fts`(`docid`, `title`, `original_title`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`original_title`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_shows_fts_AFTER_INSERT AFTER INSERT ON `shows` BEGIN INSERT INTO `shows_fts`(`docid`, `title`, `original_title`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`original_title`); END"
+        ],
+        "tableName": "shows_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT, `original_title` TEXT, content=`shows`)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "originalTitle",
+            "columnName": "original_title",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "trending_shows",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `show_id` INTEGER NOT NULL, `page` INTEGER NOT NULL, `watchers` INTEGER NOT NULL, FOREIGN KEY(`show_id`) REFERENCES `shows`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showId",
+            "columnName": "show_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watchers",
+            "columnName": "watchers",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_trending_shows_show_id",
+            "unique": true,
+            "columnNames": [
+              "show_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_trending_shows_show_id` ON `${TABLE_NAME}` (`show_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "shows",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "show_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "popular_shows",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `show_id` INTEGER NOT NULL, `page` INTEGER NOT NULL, `page_order` INTEGER NOT NULL, FOREIGN KEY(`show_id`) REFERENCES `shows`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showId",
+            "columnName": "show_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageOrder",
+            "columnName": "page_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_popular_shows_show_id",
+            "unique": true,
+            "columnNames": [
+              "show_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_popular_shows_show_id` ON `${TABLE_NAME}` (`show_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "shows",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "show_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `name` TEXT, `joined_date` TEXT, `location` TEXT, `about` TEXT, `avatar_url` TEXT, `vip` INTEGER, `is_me` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "joined",
+            "columnName": "joined_date",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "about",
+            "columnName": "about",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatar_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "vip",
+            "columnName": "vip",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isMe",
+            "columnName": "is_me",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_username",
+            "unique": true,
+            "columnNames": [
+              "username"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "watched_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `show_id` INTEGER NOT NULL, `last_watched` TEXT NOT NULL, `last_updated` TEXT NOT NULL DEFAULT '2000-01-01T00:00:00.000000Z', FOREIGN KEY(`show_id`) REFERENCES `shows`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showId",
+            "columnName": "show_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastWatched",
+            "columnName": "last_watched",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'2000-01-01T00:00:00.000000Z'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_watched_entries_show_id",
+            "unique": true,
+            "columnNames": [
+              "show_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_watched_entries_show_id` ON `${TABLE_NAME}` (`show_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "shows",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "show_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "myshows_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `show_id` INTEGER NOT NULL, `followed_at` TEXT, `pending_action` TEXT NOT NULL, `trakt_id` INTEGER, FOREIGN KEY(`show_id`) REFERENCES `shows`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showId",
+            "columnName": "show_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "followedAt",
+            "columnName": "followed_at",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pendingAction",
+            "columnName": "pending_action",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "traktId",
+            "columnName": "trakt_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_myshows_entries_show_id",
+            "unique": true,
+            "columnNames": [
+              "show_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_myshows_entries_show_id` ON `${TABLE_NAME}` (`show_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "shows",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "show_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "seasons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `show_id` INTEGER NOT NULL, `trakt_id` INTEGER, `tmdb_id` INTEGER, `title` TEXT, `overview` TEXT, `number` INTEGER, `network` TEXT, `ep_count` INTEGER, `ep_aired` INTEGER, `trakt_rating` REAL, `trakt_votes` INTEGER, `tmdb_poster_path` TEXT, `tmdb_backdrop_path` TEXT, `ignored` INTEGER NOT NULL, FOREIGN KEY(`show_id`) REFERENCES `shows`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showId",
+            "columnName": "show_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "traktId",
+            "columnName": "trakt_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tmdbId",
+            "columnName": "tmdb_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "overview",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "network",
+            "columnName": "network",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episodeCount",
+            "columnName": "ep_count",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episodesAired",
+            "columnName": "ep_aired",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "traktRating",
+            "columnName": "trakt_rating",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "traktRatingVotes",
+            "columnName": "trakt_votes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tmdbPosterPath",
+            "columnName": "tmdb_poster_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tmdbBackdropPath",
+            "columnName": "tmdb_backdrop_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ignored",
+            "columnName": "ignored",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_seasons_trakt_id",
+            "unique": true,
+            "columnNames": [
+              "trakt_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_seasons_trakt_id` ON `${TABLE_NAME}` (`trakt_id`)"
+          },
+          {
+            "name": "index_seasons_show_id",
+            "unique": false,
+            "columnNames": [
+              "show_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_seasons_show_id` ON `${TABLE_NAME}` (`show_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "shows",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "show_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `season_id` INTEGER NOT NULL, `trakt_id` INTEGER, `tmdb_id` INTEGER, `title` TEXT, `overview` TEXT, `number` INTEGER, `first_aired` TEXT, `trakt_rating` REAL, `trakt_rating_votes` INTEGER, `tmdb_backdrop_path` TEXT, FOREIGN KEY(`season_id`) REFERENCES `seasons`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seasonId",
+            "columnName": "season_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "traktId",
+            "columnName": "trakt_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tmdbId",
+            "columnName": "tmdb_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "overview",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "firstAired",
+            "columnName": "first_aired",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "traktRating",
+            "columnName": "trakt_rating",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "traktRatingVotes",
+            "columnName": "trakt_rating_votes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tmdbBackdropPath",
+            "columnName": "tmdb_backdrop_path",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodes_trakt_id",
+            "unique": true,
+            "columnNames": [
+              "trakt_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodes_trakt_id` ON `${TABLE_NAME}` (`trakt_id`)"
+          },
+          {
+            "name": "index_episodes_season_id",
+            "unique": false,
+            "columnNames": [
+              "season_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episodes_season_id` ON `${TABLE_NAME}` (`season_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "seasons",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "season_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "related_shows",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `show_id` INTEGER NOT NULL, `other_show_id` INTEGER NOT NULL, `order_index` INTEGER NOT NULL, FOREIGN KEY(`show_id`) REFERENCES `shows`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`other_show_id`) REFERENCES `shows`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showId",
+            "columnName": "show_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "otherShowId",
+            "columnName": "other_show_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "order_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_related_shows_show_id",
+            "unique": false,
+            "columnNames": [
+              "show_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_related_shows_show_id` ON `${TABLE_NAME}` (`show_id`)"
+          },
+          {
+            "name": "index_related_shows_other_show_id",
+            "unique": false,
+            "columnNames": [
+              "other_show_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_related_shows_other_show_id` ON `${TABLE_NAME}` (`other_show_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "shows",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "show_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "shows",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "other_show_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "episode_watch_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `episode_id` INTEGER NOT NULL, `trakt_id` INTEGER, `watched_at` TEXT NOT NULL, `pending_action` TEXT NOT NULL, FOREIGN KEY(`episode_id`) REFERENCES `episodes`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeId",
+            "columnName": "episode_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "traktId",
+            "columnName": "trakt_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "watchedAt",
+            "columnName": "watched_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pendingAction",
+            "columnName": "pending_action",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episode_watch_entries_episode_id",
+            "unique": false,
+            "columnNames": [
+              "episode_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episode_watch_entries_episode_id` ON `${TABLE_NAME}` (`episode_id`)"
+          },
+          {
+            "name": "index_episode_watch_entries_trakt_id",
+            "unique": true,
+            "columnNames": [
+              "trakt_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episode_watch_entries_trakt_id` ON `${TABLE_NAME}` (`trakt_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "episodes",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "episode_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "last_requests",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `request` TEXT NOT NULL, `entity_id` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "request",
+            "columnName": "request",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "_timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_last_requests_request_entity_id",
+            "unique": true,
+            "columnNames": [
+              "request",
+              "entity_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_last_requests_request_entity_id` ON `${TABLE_NAME}` (`request`, `entity_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "show_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `show_id` INTEGER NOT NULL, `path` TEXT NOT NULL, `type` TEXT NOT NULL, `lang` TEXT, `rating` REAL NOT NULL, `is_primary` INTEGER NOT NULL, FOREIGN KEY(`show_id`) REFERENCES `shows`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showId",
+            "columnName": "show_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "lang",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrimary",
+            "columnName": "is_primary",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_show_images_show_id",
+            "unique": false,
+            "columnNames": [
+              "show_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_show_images_show_id` ON `${TABLE_NAME}` (`show_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "shows",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "show_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recommended_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `show_id` INTEGER NOT NULL, `page` INTEGER NOT NULL, FOREIGN KEY(`show_id`) REFERENCES `shows`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showId",
+            "columnName": "show_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recommended_entries_show_id",
+            "unique": true,
+            "columnNames": [
+              "show_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_recommended_entries_show_id` ON `${TABLE_NAME}` (`show_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "shows",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "show_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [
+      {
+        "viewName": "shows_view_watch_stats",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT shows.id AS show_id, COUNT(*) AS episode_count, COUNT(ew.watched_at) AS watched_episode_count\n        FROM shows\n        INNER JOIN seasons AS s ON shows.id = s.show_id\n        INNER JOIN episodes AS eps ON eps.season_id = s.id\n        LEFT JOIN episode_watch_entries as ew ON ew.episode_id = eps.id\n        WHERE eps.first_aired IS NOT NULL\n            AND datetime(eps.first_aired) < datetime('now')\n            AND s.number != 0\n            AND s.ignored = 0\n        GROUP BY shows.id"
+      },
+      {
+        "viewName": "shows_last_watched",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT\n          shows.id as show_id,\n          s.id AS season_id,\n          eps.id AS episode_id,\n          MAX((1000 * s.number) + eps.number) AS last_watched_abs_number\n        FROM shows\n        INNER JOIN seasons AS s ON shows.id = s.show_id\n        INNER JOIN episodes AS eps ON eps.season_id = s.id\n        INNER JOIN episode_watch_entries as ew ON ew.episode_id = eps.id\n        WHERE\n          s.number != 0\n          AND s.ignored = 0\n        GROUP BY shows.id\n        ORDER BY ew.watched_at DESC"
+      },
+      {
+        "viewName": "shows_next_to_watch",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT\n          shows.id as show_id,\n          seasons.id AS season_id,\n          eps.id AS episode_id,\n          MIN((1000 * seasons.number) + eps.number) AS next_ep_to_watch_abs_number\n        FROM shows\n        INNER JOIN seasons ON shows.id = seasons.show_id\n        INNER JOIN episodes AS eps ON eps.season_id = seasons.id\n        LEFT JOIN episode_watch_entries as ew ON ew.episode_id = eps.id\n        LEFT JOIN shows_last_watched AS lw ON lw.show_id = shows.id\n        WHERE seasons.number != 0\n          AND seasons.ignored = 0\n          AND watched_at IS NULL\n          AND datetime(eps.first_aired) < datetime('now')\n          AND ((1000 * seasons.number) + eps.number) > coalesce(last_watched_abs_number, 0)\n        GROUP BY shows.id"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '475084588568ddf874727ed0cae5e370')"
+    ]
+  }
+}

--- a/data/db-room/src/main/java/app/tivi/data/TiviRoomDatabase.kt
+++ b/data/db-room/src/main/java/app/tivi/data/TiviRoomDatabase.kt
@@ -54,9 +54,9 @@ import app.tivi.data.models.TiviShowFts
 import app.tivi.data.models.TraktUser
 import app.tivi.data.models.TrendingShowEntry
 import app.tivi.data.models.WatchedShowEntry
-import app.tivi.data.views.FollowedShowsLastWatched
-import app.tivi.data.views.FollowedShowsNextToWatch
-import app.tivi.data.views.FollowedShowsWatchStats
+import app.tivi.data.views.ShowsLastWatched
+import app.tivi.data.views.ShowsNextToWatch
+import app.tivi.data.views.ShowsWatchStats
 
 @Database(
     entities = [
@@ -76,11 +76,11 @@ import app.tivi.data.views.FollowedShowsWatchStats
         RecommendedShowEntry::class,
     ],
     views = [
-        FollowedShowsWatchStats::class,
-        FollowedShowsLastWatched::class,
-        FollowedShowsNextToWatch::class,
+        ShowsWatchStats::class,
+        ShowsLastWatched::class,
+        ShowsNextToWatch::class,
     ],
-    version = 31,
+    version = 32,
     autoMigrations = [
         AutoMigration(from = 24, to = 25),
         AutoMigration(from = 25, to = 26),
@@ -90,6 +90,7 @@ import app.tivi.data.views.FollowedShowsWatchStats
         AutoMigration(from = 29, to = 30), // can remove this later
         AutoMigration(from = 27, to = 30),
         AutoMigration(from = 30, to = 31, spec = TiviRoomDatabase.AutoMigrationSpec31::class),
+        AutoMigration(from = 31, to = 32),
     ],
 )
 @TypeConverters(TiviTypeConverters::class, DateTimeTypeConverters::class)

--- a/data/db-room/src/main/java/app/tivi/data/daos/RoomFollowedShowsDao.kt
+++ b/data/db-room/src/main/java/app/tivi/data/daos/RoomFollowedShowsDao.kt
@@ -18,15 +18,8 @@ package app.tivi.data.daos
 
 import androidx.room.Dao
 import androidx.room.Query
-import androidx.room.RewriteQueriesToDropUnusedColumns
-import androidx.room.Transaction
-import app.cash.paging.PagingSource
-import app.tivi.data.compoundmodels.FollowedShowEntryWithShow
-import app.tivi.data.compoundmodels.UpNextEntry
 import app.tivi.data.models.FollowedShowEntry
 import app.tivi.data.models.PendingAction
-import app.tivi.data.models.Season
-import app.tivi.data.views.FollowedShowsWatchStats
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -34,70 +27,8 @@ abstract class RoomFollowedShowsDao : FollowedShowsDao, RoomEntityDao<FollowedSh
     @Query("SELECT * FROM myshows_entries")
     abstract override suspend fun entries(): List<FollowedShowEntry>
 
-    @Transaction
-    @Query(
-        """
-        SELECT myshows_entries.* FROM myshows_entries
-            INNER JOIN seasons AS s ON s.show_id = myshows_entries.show_id
-			INNER JOIN followed_next_to_watch AS next ON next.show_id = myshows_entries.show_id
-			INNER JOIN episodes AS eps ON eps.season_id = s.id
-            INNER JOIN episode_watch_entries AS ew ON ew.episode_id = eps.id
-            WHERE s.number != ${Season.NUMBER_SPECIALS} AND s.ignored = 0
-			ORDER BY datetime(ew.watched_at) DESC
-			LIMIT 1
-        """,
-    )
-    abstract override fun observeNextShowToWatch(): Flow<FollowedShowEntryWithShow?>
-
-    @Transaction
-    @RewriteQueriesToDropUnusedColumns
-    @Query(
-        """
-        SELECT followed_next_to_watch.* FROM followed_next_to_watch
-        INNER JOIN myshows_entries ON myshows_entries.show_id = followed_next_to_watch.show_id
-        LEFT JOIN followed_last_watched ON followed_last_watched.id = myshows_entries.id
-        LEFT JOIN episode_watch_entries ON episode_watch_entries.episode_id = followed_last_watched.episode_id
-        GROUP BY followed_next_to_watch.show_id
-        ORDER BY datetime(episode_watch_entries.watched_at) DESC
-        """,
-    )
-    abstract override fun pagedUpNextShowsLastWatched(): PagingSource<Int, UpNextEntry>
-
-    @Transaction
-    @RewriteQueriesToDropUnusedColumns
-    @Query(
-        """
-        SELECT followed_next_to_watch.* FROM followed_next_to_watch
-        INNER JOIN episodes ON episodes.id = followed_next_to_watch.episode_id
-        GROUP BY followed_next_to_watch.show_id
-        ORDER BY datetime(episodes.first_aired) DESC
-        """,
-    )
-    abstract override fun pagedUpNextShowsDateAired(): PagingSource<Int, UpNextEntry>
-
-    @Transaction
-    @RewriteQueriesToDropUnusedColumns
-    @Query(
-        """
-        SELECT followed_next_to_watch.* FROM followed_next_to_watch
-        INNER JOIN myshows_entries ON myshows_entries.show_id = followed_next_to_watch.show_id
-        GROUP BY followed_next_to_watch.show_id
-        ORDER BY datetime(myshows_entries.followed_at) DESC
-        """,
-    )
-    abstract override fun pagedUpNextShowsDateAdded(): PagingSource<Int, UpNextEntry>
-
-    @Transaction
-    @RewriteQueriesToDropUnusedColumns
-    @Query("SELECT * FROM followed_next_to_watch")
-    abstract override suspend fun getUpNextShows(): List<UpNextEntry>
-
     @Query("DELETE FROM myshows_entries")
     abstract override suspend fun deleteAll()
-
-    @Transaction
-    @Query("SELECT * FROM myshows_entries WHERE id = :id")
-    abstract override suspend fun entryWithId(id: Long): FollowedShowEntryWithShow?
 
     @Query("SELECT * FROM myshows_entries WHERE show_id = :showId")
     abstract override suspend fun entryWithShowId(showId: Long): FollowedShowEntry?
@@ -107,16 +38,6 @@ abstract class RoomFollowedShowsDao : FollowedShowsDao, RoomEntityDao<FollowedSh
 
     @Query("SELECT COUNT(*) FROM myshows_entries WHERE show_id = :showId")
     abstract override suspend fun entryCountWithShowId(showId: Long): Int
-
-    @Transaction
-    @Query(
-        """
-        SELECT stats.* FROM myshows_view_watch_stats as stats
-        INNER JOIN myshows_entries ON stats.id = myshows_entries.id
-        WHERE stats.show_id = :showId
-        """,
-    )
-    abstract override fun entryShowViewStats(showId: Long): Flow<FollowedShowsWatchStats>
 
     override suspend fun entriesWithNoPendingAction(): List<FollowedShowEntry> {
         return entriesWithPendingAction(PendingAction.NOTHING)

--- a/data/db-room/src/main/java/app/tivi/data/daos/RoomWatchedShowDao.kt
+++ b/data/db-room/src/main/java/app/tivi/data/daos/RoomWatchedShowDao.kt
@@ -18,8 +18,14 @@ package app.tivi.data.daos
 
 import androidx.room.Dao
 import androidx.room.Query
+import androidx.room.RewriteQueriesToDropUnusedColumns
 import androidx.room.Transaction
+import app.cash.paging.PagingSource
+import app.tivi.data.compoundmodels.UpNextEntry
+import app.tivi.data.models.Season
+import app.tivi.data.models.TiviShow
 import app.tivi.data.models.WatchedShowEntry
+import app.tivi.data.views.ShowsWatchStats
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -38,6 +44,54 @@ abstract class RoomWatchedShowDao : WatchedShowDao, RoomEntityDao<WatchedShowEnt
 
     @Query("DELETE FROM watched_entries")
     abstract override suspend fun deleteAll()
+
+    @Transaction
+    @RewriteQueriesToDropUnusedColumns
+    @Query(
+        """
+        SELECT shows_next_to_watch.* FROM shows_next_to_watch
+        LEFT JOIN shows_last_watched ON shows_last_watched.show_id = shows_next_to_watch.show_id
+        LEFT JOIN episode_watch_entries ON episode_watch_entries.episode_id = shows_last_watched.episode_id
+        GROUP BY shows_next_to_watch.show_id
+        ORDER BY datetime(episode_watch_entries.watched_at) DESC
+        """,
+    )
+    abstract override fun pagedUpNextShowsLastWatched(): PagingSource<Int, UpNextEntry>
+
+    @Transaction
+    @RewriteQueriesToDropUnusedColumns
+    @Query(
+        """
+        SELECT shows_next_to_watch.* FROM shows_next_to_watch
+        INNER JOIN episodes ON episodes.id = shows_next_to_watch.episode_id
+        GROUP BY shows_next_to_watch.show_id
+        ORDER BY datetime(episodes.first_aired) DESC
+        """,
+    )
+    abstract override fun pagedUpNextShowsDateAired(): PagingSource<Int, UpNextEntry>
+
+    @Transaction
+    @RewriteQueriesToDropUnusedColumns
+    @Query("SELECT * FROM shows_next_to_watch")
+    abstract override suspend fun getUpNextShows(): List<UpNextEntry>
+
+    @Query("SELECT * FROM shows_view_watch_stats WHERE show_id = :showId")
+    abstract override fun entryShowViewStats(showId: Long): Flow<ShowsWatchStats>
+
+    @Transaction
+    @Query(
+        """
+        SELECT shows.* FROM shows
+            INNER JOIN seasons AS s ON s.show_id = shows.id
+			INNER JOIN shows_next_to_watch AS next ON next.show_id = shows.id
+			INNER JOIN episodes AS eps ON eps.season_id = s.id
+            INNER JOIN episode_watch_entries AS ew ON ew.episode_id = eps.id
+            WHERE s.number != ${Season.NUMBER_SPECIALS} AND s.ignored = 0
+			ORDER BY datetime(ew.watched_at) DESC
+			LIMIT 1
+        """,
+    )
+    abstract override fun observeNextShowToWatch(): Flow<TiviShow?>
 
     companion object {
         private const val ENTRY_QUERY_ORDER_LAST_WATCHED = """

--- a/data/db-room/src/main/java/app/tivi/data/daos/RoomWatchedShowDao.kt
+++ b/data/db-room/src/main/java/app/tivi/data/daos/RoomWatchedShowDao.kt
@@ -52,11 +52,13 @@ abstract class RoomWatchedShowDao : WatchedShowDao, RoomEntityDao<WatchedShowEnt
         SELECT shows_next_to_watch.* FROM shows_next_to_watch
         LEFT JOIN shows_last_watched ON shows_last_watched.show_id = shows_next_to_watch.show_id
         LEFT JOIN episode_watch_entries ON episode_watch_entries.episode_id = shows_last_watched.episode_id
+        LEFT JOIN myshows_entries ON shows_next_to_watch.show_id = myshows_entries.show_id
+        WHERE :followedOnly = 0 OR myshows_entries.id IS NOT NULL
         GROUP BY shows_next_to_watch.show_id
         ORDER BY datetime(episode_watch_entries.watched_at) DESC
         """,
     )
-    abstract override fun pagedUpNextShowsLastWatched(): PagingSource<Int, UpNextEntry>
+    abstract override fun pagedUpNextShowsLastWatched(followedOnly: Boolean): PagingSource<Int, UpNextEntry>
 
     @Transaction
     @RewriteQueriesToDropUnusedColumns
@@ -64,11 +66,13 @@ abstract class RoomWatchedShowDao : WatchedShowDao, RoomEntityDao<WatchedShowEnt
         """
         SELECT shows_next_to_watch.* FROM shows_next_to_watch
         INNER JOIN episodes ON episodes.id = shows_next_to_watch.episode_id
+        LEFT JOIN myshows_entries ON shows_next_to_watch.show_id = myshows_entries.show_id
+        WHERE :followedOnly = 0 OR myshows_entries.id IS NOT NULL
         GROUP BY shows_next_to_watch.show_id
         ORDER BY datetime(episodes.first_aired) DESC
         """,
     )
-    abstract override fun pagedUpNextShowsDateAired(): PagingSource<Int, UpNextEntry>
+    abstract override fun pagedUpNextShowsDateAired(followedOnly: Boolean): PagingSource<Int, UpNextEntry>
 
     @Transaction
     @RewriteQueriesToDropUnusedColumns

--- a/data/db/src/main/java/app/tivi/data/daos/FollowedShowsDao.kt
+++ b/data/db/src/main/java/app/tivi/data/daos/FollowedShowsDao.kt
@@ -16,39 +16,22 @@
 
 package app.tivi.data.daos
 
-import app.cash.paging.PagingSource
 import app.tivi.data.compoundmodels.FollowedShowEntryWithShow
-import app.tivi.data.compoundmodels.UpNextEntry
 import app.tivi.data.models.FollowedShowEntry
 import app.tivi.data.models.PendingAction
-import app.tivi.data.views.FollowedShowsWatchStats
 import kotlinx.coroutines.flow.Flow
 
 interface FollowedShowsDao : EntryDao<FollowedShowEntry, FollowedShowEntryWithShow> {
 
     suspend fun entries(): List<FollowedShowEntry>
 
-    fun observeNextShowToWatch(): Flow<FollowedShowEntryWithShow?>
-
-    fun pagedUpNextShowsLastWatched(): PagingSource<Int, UpNextEntry>
-
-    fun pagedUpNextShowsDateAired(): PagingSource<Int, UpNextEntry>
-
-    fun pagedUpNextShowsDateAdded(): PagingSource<Int, UpNextEntry>
-
-    suspend fun getUpNextShows(): List<UpNextEntry>
-
     override suspend fun deleteAll()
-
-    suspend fun entryWithId(id: Long): FollowedShowEntryWithShow?
 
     suspend fun entryWithShowId(showId: Long): FollowedShowEntry?
 
     fun entryCountWithShowIdNotPendingDeleteObservable(showId: Long): Flow<Int>
 
     suspend fun entryCountWithShowId(showId: Long): Int
-
-    fun entryShowViewStats(showId: Long): Flow<FollowedShowsWatchStats>
 
     suspend fun entriesWithNoPendingAction(): List<FollowedShowEntry>
 

--- a/data/db/src/main/java/app/tivi/data/daos/WatchedShowDao.kt
+++ b/data/db/src/main/java/app/tivi/data/daos/WatchedShowDao.kt
@@ -34,9 +34,9 @@ interface WatchedShowDao : EntryDao<WatchedShowEntry, WatchedShowEntryWithShow> 
 
     override suspend fun deleteAll()
 
-    fun pagedUpNextShowsLastWatched(): PagingSource<Int, UpNextEntry>
+    fun pagedUpNextShowsLastWatched(followedOnly: Boolean = false): PagingSource<Int, UpNextEntry>
 
-    fun pagedUpNextShowsDateAired(): PagingSource<Int, UpNextEntry>
+    fun pagedUpNextShowsDateAired(followedOnly: Boolean = false): PagingSource<Int, UpNextEntry>
 
     suspend fun getUpNextShows(): List<UpNextEntry>
 

--- a/data/db/src/main/java/app/tivi/data/daos/WatchedShowDao.kt
+++ b/data/db/src/main/java/app/tivi/data/daos/WatchedShowDao.kt
@@ -16,8 +16,12 @@
 
 package app.tivi.data.daos
 
+import app.cash.paging.PagingSource
+import app.tivi.data.compoundmodels.UpNextEntry
 import app.tivi.data.compoundmodels.WatchedShowEntryWithShow
+import app.tivi.data.models.TiviShow
 import app.tivi.data.models.WatchedShowEntry
+import app.tivi.data.views.ShowsWatchStats
 import kotlinx.coroutines.flow.Flow
 
 interface WatchedShowDao : EntryDao<WatchedShowEntry, WatchedShowEntryWithShow> {
@@ -29,4 +33,14 @@ interface WatchedShowDao : EntryDao<WatchedShowEntry, WatchedShowEntryWithShow> 
     fun entriesObservable(): Flow<List<WatchedShowEntry>>
 
     override suspend fun deleteAll()
+
+    fun pagedUpNextShowsLastWatched(): PagingSource<Int, UpNextEntry>
+
+    fun pagedUpNextShowsDateAired(): PagingSource<Int, UpNextEntry>
+
+    suspend fun getUpNextShows(): List<UpNextEntry>
+
+    fun entryShowViewStats(showId: Long): Flow<ShowsWatchStats>
+
+    fun observeNextShowToWatch(): Flow<TiviShow?>
 }

--- a/data/episodes/src/main/java/app/tivi/data/episodes/SeasonsEpisodesRepository.kt
+++ b/data/episodes/src/main/java/app/tivi/data/episodes/SeasonsEpisodesRepository.kt
@@ -37,6 +37,7 @@ import kotlin.time.Duration.Companion.hours
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -85,7 +86,7 @@ class SeasonsEpisodesRepository(
     }
 
     fun observeEpisode(episodeId: Long): Flow<EpisodeWithSeason> {
-        return episodesDao.episodeWithIdObservable(episodeId)
+        return episodesDao.episodeWithIdObservable(episodeId).filterNotNull()
     }
 
     suspend fun getEpisode(episodeId: Long): Episode? {
@@ -161,7 +162,9 @@ class SeasonsEpisodesRepository(
             traktEpisodeDataSource.getEpisode(season.showId, season.number!!, local.number!!)
         }
         val tmdbDeferred = async {
-            tmdbEpisodeDataSource.getEpisode(season.showId, season.number!!, local.number!!)
+            runCatching {
+                tmdbEpisodeDataSource.getEpisode(season.showId, season.number!!, local.number!!)
+            }.getOrNull()
         }
 
         val trakt = try {

--- a/data/followedshows/src/main/java/app/tivi/data/followedshows/FollowedShowsRepository.kt
+++ b/data/followedshows/src/main/java/app/tivi/data/followedshows/FollowedShowsRepository.kt
@@ -16,7 +16,6 @@
 
 package app.tivi.data.followedshows
 
-import app.tivi.data.compoundmodels.FollowedShowEntryWithShow
 import app.tivi.data.daos.FollowedShowsDao
 import app.tivi.data.daos.TiviShowDao
 import app.tivi.data.daos.getIdOrSavePlaceholder
@@ -25,7 +24,6 @@ import app.tivi.data.models.PendingAction
 import app.tivi.data.util.ItemSyncerResult
 import app.tivi.data.util.inPast
 import app.tivi.data.util.syncerForEntity
-import app.tivi.data.views.FollowedShowsWatchStats
 import app.tivi.inject.ApplicationScope
 import app.tivi.trakt.TraktAuthState
 import app.tivi.trakt.TraktManager
@@ -56,17 +54,9 @@ class FollowedShowsRepository(
         logger = logger,
     )
 
-    fun observeShowViewStats(showId: Long): Flow<FollowedShowsWatchStats?> {
-        return followedShowsDao.entryShowViewStats(showId)
-    }
-
     fun observeIsShowFollowed(showId: Long): Flow<Boolean> {
         return followedShowsDao.entryCountWithShowIdNotPendingDeleteObservable(showId)
             .map { it > 0 }
-    }
-
-    fun observeNextShowToWatch(): Flow<FollowedShowEntryWithShow?> {
-        return followedShowsDao.observeNextShowToWatch()
     }
 
     suspend fun isShowFollowed(showId: Long): Boolean {

--- a/data/models/src/main/java/app/tivi/data/compoundmodels/FollowedShowEntryWithShow.kt
+++ b/data/models/src/main/java/app/tivi/data/compoundmodels/FollowedShowEntryWithShow.kt
@@ -20,7 +20,6 @@ import androidx.room.Embedded
 import androidx.room.Relation
 import app.tivi.data.models.FollowedShowEntry
 import app.tivi.data.models.TiviShow
-import app.tivi.data.views.FollowedShowsWatchStats
 import java.util.Objects
 
 class FollowedShowEntryWithShow : EntryWithShow<FollowedShowEntry> {
@@ -30,20 +29,13 @@ class FollowedShowEntryWithShow : EntryWithShow<FollowedShowEntry> {
     @Relation(parentColumn = "show_id", entityColumn = "id")
     override lateinit var relations: List<TiviShow>
 
-    @Suppress("PropertyName")
-    @Relation(parentColumn = "id", entityColumn = "id")
-    lateinit var _stats: List<FollowedShowsWatchStats>
-
-    val stats: FollowedShowsWatchStats?
-        get() = _stats.firstOrNull()
-
     override fun equals(other: Any?): Boolean = when {
         other === this -> true
         other is FollowedShowEntryWithShow -> {
-            entry == other.entry && relations == other.relations && stats == other.stats
+            entry == other.entry && relations == other.relations
         }
         else -> false
     }
 
-    override fun hashCode(): Int = Objects.hash(entry, relations, stats)
+    override fun hashCode(): Int = Objects.hash(entry, relations)
 }

--- a/data/models/src/main/java/app/tivi/data/compoundmodels/LibraryShow.kt
+++ b/data/models/src/main/java/app/tivi/data/compoundmodels/LibraryShow.kt
@@ -19,10 +19,9 @@ package app.tivi.data.compoundmodels
 import androidx.room.Embedded
 import androidx.room.Ignore
 import androidx.room.Relation
-import app.tivi.data.models.FollowedShowEntry
 import app.tivi.data.models.TiviShow
 import app.tivi.data.models.WatchedShowEntry
-import app.tivi.data.views.FollowedShowsWatchStats
+import app.tivi.data.views.ShowsWatchStats
 
 @Suppress("PropertyName")
 class LibraryShow {
@@ -30,22 +29,16 @@ class LibraryShow {
     lateinit var show: TiviShow
 
     @Relation(parentColumn = "id", entityColumn = "show_id")
-    lateinit var _followedEntities: List<FollowedShowEntry>
-
-    @Relation(parentColumn = "id", entityColumn = "show_id")
     lateinit var _watchedEntities: List<WatchedShowEntry>
 
     @Relation(parentColumn = "id", entityColumn = "show_id")
-    lateinit var _stats: List<FollowedShowsWatchStats>
-
-    @get:Ignore
-    val followedEntity: FollowedShowEntry? get() = _followedEntities.firstOrNull()
+    lateinit var _stats: List<ShowsWatchStats>
 
     @get:Ignore
     val watchedEntry: WatchedShowEntry? get() = _watchedEntities.firstOrNull()
 
     @get:Ignore
-    val stats: FollowedShowsWatchStats? get() = _stats.firstOrNull()
+    val stats: ShowsWatchStats? get() = _stats.firstOrNull()
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -54,7 +47,6 @@ class LibraryShow {
         other as LibraryShow
 
         if (show != other.show) return false
-        if (_followedEntities != other._followedEntities) return false
         if (_watchedEntities != other._watchedEntities) return false
         if (_stats != other._stats) return false
 
@@ -63,7 +55,6 @@ class LibraryShow {
 
     override fun hashCode(): Int {
         var result = show.hashCode()
-        result = 31 * result + _followedEntities.hashCode()
         result = 31 * result + _watchedEntities.hashCode()
         result = 31 * result + _stats.hashCode()
         return result

--- a/data/models/src/main/java/app/tivi/data/compoundmodels/UpNextEntry.kt
+++ b/data/models/src/main/java/app/tivi/data/compoundmodels/UpNextEntry.kt
@@ -22,12 +22,12 @@ import androidx.room.Relation
 import app.tivi.data.models.Episode
 import app.tivi.data.models.Season
 import app.tivi.data.models.TiviShow
-import app.tivi.data.views.FollowedShowsNextToWatch
+import app.tivi.data.views.ShowsNextToWatch
 import app.tivi.extensions.unsafeLazy
 
 class UpNextEntry {
     @Embedded
-    lateinit var entity: FollowedShowsNextToWatch
+    lateinit var entity: ShowsNextToWatch
 
     @Relation(parentColumn = "show_id", entityColumn = "id")
     lateinit var _show: List<TiviShow>

--- a/data/models/src/main/java/app/tivi/data/views/ShowsNextToWatch.kt
+++ b/data/models/src/main/java/app/tivi/data/views/ShowsNextToWatch.kt
@@ -21,29 +21,27 @@ import androidx.room.DatabaseView
 import app.tivi.data.models.Season
 
 @DatabaseView(
-    viewName = "followed_next_to_watch",
+    viewName = "shows_next_to_watch",
     value = """
         SELECT
-          fs.show_id AS show_id,
-          s.id AS season_id,
+          shows.id as show_id,
+          seasons.id AS season_id,
           eps.id AS episode_id,
-          MIN((1000 * s.number) + eps.number) AS next_ep_to_watch_abs_number
-        FROM
-          myshows_entries as fs
-          INNER JOIN seasons AS s ON fs.show_id = s.show_id
-          INNER JOIN episodes AS eps ON eps.season_id = s.id
-          LEFT JOIN episode_watch_entries as ew ON ew.episode_id = eps.id
-          LEFT JOIN followed_last_watched AS lw ON lw.id = fs.id
-        WHERE
-          s.number != ${Season.NUMBER_SPECIALS}
-          AND s.ignored = 0
+          MIN((1000 * seasons.number) + eps.number) AS next_ep_to_watch_abs_number
+        FROM shows
+        INNER JOIN seasons ON shows.id = seasons.show_id
+        INNER JOIN episodes AS eps ON eps.season_id = seasons.id
+        LEFT JOIN episode_watch_entries as ew ON ew.episode_id = eps.id
+        LEFT JOIN shows_last_watched AS lw ON lw.show_id = shows.id
+        WHERE seasons.number != ${Season.NUMBER_SPECIALS}
+          AND seasons.ignored = 0
           AND watched_at IS NULL
-          AND datetime(first_aired) < datetime('now')
-          AND ((1000 * s.number) + eps.number) > coalesce(last_watched_abs_number, 0)
-        GROUP BY fs.id
+          AND datetime(eps.first_aired) < datetime('now')
+          AND ((1000 * seasons.number) + eps.number) > coalesce(last_watched_abs_number, 0)
+        GROUP BY shows.id
     """,
 )
-data class FollowedShowsNextToWatch(
+data class ShowsNextToWatch(
     @ColumnInfo(name = "show_id") val showId: Long,
     @ColumnInfo(name = "season_id") val seasonId: Long,
     @ColumnInfo(name = "episode_id") val episodeId: Long,

--- a/data/test/src/test/java/app/tivi/utils/TiviTestDatabase.kt
+++ b/data/test/src/test/java/app/tivi/utils/TiviTestDatabase.kt
@@ -35,9 +35,9 @@ import app.tivi.data.models.TiviShow
 import app.tivi.data.models.TraktUser
 import app.tivi.data.models.TrendingShowEntry
 import app.tivi.data.models.WatchedShowEntry
-import app.tivi.data.views.FollowedShowsLastWatched
-import app.tivi.data.views.FollowedShowsNextToWatch
-import app.tivi.data.views.FollowedShowsWatchStats
+import app.tivi.data.views.ShowsLastWatched
+import app.tivi.data.views.ShowsNextToWatch
+import app.tivi.data.views.ShowsWatchStats
 
 @Database(
     entities = [
@@ -57,9 +57,9 @@ import app.tivi.data.views.FollowedShowsWatchStats
         FakeTiviShowFts::class,
     ],
     views = [
-        FollowedShowsWatchStats::class,
-        FollowedShowsLastWatched::class,
-        FollowedShowsNextToWatch::class,
+        ShowsWatchStats::class,
+        ShowsLastWatched::class,
+        ShowsNextToWatch::class,
     ],
     version = 1,
     exportSchema = false,

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateShowSeasons.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateShowSeasons.kt
@@ -17,7 +17,6 @@
 package app.tivi.domain.interactors
 
 import app.tivi.data.episodes.SeasonsEpisodesRepository
-import app.tivi.data.followedshows.FollowedShowsRepository
 import app.tivi.domain.Interactor
 import app.tivi.domain.interactors.UpdateShowSeasons.Params
 import app.tivi.util.AppCoroutineDispatchers
@@ -28,24 +27,19 @@ import me.tatarka.inject.annotations.Inject
 @Inject
 class UpdateShowSeasons(
     private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
-    private val followedShowsRepository: FollowedShowsRepository,
     private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<Params>() {
     override suspend fun doWork(params: Params) {
         withContext(dispatchers.io) {
-            if (followedShowsRepository.isShowFollowed(params.showId)) {
-                // Then update the seasons/episodes
-                if (params.forceRefresh || seasonsEpisodesRepository.needShowSeasonsUpdate(params.showId)) {
-                    seasonsEpisodesRepository.updateSeasonsEpisodes(params.showId)
-                }
+            // Then update the seasons/episodes
+            if (params.forceRefresh || seasonsEpisodesRepository.needShowSeasonsUpdate(params.showId)) {
+                seasonsEpisodesRepository.updateSeasonsEpisodes(params.showId)
+            }
 
-                ensureActive()
-                // Finally update any watched progress
-                if (params.forceRefresh || seasonsEpisodesRepository.needShowEpisodeWatchesSync(params.showId)) {
-                    seasonsEpisodesRepository.syncEpisodeWatchesForShow(params.showId)
-                }
-            } else {
-                seasonsEpisodesRepository.removeShowSeasonData(params.showId)
+            ensureActive()
+            // Finally update any watched progress
+            if (params.forceRefresh || seasonsEpisodesRepository.needShowEpisodeWatchesSync(params.showId)) {
+                seasonsEpisodesRepository.syncEpisodeWatchesForShow(params.showId)
             }
         }
     }

--- a/domain/src/main/java/app/tivi/domain/interactors/UpdateUpNextEpisodes.kt
+++ b/domain/src/main/java/app/tivi/domain/interactors/UpdateUpNextEpisodes.kt
@@ -16,7 +16,7 @@
 
 package app.tivi.domain.interactors
 
-import app.tivi.data.daos.FollowedShowsDao
+import app.tivi.data.daos.WatchedShowDao
 import app.tivi.data.episodes.SeasonsEpisodesRepository
 import app.tivi.domain.Interactor
 import app.tivi.util.AppCoroutineDispatchers
@@ -26,7 +26,7 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class UpdateUpNextEpisodes(
-    private val followedShowsDao: FollowedShowsDao,
+    private val watchedShowsDao: WatchedShowDao,
     private val seasonEpisodeRepository: SeasonsEpisodesRepository,
     private val updateLibraryShows: UpdateLibraryShows,
     private val dispatchers: AppCoroutineDispatchers,
@@ -39,7 +39,7 @@ class UpdateUpNextEpisodes(
 
         // Now update the next episodes, to fetch images, etc
         withContext(dispatchers.io) {
-            followedShowsDao.getUpNextShows().parallelForEach { entry ->
+            watchedShowsDao.getUpNextShows().parallelForEach { entry ->
                 if (seasonEpisodeRepository.needEpisodeUpdate(entry.episode.id)) {
                     seasonEpisodeRepository.updateEpisode(entry.episode.id)
                 }

--- a/domain/src/main/java/app/tivi/domain/observers/ObserveNextShowEpisodeToWatch.kt
+++ b/domain/src/main/java/app/tivi/domain/observers/ObserveNextShowEpisodeToWatch.kt
@@ -17,8 +17,8 @@
 package app.tivi.domain.observers
 
 import app.tivi.data.compoundmodels.EpisodeWithSeasonWithShow
+import app.tivi.data.daos.WatchedShowDao
 import app.tivi.data.episodes.SeasonsEpisodesRepository
-import app.tivi.data.followedshows.FollowedShowsRepository
 import app.tivi.domain.SubjectInteractor
 import app.tivi.extensions.flatMapLatestNullable
 import app.tivi.extensions.mapNullable
@@ -27,14 +27,14 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class ObserveNextShowEpisodeToWatch(
-    private val followedShowsRepository: FollowedShowsRepository,
+    private val watchedShowDao: WatchedShowDao,
     private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
 ) : SubjectInteractor<Unit, EpisodeWithSeasonWithShow?>() {
 
     override fun createObservable(params: Unit): Flow<EpisodeWithSeasonWithShow?> {
-        return followedShowsRepository.observeNextShowToWatch().flatMapLatestNullable { nextShow ->
-            seasonsEpisodesRepository.observeNextEpisodeToWatch(nextShow.entry.showId).mapNullable {
-                EpisodeWithSeasonWithShow(it.episode!!, it.season!!, nextShow.show)
+        return watchedShowDao.observeNextShowToWatch().flatMapLatestNullable { nextShow ->
+            seasonsEpisodesRepository.observeNextEpisodeToWatch(nextShow.id).mapNullable {
+                EpisodeWithSeasonWithShow(it.episode!!, it.season!!, nextShow)
             }
         }
     }

--- a/domain/src/main/java/app/tivi/domain/observers/ObservePagedUpNextShows.kt
+++ b/domain/src/main/java/app/tivi/domain/observers/ObservePagedUpNextShows.kt
@@ -35,13 +35,14 @@ class ObservePagedUpNextShows(
         params: Parameters,
     ): Flow<PagingData<UpNextEntry>> = Pager(config = params.pagingConfig) {
         when (params.sort) {
-            SortOption.AIR_DATE -> watchedShowsDao.pagedUpNextShowsDateAired()
-            else -> watchedShowsDao.pagedUpNextShowsLastWatched()
+            SortOption.AIR_DATE -> watchedShowsDao.pagedUpNextShowsDateAired(params.followedOnly)
+            else -> watchedShowsDao.pagedUpNextShowsLastWatched(params.followedOnly)
         }
     }.flow
 
     data class Parameters(
         val sort: SortOption,
+        val followedOnly: Boolean,
         override val pagingConfig: PagingConfig,
     ) : PagingInteractor.Parameters<UpNextEntry>
 }

--- a/domain/src/main/java/app/tivi/domain/observers/ObservePagedUpNextShows.kt
+++ b/domain/src/main/java/app/tivi/domain/observers/ObservePagedUpNextShows.kt
@@ -20,7 +20,7 @@ import app.cash.paging.Pager
 import app.cash.paging.PagingConfig
 import app.cash.paging.PagingData
 import app.tivi.data.compoundmodels.UpNextEntry
-import app.tivi.data.daos.FollowedShowsDao
+import app.tivi.data.daos.WatchedShowDao
 import app.tivi.data.models.SortOption
 import app.tivi.domain.PagingInteractor
 import kotlinx.coroutines.flow.Flow
@@ -28,16 +28,15 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class ObservePagedUpNextShows(
-    private val followedShowsDao: FollowedShowsDao,
+    private val watchedShowsDao: WatchedShowDao,
 ) : PagingInteractor<ObservePagedUpNextShows.Parameters, UpNextEntry>() {
 
     override fun createObservable(
         params: Parameters,
     ): Flow<PagingData<UpNextEntry>> = Pager(config = params.pagingConfig) {
         when (params.sort) {
-            SortOption.AIR_DATE -> followedShowsDao.pagedUpNextShowsDateAired()
-            SortOption.DATE_ADDED -> followedShowsDao.pagedUpNextShowsDateAdded()
-            else -> followedShowsDao.pagedUpNextShowsLastWatched()
+            SortOption.AIR_DATE -> watchedShowsDao.pagedUpNextShowsDateAired()
+            else -> watchedShowsDao.pagedUpNextShowsLastWatched()
         }
     }.flow
 

--- a/domain/src/main/java/app/tivi/domain/observers/ObserveShowViewStats.kt
+++ b/domain/src/main/java/app/tivi/domain/observers/ObserveShowViewStats.kt
@@ -16,19 +16,19 @@
 
 package app.tivi.domain.observers
 
-import app.tivi.data.followedshows.FollowedShowsRepository
-import app.tivi.data.views.FollowedShowsWatchStats
+import app.tivi.data.daos.WatchedShowDao
+import app.tivi.data.views.ShowsWatchStats
 import app.tivi.domain.SubjectInteractor
 import kotlinx.coroutines.flow.Flow
 import me.tatarka.inject.annotations.Inject
 
 @Inject
 class ObserveShowViewStats(
-    private val repository: FollowedShowsRepository,
-) : SubjectInteractor<ObserveShowViewStats.Params, FollowedShowsWatchStats?>() {
+    private val dao: WatchedShowDao,
+) : SubjectInteractor<ObserveShowViewStats.Params, ShowsWatchStats?>() {
 
-    override fun createObservable(params: Params): Flow<FollowedShowsWatchStats?> {
-        return repository.observeShowViewStats(params.showId)
+    override fun createObservable(params: Params): Flow<ShowsWatchStats?> {
+        return dao.entryShowViewStats(params.showId)
     }
 
     data class Params(val showId: Long)

--- a/ui/show/details/src/main/java/app/tivi/showdetails/details/ShowDetails.kt
+++ b/ui/show/details/src/main/java/app/tivi/showdetails/details/ShowDetails.kt
@@ -132,7 +132,7 @@ import app.tivi.data.models.Season
 import app.tivi.data.models.ShowStatus
 import app.tivi.data.models.ShowTmdbImage
 import app.tivi.data.models.TiviShow
-import app.tivi.data.views.FollowedShowsWatchStats
+import app.tivi.data.views.ShowsWatchStats
 import kotlinx.datetime.Instant
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
@@ -302,7 +302,7 @@ private fun ShowDetailsScrollingContent(
     relatedShows: List<RelatedShowEntryWithShow>,
     nextEpisodeToWatch: EpisodeWithSeason?,
     seasons: List<SeasonWithEpisodesAndWatches>,
-    watchStats: FollowedShowsWatchStats?,
+    watchStats: ShowsWatchStats?,
     listState: LazyListState,
     openShowDetails: (showId: Long) -> Unit,
     openEpisodeDetails: (episodeId: Long) -> Unit,

--- a/ui/show/details/src/main/java/app/tivi/showdetails/details/ShowDetailsViewState.kt
+++ b/ui/show/details/src/main/java/app/tivi/showdetails/details/ShowDetailsViewState.kt
@@ -22,7 +22,7 @@ import app.tivi.data.compoundmodels.EpisodeWithSeason
 import app.tivi.data.compoundmodels.RelatedShowEntryWithShow
 import app.tivi.data.compoundmodels.SeasonWithEpisodesAndWatches
 import app.tivi.data.models.TiviShow
-import app.tivi.data.views.FollowedShowsWatchStats
+import app.tivi.data.views.ShowsWatchStats
 
 @Immutable
 data class ShowDetailsViewState(
@@ -30,7 +30,7 @@ data class ShowDetailsViewState(
     val show: TiviShow = TiviShow.EMPTY_SHOW,
     val relatedShows: List<RelatedShowEntryWithShow> = emptyList(),
     val nextEpisodeToWatch: EpisodeWithSeason? = null,
-    val watchStats: FollowedShowsWatchStats? = null,
+    val watchStats: ShowsWatchStats? = null,
     val seasons: List<SeasonWithEpisodesAndWatches> = emptyList(),
     val refreshing: Boolean = false,
     val message: UiMessage? = null,

--- a/ui/upnext/src/main/java/app/tivi/home/upnext/UpNext.kt
+++ b/ui/upnext/src/main/java/app/tivi/home/upnext/UpNext.kt
@@ -18,6 +18,7 @@
 
 package app.tivi.home.upnext
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -37,6 +38,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
@@ -44,6 +46,7 @@ import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.Card
 import androidx.compose.material3.DismissValue
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -133,6 +136,7 @@ internal fun UpNext(
         openUser = openUser,
         refresh = viewModel::refresh,
         onSortSelected = viewModel::setSort,
+        onToggleFollowedShowsOnly = viewModel::toggleFollowedShowsOnly,
     )
 }
 
@@ -147,6 +151,7 @@ internal fun UpNext(
     refresh: () -> Unit,
     openUser: () -> Unit,
     onSortSelected: (SortOption) -> Unit,
+    onToggleFollowedShowsOnly: () -> Unit,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -229,6 +234,24 @@ internal fun UpNext(
                             .padding(vertical = 8.dp, horizontal = 8.dp)
                             .fillMaxWidth(),
                     ) {
+                        FilterChip(
+                            selected = state.followedShowsOnly,
+                            leadingIcon = {
+                                AnimatedVisibility(visible = state.followedShowsOnly) {
+                                    Icon(
+                                        imageVector = Icons.Default.Done,
+                                        contentDescription = null,
+                                    )
+                                }
+                            },
+                            onClick = onToggleFollowedShowsOnly,
+                            label = {
+                                Text(text = stringResource(UiR.string.upnext_filter_followed_shows_only_title))
+                            },
+                        )
+
+                        Spacer(modifier = Modifier.weight(1f))
+
                         SortChip(
                             sortOptions = state.availableSorts,
                             currentSortOption = state.sort,

--- a/ui/upnext/src/main/java/app/tivi/home/upnext/UpNextViewModel.kt
+++ b/ui/upnext/src/main/java/app/tivi/home/upnext/UpNextViewModel.kt
@@ -30,6 +30,8 @@ import app.tivi.domain.interactors.UpdateUpNextEpisodes
 import app.tivi.domain.observers.ObservePagedUpNextShows
 import app.tivi.domain.observers.ObserveTraktAuthState
 import app.tivi.domain.observers.ObserveUserDetails
+import app.tivi.extensions.combine
+import app.tivi.settings.TiviPreferences
 import app.tivi.trakt.TraktAuthState
 import app.tivi.util.Logger
 import app.tivi.util.ObservableLoadingCounter
@@ -38,7 +40,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -53,6 +54,7 @@ class UpNextViewModel(
     observeTraktAuthState: ObserveTraktAuthState,
     observeUserDetails: ObserveUserDetails,
     private val getTraktAuthState: GetTraktAuthState,
+    private val preferences: TiviPreferences,
     private val logger: Logger,
 ) : ViewModel() {
     private val loadingState = ObservableLoadingCounter()
@@ -68,13 +70,17 @@ class UpNextViewModel(
 
     private val sort = MutableStateFlow(SortOption.LAST_WATCHED)
 
+    private val followedOnly = preferences.observeUpNextFollowedOnly()
+        .stateIn(viewModelScope, WhileSubscribed(), false)
+
     val state: StateFlow<UpNextViewState> = combine(
         loadingState.observable,
         observeTraktAuthState.flow,
         observeUserDetails.flow,
         sort,
         uiMessageManager.message,
-    ) { loading, authState, user, sort, message ->
+        followedOnly,
+    ) { loading, authState, user, sort, message, followedShowsOnly ->
         UpNextViewState(
             user = user,
             authState = authState,
@@ -82,6 +88,7 @@ class UpNextViewModel(
             availableSorts = availableSorts,
             sort = sort,
             message = message,
+            followedShowsOnly = followedShowsOnly,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -103,6 +110,10 @@ class UpNextViewModel(
             .filter { it == TraktAuthState.LOGGED_IN }
             .onEach { refresh(false) }
             .launchIn(viewModelScope)
+
+        followedOnly
+            .onEach { updateDataSource() }
+            .launchIn(viewModelScope)
     }
 
     private fun updateDataSource() {
@@ -110,6 +121,7 @@ class UpNextViewModel(
             ObservePagedUpNextShows.Parameters(
                 sort = sort.value,
                 pagingConfig = PAGING_CONFIG,
+                followedOnly = preferences.upNextFollowedOnly,
             ),
         )
     }
@@ -134,6 +146,10 @@ class UpNextViewModel(
         viewModelScope.launch {
             uiMessageManager.clearMessage(id)
         }
+    }
+
+    fun toggleFollowedShowsOnly() {
+        preferences.upNextFollowedOnly = !preferences.upNextFollowedOnly
     }
 
     companion object {

--- a/ui/upnext/src/main/java/app/tivi/home/upnext/UpNextViewModel.kt
+++ b/ui/upnext/src/main/java/app/tivi/home/upnext/UpNextViewModel.kt
@@ -64,7 +64,6 @@ class UpNextViewModel(
     private val availableSorts = listOf(
         SortOption.LAST_WATCHED,
         SortOption.AIR_DATE,
-        SortOption.DATE_ADDED,
     )
 
     private val sort = MutableStateFlow(SortOption.LAST_WATCHED)

--- a/ui/upnext/src/main/java/app/tivi/home/upnext/UpNextViewState.kt
+++ b/ui/upnext/src/main/java/app/tivi/home/upnext/UpNextViewState.kt
@@ -28,6 +28,7 @@ data class UpNextViewState(
     val availableSorts: List<SortOption> = emptyList(),
     val sort: SortOption = SortOption.LAST_WATCHED,
     val message: UiMessage? = null,
+    val followedShowsOnly: Boolean = false,
 ) {
     companion object {
         val Empty = UpNextViewState()


### PR DESCRIPTION
This PR changes the fundamental feature of what a followed show actually. Previous to this PR, it controlled most of of the features in the app (such as syncing episode data, etc). Now being a followed show is similar to what of metadata, and will in the future control things like notifications.

I will add a 'followed only' filter to Up Next, but that can wait for now.