### PR TITLE
Fix package name declaration

### DIFF
--- a/core/base/src/commonMain/kotlin/app/tivi/animations/Lerp.kt
+++ b/core/base/src/commonMain/kotlin/app/tivi/animations/Lerp.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package app.tivi.ui.animations
+package app.tivi.animations
 
 fun lerp(
     startValue: Float,


### PR DESCRIPTION
The Kotlin file `Lerp` under the `:core:base` module had a wrong package name declaration.

There were no usages of the method declared here, so there wasn't necessary any other refactoring.