### PR TITLE
Add ktlint to libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -128,6 +128,9 @@ kotlin-extensions = { module = "org.jetbrains.kotlin:kotlin-android-extensions",
 kotlininject-compiler = { module = "me.tatarka.inject:kotlin-inject-compiler-ksp", version.ref = "kotlininject" }
 kotlininject-runtime = { module = "me.tatarka.inject:kotlin-inject-runtime", version.ref = "kotlininject" }
 
+# This isn't strictly used, but allows Renovate to see us using the ktlint artifact
+ktlint = { module = "com.pinterest:ktlint", version.ref = "ktlint" }
+
 leakCanary = "com.squareup.leakcanary:leakcanary-android:2.10"
 
 mockK = "io.mockk:mockk:1.13.5"


### PR DESCRIPTION
Much like the trick with the Compose Compiler we can do the same with ktlint to allow Renovate to update.