### PR TITLE
Fix list position restoration

### DIFF
--- a/common/ui/compose/src/main/java/app/tivi/common/compose/EntryGrid.kt
+++ b/common/ui/compose/src/main/java/app/tivi/common/compose/EntryGrid.kt
@@ -142,6 +142,7 @@ fun <E : Entry> EntryGrid(
             val gutter = Layout.gutter
 
             LazyVerticalGrid(
+                state = rememberLazyGridState(lazyPagingItems.itemCount == 0),
                 columns = GridCells.Fixed((columns / 1.5).roundToInt()),
                 contentPadding = paddingValues +
                     PaddingValues(horizontal = bodyMargin, vertical = gutter),

--- a/common/ui/compose/src/main/java/app/tivi/common/compose/LazyPagingExtensions.kt
+++ b/common/ui/compose/src/main/java/app/tivi/common/compose/LazyPagingExtensions.kt
@@ -16,6 +16,10 @@
 
 package app.tivi.common.compose
 
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.paging.CombinedLoadStates
 import androidx.paging.LoadState
 import app.tivi.api.UiMessage
@@ -33,4 +37,37 @@ fun CombinedLoadStates.prependErrorOrNull(): UiMessage? {
 fun CombinedLoadStates.refreshErrorOrNull(): UiMessage? {
     return (refresh.takeIf { it is LoadState.Error } as? LoadState.Error)
         ?.let { UiMessage(it.error) }
+}
+
+/*
+ * The following are workarounds for https://issuetracker.google.com/issues/177245496.
+ *
+ * Due to the way which paging loads data, it will always result in an initial empty state,
+ * and then the loaded items. That conflicts with the way which rememberLazyListState() and
+ * friends store their state, as they rely on the items being present at the time of
+ * (Android) state restoration. To workaround this, we use a different LazyListState while the
+ * lazy paging items are empty, and then switcheroo to the standard state once we know we have the
+ * items available.
+ */
+
+@Composable
+fun rememberLazyListState(empty: Boolean = false): LazyListState {
+    return if (empty) {
+        // Return a different state instance
+        remember { LazyListState(0, 0) }
+    } else {
+        // Return restored state
+        androidx.compose.foundation.lazy.rememberLazyListState()
+    }
+}
+
+@Composable
+fun rememberLazyGridState(empty: Boolean = false): LazyGridState {
+    return if (empty) {
+        // Return a different state instance
+        remember { LazyGridState(0, 0) }
+    } else {
+        // Return restored state
+        androidx.compose.foundation.lazy.grid.rememberLazyGridState()
+    }
 }

--- a/ui/library/src/main/java/app/tivi/home/library/Library.kt
+++ b/ui/library/src/main/java/app/tivi/home/library/Library.kt
@@ -82,6 +82,7 @@ import app.tivi.common.compose.LocalTiviTextCreator
 import app.tivi.common.compose.bodyWidth
 import app.tivi.common.compose.fullSpanItem
 import app.tivi.common.compose.items
+import app.tivi.common.compose.rememberLazyGridState
 import app.tivi.common.compose.ui.PosterCard
 import app.tivi.common.compose.ui.SearchTextField
 import app.tivi.common.compose.ui.SortChip
@@ -127,7 +128,7 @@ internal fun Library(
 
     Library(
         state = viewState,
-        list = pagingItems,
+        lazyPagingItems = pagingItems,
         openShowDetails = openShowDetails,
         onMessageShown = viewModel::clearMessage,
         onToggleIncludeFollowedShows = viewModel::toggleFollowedShowsIncluded,
@@ -143,7 +144,7 @@ internal fun Library(
 @Composable
 internal fun Library(
     state: LibraryViewState,
-    list: LazyPagingItems<LibraryShow>,
+    lazyPagingItems: LazyPagingItems<LibraryShow>,
     openShowDetails: (showId: Long) -> Unit,
     onMessageShown: (id: Long) -> Unit,
     onToggleIncludeFollowedShows: () -> Unit,
@@ -216,6 +217,7 @@ internal fun Library(
             var filterExpanded by remember { mutableStateOf(false) }
 
             LazyVerticalGrid(
+                state = rememberLazyGridState(lazyPagingItems.itemCount == 0),
                 columns = GridCells.Fixed(columns / 4),
                 contentPadding = paddingValues + PaddingValues(
                     horizontal = (bodyMargin - 8.dp).coerceAtLeast(0.dp),
@@ -250,7 +252,7 @@ internal fun Library(
                                     filter = value
                                     onFilterChanged(value.text)
                                 },
-                                hint = stringResource(UiR.string.filter_shows, list.itemCount),
+                                hint = stringResource(UiR.string.filter_shows, lazyPagingItems.itemCount),
                                 modifier = Modifier.fillMaxWidth(),
                                 showClearButton = true,
                                 onCleared = {
@@ -304,7 +306,7 @@ internal fun Library(
                 }
 
                 items(
-                    items = list,
+                    items = lazyPagingItems,
                     key = { it.show.id },
                 ) { entry ->
                     if (entry != null) {

--- a/ui/upnext/src/main/java/app/tivi/home/upnext/UpNext.kt
+++ b/ui/upnext/src/main/java/app/tivi/home/upnext/UpNext.kt
@@ -79,6 +79,7 @@ import app.tivi.common.compose.LocalTiviTextCreator
 import app.tivi.common.compose.bodyWidth
 import app.tivi.common.compose.fullSpanItem
 import app.tivi.common.compose.items
+import app.tivi.common.compose.rememberLazyGridState
 import app.tivi.common.compose.ui.AsyncImage
 import app.tivi.common.compose.ui.SortChip
 import app.tivi.common.compose.ui.TiviStandardAppBar
@@ -134,7 +135,7 @@ internal fun UpNext(
 
     UpNext(
         state = viewState,
-        list = pagingItems,
+        lazyPagingItems = pagingItems,
         openShowDetails = openShowDetails,
         openTrackEpisode = openTrackEpisode,
         onMessageShown = viewModel::clearMessage,
@@ -149,7 +150,7 @@ internal fun UpNext(
 @Composable
 internal fun UpNext(
     state: UpNextViewState,
-    list: LazyPagingItems<UpNextEntry>,
+    lazyPagingItems: LazyPagingItems<UpNextEntry>,
     openShowDetails: (showId: Long, seasonId: Long, episodeId: Long) -> Unit,
     openTrackEpisode: (episodeId: Long) -> Unit,
     onMessageShown: (id: Long) -> Unit,
@@ -219,6 +220,7 @@ internal fun UpNext(
             val gutter = Layout.gutter
 
             LazyVerticalGrid(
+                state = rememberLazyGridState(lazyPagingItems.itemCount == 0),
                 columns = GridCells.Fixed(columns / 4),
                 contentPadding = paddingValues + PaddingValues(
                     horizontal = (bodyMargin - 8.dp).coerceAtLeast(0.dp),
@@ -266,7 +268,7 @@ internal fun UpNext(
                 }
 
                 items(
-                    items = list,
+                    items = lazyPagingItems,
                     key = { it.show.id },
                 ) { entry ->
                     if (entry != null) {


### PR DESCRIPTION
Contains a workaround for  https://issuetracker.google.com/issues/177245496.

Due to the way which paging loads data, it will always result in an initial empty state, and then the loaded items. That conflicts with the way which rememberLazyListState() and friends store their state, as they rely on the items being present at the time of (Android) state restoration. To workaround this, we use a different LazyListState while the lazy paging items are empty, and then switcheroo to the standard state once we know we have the items available.