### PR TITLE
Remove extra ProGuard rules for Okhttp

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -45,10 +45,6 @@
 
 -renamesourcefileattribute SourceFile
 
--dontwarn org.conscrypt.**
--dontwarn org.bouncycastle.**
--dontwarn org.openjsse.**
-
 # Dagger
 -dontwarn com.google.errorprone.annotations.*
 


### PR DESCRIPTION
These rule are bundled in Okhttp 4.11.0 for now.