### PR TITLE
Fixes around Play Services Block Store

### DIFF
--- a/data/traktauth/src/androidMain/kotlin/app/tivi/data/traktauth/store/BlockStoreAuthStore.kt
+++ b/data/traktauth/src/androidMain/kotlin/app/tivi/data/traktauth/store/BlockStoreAuthStore.kt
@@ -20,6 +20,8 @@ import android.app.Application
 import app.tivi.data.traktauth.AppAuthAuthStateWrapper
 import app.tivi.data.traktauth.AuthState
 import com.google.android.gms.auth.blockstore.Blockstore
+import com.google.android.gms.auth.blockstore.BlockstoreClient
+import com.google.android.gms.auth.blockstore.RetrieveBytesRequest
 import com.google.android.gms.auth.blockstore.StoreBytesData
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
@@ -27,7 +29,6 @@ import kotlinx.coroutines.tasks.await
 import me.tatarka.inject.annotations.Inject
 
 @Inject
-@Suppress("DEPRECATION") // We need to wait for Play Services update to rollout
 class BlockStoreAuthStore(
     private val context: Application,
 ) : AuthStore {
@@ -38,28 +39,52 @@ class BlockStoreAuthStore(
             .isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS
 
     override suspend fun get(): AuthState? = runCatching {
-        client.retrieveBytes()
-            .await()
-            .decodeToString()
-            .let(::AppAuthAuthStateWrapper)
+        // For new clients, we store using our app's key
+        // The old version of the BlockStore used an implicit key,
+        // so we need to check for that too
+        get(TRAKT_AUTH_KEY) ?: get(BlockstoreClient.DEFAULT_BYTES_DATA_KEY)?.also {
+            // Clear out any saved state, and save it to our app's key
+            clear()
+            save(it)
+        }
     }.getOrNull()
 
     override suspend fun save(state: AuthState) {
-        val data = StoreBytesData.Builder()
-            .setShouldBackupToCloud(false)
-            .setBytes(state.serializeToJson().encodeToByteArray())
-            .build()
-
-        client.storeBytes(data).await()
+        save(TRAKT_AUTH_KEY, state.serializeToJson().encodeToByteArray())
     }
 
     override suspend fun clear() {
+        val zero = ByteArray(0)
+        save(TRAKT_AUTH_KEY, zero)
+        save(BlockstoreClient.DEFAULT_BYTES_DATA_KEY, zero)
+    }
+
+    private suspend fun get(key: String): AuthState? {
+        val response = client.retrieveBytes(
+            RetrieveBytesRequest.Builder()
+                .setKeys(listOf(key))
+                .build(),
+        ).await()
+
+        return response.blockstoreDataMap[key]
+            ?.bytes
+            ?.decodeToString()
+            ?.let(::AppAuthAuthStateWrapper)
+    }
+
+    private suspend fun save(key: String, bytes: ByteArray) {
         val data = StoreBytesData.Builder()
-            .setBytes(ByteArray(0))
+            .setShouldBackupToCloud(false)
+            .setKey(key)
+            .setBytes(bytes)
             .build()
 
         client.storeBytes(data).await()
     }
 
     override suspend fun isAvailable(): Boolean = playServicesAvailable
+
+    private companion object {
+        const val TRAKT_AUTH_KEY = "app.tivi.blockstore.trakt_auth"
+    }
 }


### PR DESCRIPTION
- Re-merge change to migrate from deprecated APIs
- Add stricter API availability checks to avoid crashes on devices with older versions of Play Services
