### PR TITLE
Disable Gradle configuration caching for now

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,9 @@ org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx3072m -Dfile.encoding=UTF-8
 
 # https://docs.gradle.org/7.6/userguide/configuration_cache.html
-org.gradle.unsafe.configuration-cache=true
+# Disabled due to KMP plugin. Should be fixed in Kotlin 1.9:
+#   https://youtrack.jetbrains.com/issue/KT-49933/Support-Gradle-Configuration-caching-with-HMPP
+org.gradle.unsafe.configuration-cache=false
 
 # AndroidX
 android.useAndroidX=true


### PR DESCRIPTION
Can't use it due to an incompatability with Kotlin 1.8 and Gradle 8.1