### PR TITLE
Add Compose Compiler to libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,6 +101,9 @@ compose-ui-uitextfonts = { module = "androidx.compose.ui:ui-text-google-fonts" }
 compose-ui-util = { module = "androidx.compose.ui:ui-util" }
 compose-ui-viewbinding = { module = "androidx.compose.ui:ui-viewbinding" }
 
+# This isn't strictly used, but allows Renovate to see us using the Compose Compiler artifact
+compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "composecompiler" }
+
 google-firebase-analytics = "com.google.firebase:firebase-analytics-ktx:21.2.2"
 google-firebase-crashlytics = "com.google.firebase:firebase-crashlytics-ktx:18.3.6"
 


### PR DESCRIPTION
This should allow Renovate to detect our Compose Compiler version