### PR TITLE
Migrate ViewModel implementations to be composable backed

### DIFF
--- a/common/ui/compose/src/main/java/app/tivi/common/compose/EntryGrid.kt
+++ b/common/ui/compose/src/main/java/app/tivi/common/compose/EntryGrid.kt
@@ -70,7 +70,7 @@ import kotlin.math.roundToInt
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun <E : Entry> EntryGrid(
-    lazyPagingItems: LazyPagingItems<out EntryWithShow<E>>,
+    lazyPagingItems: LazyPagingItems<EntryWithShow<E>>,
     title: String,
     onNavigateUp: () -> Unit,
     onOpenShowDetails: (Long) -> Unit,

--- a/ui/account/src/main/java/app/tivi/account/AccountUi.kt
+++ b/ui/account/src/main/java/app/tivi/account/AccountUi.kt
@@ -41,7 +41,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -86,13 +85,13 @@ internal fun AccountUi(
     openSettings: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val viewState by viewModel.state.collectAsState()
+    val viewState = viewModel.presenter()
 
     AccountUi(
         viewState = viewState,
         openSettings = openSettings,
-        login = viewModel::login,
-        logout = viewModel::logout,
+        login = { viewState.eventSink(AccountUiViewState.AccountUiEvent.Login) },
+        logout = { viewState.eventSink(AccountUiViewState.AccountUiEvent.Logout) },
         modifier = modifier,
     )
 }

--- a/ui/account/src/main/java/app/tivi/account/AccountUi.kt
+++ b/ui/account/src/main/java/app/tivi/account/AccountUi.kt
@@ -90,8 +90,8 @@ internal fun AccountUi(
     AccountUi(
         viewState = viewState,
         openSettings = openSettings,
-        login = { viewState.eventSink(AccountUiViewState.AccountUiEvent.Login) },
-        logout = { viewState.eventSink(AccountUiViewState.AccountUiEvent.Logout) },
+        login = { viewState.eventSink(AccountUiEvent.Login) },
+        logout = { viewState.eventSink(AccountUiEvent.Logout) },
         modifier = modifier,
     )
 }

--- a/ui/account/src/main/java/app/tivi/account/AccountUiViewModel.kt
+++ b/ui/account/src/main/java/app/tivi/account/AccountUiViewModel.kt
@@ -57,8 +57,8 @@ class AccountUiViewModel(
             authState = authState,
         ) { event ->
             when (event) {
-                AccountUiViewState.AccountUiEvent.Login -> loginToTraktInteractor.launch()
-                AccountUiViewState.AccountUiEvent.Logout -> {
+                AccountUiEvent.Login -> loginToTraktInteractor.launch()
+                AccountUiEvent.Logout -> {
                     scope.launch {
                         traktAuthRepository.clearAuth()
                         clearUserDetails(ClearUserDetails.Params("me")).collect()

--- a/ui/account/src/main/java/app/tivi/account/AccountUiViewModel.kt
+++ b/ui/account/src/main/java/app/tivi/account/AccountUiViewModel.kt
@@ -16,18 +16,19 @@
 
 package app.tivi.account
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import app.tivi.data.traktauth.LoginToTraktInteractor
 import app.tivi.data.traktauth.TraktAuthRepository
+import app.tivi.data.traktauth.TraktAuthState
 import app.tivi.domain.interactors.ClearUserDetails
 import app.tivi.domain.observers.ObserveTraktAuthState
 import app.tivi.domain.observers.ObserveUserDetails
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Inject
 
@@ -35,40 +36,35 @@ import me.tatarka.inject.annotations.Inject
 class AccountUiViewModel(
     private val traktAuthRepository: TraktAuthRepository,
     private val loginToTraktInteractor: LoginToTraktInteractor,
-    observeTraktAuthState: ObserveTraktAuthState,
-    observeUserDetails: ObserveUserDetails,
+    private val observeTraktAuthState: ObserveTraktAuthState,
+    private val observeUserDetails: ObserveUserDetails,
     private val clearUserDetails: ClearUserDetails,
 ) : ViewModel() {
 
-    val state: StateFlow<AccountUiViewState> = combine(
-        observeTraktAuthState.flow,
-        observeUserDetails.flow,
-    ) { authState, user ->
-        AccountUiViewState(
+    @Composable
+    fun presenter(): AccountUiViewState {
+        val user by observeUserDetails.flow.collectAsState(null)
+        val authState by observeTraktAuthState.flow.collectAsState(TraktAuthState.LOGGED_OUT)
+        val scope = rememberCoroutineScope()
+
+        LaunchedEffect(Unit) {
+            observeTraktAuthState(Unit)
+            observeUserDetails(ObserveUserDetails.Params("me"))
+        }
+
+        return AccountUiViewState(
             user = user,
             authState = authState,
-        )
-    }.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(),
-        initialValue = AccountUiViewState.Empty,
-    )
-
-    init {
-        observeTraktAuthState(Unit)
-        observeUserDetails(ObserveUserDetails.Params("me"))
-    }
-
-    fun logout() {
-        viewModelScope.launch {
-            traktAuthRepository.clearAuth()
-            clearUserDetails(ClearUserDetails.Params("me")).collect()
-        }
-    }
-
-    fun login() {
-        viewModelScope.launch {
-            loginToTraktInteractor.launch()
+        ) { event ->
+            when (event) {
+                AccountUiViewState.AccountUiEvent.Login -> loginToTraktInteractor.launch()
+                AccountUiViewState.AccountUiEvent.Logout -> {
+                    scope.launch {
+                        traktAuthRepository.clearAuth()
+                        clearUserDetails(ClearUserDetails.Params("me")).collect()
+                    }
+                }
+            }
         }
     }
 }

--- a/ui/account/src/main/java/app/tivi/account/AccountUiViewState.kt
+++ b/ui/account/src/main/java/app/tivi/account/AccountUiViewState.kt
@@ -24,8 +24,10 @@ import app.tivi.data.traktauth.TraktAuthState
 data class AccountUiViewState(
     val user: TraktUser? = null,
     val authState: TraktAuthState = TraktAuthState.LOGGED_OUT,
+    val eventSink: (AccountUiEvent) -> Unit,
 ) {
-    companion object {
-        val Empty = AccountUiViewState()
+    sealed interface AccountUiEvent {
+        object Login : AccountUiEvent
+        object Logout : AccountUiEvent
     }
 }

--- a/ui/account/src/main/java/app/tivi/account/AccountUiViewState.kt
+++ b/ui/account/src/main/java/app/tivi/account/AccountUiViewState.kt
@@ -25,9 +25,9 @@ data class AccountUiViewState(
     val user: TraktUser? = null,
     val authState: TraktAuthState = TraktAuthState.LOGGED_OUT,
     val eventSink: (AccountUiEvent) -> Unit,
-) {
-    sealed interface AccountUiEvent {
-        object Login : AccountUiEvent
-        object Logout : AccountUiEvent
-    }
+)
+
+sealed interface AccountUiEvent {
+    object Login : AccountUiEvent
+    object Logout : AccountUiEvent
 }

--- a/ui/discover/src/main/java/app/tivi/home/discover/Discover.kt
+++ b/ui/discover/src/main/java/app/tivi/home/discover/Discover.kt
@@ -62,7 +62,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDismissState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -128,17 +127,17 @@ internal fun Discover(
     openShowDetails: (showId: Long, seasonId: Long?, episodeId: Long?) -> Unit,
     openUser: () -> Unit,
 ) {
-    val viewState by viewModel.state.collectAsState()
+    val viewState = viewModel.presenter()
 
     Discover(
         state = viewState,
-        refresh = viewModel::refresh,
+        refresh = { viewState.eventSink(DiscoverUiEvent.Refresh(true)) },
         openUser = openUser,
         openShowDetails = openShowDetails,
         openTrendingShows = openTrendingShows,
         openRecommendedShows = openRecommendedShows,
         openPopularShows = openPopularShows,
-        onMessageShown = viewModel::clearMessage,
+        onMessageShown = { viewState.eventSink(DiscoverUiEvent.ClearMessage(it)) },
     )
 }
 
@@ -222,7 +221,7 @@ internal fun Discover(
                     Spacer(Modifier.height(Layout.gutter))
                 }
 
-                state.nextEpisodeWithShowToWatched?.let { nextEpisodeToWatch ->
+                state.nextEpisodeWithShowToWatch?.let { nextEpisodeToWatch ->
                     item {
                         NextEpisodeToWatch(
                             show = nextEpisodeToWatch.show,

--- a/ui/discover/src/main/java/app/tivi/home/discover/DiscoverViewState.kt
+++ b/ui/discover/src/main/java/app/tivi/home/discover/DiscoverViewState.kt
@@ -35,13 +35,15 @@ data class DiscoverViewState(
     val popularRefreshing: Boolean = false,
     val recommendedItems: List<RecommendedEntryWithShow> = emptyList(),
     val recommendedRefreshing: Boolean = false,
-    val nextEpisodeWithShowToWatched: EpisodeWithSeasonWithShow? = null,
+    val nextEpisodeWithShowToWatch: EpisodeWithSeasonWithShow? = null,
     val message: UiMessage? = null,
+    val eventSink: (DiscoverUiEvent) -> Unit,
 ) {
     val refreshing: Boolean
         get() = trendingRefreshing || popularRefreshing || recommendedRefreshing
+}
 
-    companion object {
-        val Empty = DiscoverViewState()
-    }
+sealed interface DiscoverUiEvent {
+    data class Refresh(val fromUser: Boolean = false) : DiscoverUiEvent
+    data class ClearMessage(val id: Long) : DiscoverUiEvent
 }

--- a/ui/episode/details/src/main/java/app/tivi/episodedetails/EpisodeDetailsViewModel.kt
+++ b/ui/episode/details/src/main/java/app/tivi/episodedetails/EpisodeDetailsViewModel.kt
@@ -16,9 +16,14 @@
 
 package app.tivi.episodedetails
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import app.tivi.api.UiMessageManager
 import app.tivi.domain.interactors.RemoveEpisodeWatch
 import app.tivi.domain.interactors.RemoveEpisodeWatches
@@ -28,10 +33,6 @@ import app.tivi.domain.observers.ObserveEpisodeWatches
 import app.tivi.util.Logger
 import app.tivi.util.ObservableLoadingCounter
 import app.tivi.util.collectStatus
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
@@ -40,71 +41,74 @@ import me.tatarka.inject.annotations.Inject
 class EpisodeDetailsViewModel(
     @Assisted savedStateHandle: SavedStateHandle,
     private val updateEpisodeDetails: UpdateEpisodeDetails,
-    observeEpisodeDetails: ObserveEpisodeDetails,
-    observeEpisodeWatches: ObserveEpisodeWatches,
+    private val observeEpisodeDetails: ObserveEpisodeDetails,
+    private val observeEpisodeWatches: ObserveEpisodeWatches,
     private val removeEpisodeWatches: RemoveEpisodeWatches,
     private val removeEpisodeWatch: RemoveEpisodeWatch,
     private val logger: Logger,
 ) : ViewModel() {
     private val episodeId: Long = savedStateHandle["episodeId"]!!
 
-    private val loadingState = ObservableLoadingCounter()
-    private val uiMessageManager = UiMessageManager()
+    @Composable
+    fun presenter(): EpisodeDetailsViewState {
+        val scope = rememberCoroutineScope()
 
-    val state: StateFlow<EpisodeDetailsViewState> = combine(
-        observeEpisodeDetails.flow,
-        observeEpisodeWatches.flow,
-        loadingState.observable,
-        uiMessageManager.message,
-    ) { episodeDetails, episodeWatches, refreshing, message ->
-        EpisodeDetailsViewState(
-            episode = episodeDetails.episode,
-            season = episodeDetails.season,
+        val loadingState = remember { ObservableLoadingCounter() }
+        val uiMessageManager = remember { UiMessageManager() }
+
+        val refreshing by loadingState.observable.collectAsState(false)
+        val message by uiMessageManager.message.collectAsState(null)
+
+        val episodeDetails by observeEpisodeDetails.flow.collectAsState(null)
+        val episodeWatches by observeEpisodeWatches.flow.collectAsState(emptyList())
+
+        fun eventSink(event: EpisodeDetailsUiEvent) = when (event) {
+            is EpisodeDetailsUiEvent.Refresh -> {
+                scope.launch {
+                    updateEpisodeDetails(
+                        UpdateEpisodeDetails.Params(episodeId, event.fromUser),
+                    ).collectStatus(loadingState, logger, uiMessageManager)
+                }
+            }
+
+            is EpisodeDetailsUiEvent.ClearMessage -> {
+                scope.launch {
+                    uiMessageManager.clearMessage(event.id)
+                }
+            }
+
+            EpisodeDetailsUiEvent.RemoveAllWatches -> {
+                scope.launch {
+                    removeEpisodeWatches(
+                        RemoveEpisodeWatches.Params(episodeId),
+                    ).collectStatus(loadingState, logger, uiMessageManager)
+                }
+            }
+
+            is EpisodeDetailsUiEvent.RemoveWatchEntry -> {
+                scope.launch {
+                    removeEpisodeWatch(
+                        RemoveEpisodeWatch.Params(event.id),
+                    ).collectStatus(loadingState, logger, uiMessageManager)
+                }
+            }
+        }
+
+        LaunchedEffect(Unit) {
+            observeEpisodeDetails(ObserveEpisodeDetails.Params(episodeId))
+            observeEpisodeWatches(ObserveEpisodeWatches.Params(episodeId))
+
+            eventSink(EpisodeDetailsUiEvent.Refresh(fromUser = false))
+        }
+
+        return EpisodeDetailsViewState(
+            episode = episodeDetails?.episode,
+            season = episodeDetails?.season,
             watches = episodeWatches,
-            canAddEpisodeWatch = episodeDetails.episode.hasAired,
+            canAddEpisodeWatch = episodeDetails?.episode?.hasAired ?: false,
             refreshing = refreshing,
             message = message,
+            eventSink = ::eventSink,
         )
-    }.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(),
-        initialValue = EpisodeDetailsViewState.Empty,
-    )
-
-    init {
-        observeEpisodeDetails(ObserveEpisodeDetails.Params(episodeId))
-        observeEpisodeWatches(ObserveEpisodeWatches.Params(episodeId))
-
-        refresh(false)
-    }
-
-    fun refresh(fromUserInteraction: Boolean = true) {
-        viewModelScope.launch {
-            updateEpisodeDetails(
-                UpdateEpisodeDetails.Params(episodeId, fromUserInteraction),
-            ).collectStatus(loadingState, logger, uiMessageManager)
-        }
-    }
-
-    fun removeWatchEntry(watchId: Long) {
-        viewModelScope.launch {
-            removeEpisodeWatch(
-                RemoveEpisodeWatch.Params(watchId),
-            ).collectStatus(loadingState, logger, uiMessageManager)
-        }
-    }
-
-    fun removeAllWatches() {
-        viewModelScope.launch {
-            removeEpisodeWatches(
-                RemoveEpisodeWatches.Params(episodeId),
-            ).collectStatus(loadingState, logger, uiMessageManager)
-        }
-    }
-
-    fun clearMessage(id: Long) {
-        viewModelScope.launch {
-            uiMessageManager.clearMessage(id)
-        }
     }
 }

--- a/ui/episode/details/src/main/java/app/tivi/episodedetails/EpisodeDetailsViewState.kt
+++ b/ui/episode/details/src/main/java/app/tivi/episodedetails/EpisodeDetailsViewState.kt
@@ -30,8 +30,12 @@ data class EpisodeDetailsViewState(
     val canAddEpisodeWatch: Boolean = false,
     val refreshing: Boolean = false,
     val message: UiMessage? = null,
-) {
-    companion object {
-        val Empty = EpisodeDetailsViewState()
-    }
+    val eventSink: (EpisodeDetailsUiEvent) -> Unit,
+)
+
+sealed interface EpisodeDetailsUiEvent {
+    data class Refresh(val fromUser: Boolean = false) : EpisodeDetailsUiEvent
+    data class RemoveWatchEntry(val id: Long) : EpisodeDetailsUiEvent
+    data class ClearMessage(val id: Long) : EpisodeDetailsUiEvent
+    object RemoveAllWatches : EpisodeDetailsUiEvent
 }

--- a/ui/episode/track/src/main/java/app/tivi/episode/track/EpisodeTrack.kt
+++ b/ui/episode/track/src/main/java/app/tivi/episode/track/EpisodeTrack.kt
@@ -91,7 +91,14 @@ internal fun EpisodeTrack(
         viewState = viewState,
         navigateUp = navigateUp,
         onSubmit = { viewState.eventSink(EpisodeTrackUiEvent.Submit) },
-        onNowSelected = { viewState.eventSink(EpisodeTrackUiEvent.SelectNow) },
+        onNowSelected = { selected ->
+            viewState.eventSink(
+                when {
+                    selected -> EpisodeTrackUiEvent.SelectNow
+                    else -> EpisodeTrackUiEvent.UnselectNow
+                },
+            )
+        },
         onSetFirstAired = { viewState.eventSink(EpisodeTrackUiEvent.SelectFirstAired) },
         onDateSelected = { viewState.eventSink(EpisodeTrackUiEvent.SelectDate(it)) },
         onTimeSelected = { viewState.eventSink(EpisodeTrackUiEvent.SelectTime(it)) },

--- a/ui/episode/track/src/main/java/app/tivi/episode/track/EpisodeTrack.kt
+++ b/ui/episode/track/src/main/java/app/tivi/episode/track/EpisodeTrack.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:Suppress("UNUSED_PARAMETER")
-
 package app.tivi.episode.track
 
 import androidx.compose.animation.AnimatedVisibility
@@ -43,8 +41,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDismissState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -90,17 +86,16 @@ internal fun EpisodeTrack(
     viewModel: EpisodeTrackViewModel,
     navigateUp: () -> Unit,
 ) {
-    val viewState by viewModel.state.collectAsState()
+    val viewState = viewModel.presenter()
     EpisodeTrack(
         viewState = viewState,
         navigateUp = navigateUp,
-        refresh = viewModel::refresh,
-        onSubmit = viewModel::submitWatch,
-        onNowSelected = viewModel::selectNow,
-        onSetFirstAired = viewModel::selectEpisodeFirstAired,
-        onDateSelected = viewModel::selectDate,
-        onTimeSelected = viewModel::selectTime,
-        onMessageShown = viewModel::clearMessage,
+        onSubmit = { viewState.eventSink(EpisodeTrackUiEvent.Submit) },
+        onNowSelected = { viewState.eventSink(EpisodeTrackUiEvent.SelectNow) },
+        onSetFirstAired = { viewState.eventSink(EpisodeTrackUiEvent.SelectFirstAired) },
+        onDateSelected = { viewState.eventSink(EpisodeTrackUiEvent.SelectDate(it)) },
+        onTimeSelected = { viewState.eventSink(EpisodeTrackUiEvent.SelectTime(it)) },
+        onMessageShown = { viewState.eventSink(EpisodeTrackUiEvent.ClearMessage(it)) },
     )
 }
 
@@ -109,7 +104,6 @@ internal fun EpisodeTrack(
 internal fun EpisodeTrack(
     viewState: EpisodeTrackViewState,
     navigateUp: () -> Unit,
-    refresh: () -> Unit,
     onSubmit: () -> Unit,
     onNowSelected: (Boolean) -> Unit,
     onDateSelected: (LocalDate) -> Unit,

--- a/ui/episode/track/src/main/java/app/tivi/episode/track/EpisodeTrackViewModel.kt
+++ b/ui/episode/track/src/main/java/app/tivi/episode/track/EpisodeTrackViewModel.kt
@@ -17,6 +17,7 @@
 package app.tivi.episode.track
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -117,6 +118,10 @@ class EpisodeTrackViewModel(
                     selectedNow = true
                 }
 
+                EpisodeTrackUiEvent.UnselectNow -> {
+                    selectedNow = false
+                }
+
                 is EpisodeTrackUiEvent.SelectTime -> {
                     selectedTime = event.time
                 }
@@ -144,6 +149,11 @@ class EpisodeTrackViewModel(
                     }
                 }
             }
+        }
+
+        LaunchedEffect(Unit) {
+            observeEpisodeDetails(ObserveEpisodeDetails.Params(episodeId))
+            eventSink(EpisodeTrackUiEvent.Refresh(false))
         }
 
         return EpisodeTrackViewState(

--- a/ui/episode/track/src/main/java/app/tivi/episode/track/EpisodeTrackViewState.kt
+++ b/ui/episode/track/src/main/java/app/tivi/episode/track/EpisodeTrackViewState.kt
@@ -48,6 +48,7 @@ sealed interface EpisodeTrackUiEvent {
     data class Refresh(val fromUser: Boolean = false) : EpisodeTrackUiEvent
     object Submit : EpisodeTrackUiEvent
     object SelectNow : EpisodeTrackUiEvent
+    object UnselectNow : EpisodeTrackUiEvent
     object SelectFirstAired : EpisodeTrackUiEvent
     data class SelectDate(val date: LocalDate) : EpisodeTrackUiEvent
     data class SelectTime(val time: LocalTime) : EpisodeTrackUiEvent

--- a/ui/episode/track/src/main/java/app/tivi/episode/track/EpisodeTrackViewState.kt
+++ b/ui/episode/track/src/main/java/app/tivi/episode/track/EpisodeTrackViewState.kt
@@ -40,8 +40,16 @@ data class EpisodeTrackViewState(
     val selectedNow: Boolean = true,
 
     val shouldDismiss: Boolean = false,
-) {
-    companion object {
-        val Empty = EpisodeTrackViewState()
-    }
+
+    val eventSink: (EpisodeTrackUiEvent) -> Unit,
+)
+
+sealed interface EpisodeTrackUiEvent {
+    data class Refresh(val fromUser: Boolean = false) : EpisodeTrackUiEvent
+    object Submit : EpisodeTrackUiEvent
+    object SelectNow : EpisodeTrackUiEvent
+    object SelectFirstAired : EpisodeTrackUiEvent
+    data class SelectDate(val date: LocalDate) : EpisodeTrackUiEvent
+    data class SelectTime(val time: LocalTime) : EpisodeTrackUiEvent
+    data class ClearMessage(val id: Long) : EpisodeTrackUiEvent
 }

--- a/ui/library/src/main/java/app/tivi/home/library/LibraryViewState.kt
+++ b/ui/library/src/main/java/app/tivi/home/library/LibraryViewState.kt
@@ -16,12 +16,15 @@
 
 package app.tivi.home.library
 
+import androidx.paging.compose.LazyPagingItems
 import app.tivi.api.UiMessage
+import app.tivi.data.compoundmodels.LibraryShow
 import app.tivi.data.models.SortOption
 import app.tivi.data.models.TraktUser
 import app.tivi.data.traktauth.TraktAuthState
 
 data class LibraryViewState(
+    val items: LazyPagingItems<LibraryShow>,
     val user: TraktUser? = null,
     val authState: TraktAuthState = TraktAuthState.LOGGED_OUT,
     val isLoading: Boolean = false,
@@ -32,8 +35,14 @@ data class LibraryViewState(
     val message: UiMessage? = null,
     val followedShowsIncluded: Boolean = false,
     val watchedShowsIncluded: Boolean = false,
-) {
-    companion object {
-        val Empty = LibraryViewState()
-    }
+    val eventSink: (LibraryUiEvent) -> Unit,
+)
+
+sealed interface LibraryUiEvent {
+    data class ClearMessage(val id: Long) : LibraryUiEvent
+    data class Refresh(val fromUser: Boolean = false) : LibraryUiEvent
+    data class ChangeFilter(val filter: String?) : LibraryUiEvent
+    data class ChangeSort(val sort: SortOption) : LibraryUiEvent
+    object ToggleFollowedShowsIncluded : LibraryUiEvent
+    object ToggleWatchedShowsIncluded : LibraryUiEvent
 }

--- a/ui/popular/src/main/java/app/tivi/home/popular/Popular.kt
+++ b/ui/popular/src/main/java/app/tivi/home/popular/Popular.kt
@@ -17,7 +17,6 @@
 package app.tivi.home.popular
 
 import androidx.compose.runtime.Composable
-import androidx.paging.compose.collectAsLazyPagingItems
 import app.tivi.common.compose.EntryGrid
 import app.tivi.common.compose.viewModel
 import app.tivi.common.ui.resources.MR
@@ -50,8 +49,9 @@ internal fun PopularShows(
     openShowDetails: (showId: Long) -> Unit,
     navigateUp: () -> Unit,
 ) {
+    val viewState = viewModel.presenter()
     EntryGrid(
-        lazyPagingItems = viewModel.pagedList.collectAsLazyPagingItems(),
+        lazyPagingItems = viewState.items,
         title = stringResource(MR.strings.discover_popular_title),
         onOpenShowDetails = openShowDetails,
         onNavigateUp = navigateUp,

--- a/ui/popular/src/main/java/app/tivi/home/popular/PopularShowsViewModel.kt
+++ b/ui/popular/src/main/java/app/tivi/home/popular/PopularShowsViewModel.kt
@@ -16,26 +16,30 @@
 
 package app.tivi.home.popular
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingConfig
-import androidx.paging.PagingData
-import androidx.paging.cachedIn
-import app.tivi.data.compoundmodels.PopularEntryWithShow
+import androidx.paging.compose.collectAsLazyPagingItems
 import app.tivi.domain.observers.ObservePagedPopularShows
-import kotlinx.coroutines.flow.Flow
 import me.tatarka.inject.annotations.Inject
 
 @Inject
 class PopularShowsViewModel(
-    pagingInteractor: ObservePagedPopularShows,
+    private val pagingInteractor: ObservePagedPopularShows,
 ) : ViewModel() {
 
-    val pagedList: Flow<PagingData<PopularEntryWithShow>> =
-        pagingInteractor.flow.cachedIn(viewModelScope)
+    @Composable
+    fun presenter(): PopularViewState {
+        val items = pagingInteractor.flow.collectAsLazyPagingItems()
 
-    init {
-        pagingInteractor(ObservePagedPopularShows.Params(PAGING_CONFIG))
+        LaunchedEffect(Unit) {
+            pagingInteractor(ObservePagedPopularShows.Params(PAGING_CONFIG))
+        }
+
+        return PopularViewState(
+            items = items,
+        )
     }
 
     companion object {

--- a/ui/popular/src/main/java/app/tivi/home/popular/PopularViewState.kt
+++ b/ui/popular/src/main/java/app/tivi/home/popular/PopularViewState.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.tivi.home.popular
+
+import androidx.paging.compose.LazyPagingItems
+import app.tivi.data.compoundmodels.PopularEntryWithShow
+
+data class PopularViewState(
+    val items: LazyPagingItems<PopularEntryWithShow>,
+)

--- a/ui/recommended/src/main/java/app/tivi/home/recommended/Recommended.kt
+++ b/ui/recommended/src/main/java/app/tivi/home/recommended/Recommended.kt
@@ -52,7 +52,7 @@ internal fun RecommendedShows(
     val viewState = viewModel.presenter()
     EntryGrid(
         lazyPagingItems = viewState.items,
-        title = stringResource(MR.strings.discover_popular_title),
+        title = stringResource(MR.strings.discover_recommended_title),
         onOpenShowDetails = openShowDetails,
         onNavigateUp = navigateUp,
     )

--- a/ui/recommended/src/main/java/app/tivi/home/recommended/Recommended.kt
+++ b/ui/recommended/src/main/java/app/tivi/home/recommended/Recommended.kt
@@ -16,10 +16,7 @@
 
 package app.tivi.home.recommended
 
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.paging.compose.collectAsLazyPagingItems
 import app.tivi.common.compose.EntryGrid
 import app.tivi.common.compose.viewModel
 import app.tivi.common.ui.resources.MR
@@ -52,11 +49,11 @@ internal fun RecommendedShows(
     openShowDetails: (showId: Long) -> Unit,
     navigateUp: () -> Unit,
 ) {
+    val viewState = viewModel.presenter()
     EntryGrid(
-        lazyPagingItems = viewModel.pagedList.collectAsLazyPagingItems(),
-        title = stringResource(MR.strings.discover_recommended_title),
+        lazyPagingItems = viewState.items,
+        title = stringResource(MR.strings.discover_popular_title),
         onOpenShowDetails = openShowDetails,
         onNavigateUp = navigateUp,
-        modifier = Modifier.fillMaxSize(),
     )
 }

--- a/ui/recommended/src/main/java/app/tivi/home/recommended/RecommendedShowsViewModel.kt
+++ b/ui/recommended/src/main/java/app/tivi/home/recommended/RecommendedShowsViewModel.kt
@@ -16,25 +16,30 @@
 
 package app.tivi.home.recommended
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingConfig
-import androidx.paging.PagingData
-import androidx.paging.cachedIn
-import app.tivi.data.compoundmodels.RecommendedEntryWithShow
+import androidx.paging.compose.collectAsLazyPagingItems
 import app.tivi.domain.observers.ObservePagedRecommendedShows
-import kotlinx.coroutines.flow.Flow
 import me.tatarka.inject.annotations.Inject
 
 @Inject
 class RecommendedShowsViewModel(
-    pagingInteractor: ObservePagedRecommendedShows,
+    private val pagingInteractor: ObservePagedRecommendedShows,
 ) : ViewModel() {
-    val pagedList: Flow<PagingData<RecommendedEntryWithShow>> =
-        pagingInteractor.flow.cachedIn(viewModelScope)
 
-    init {
-        pagingInteractor(ObservePagedRecommendedShows.Params(PAGING_CONFIG))
+    @Composable
+    fun presenter(): RecommendedShowsViewState {
+        val items = pagingInteractor.flow.collectAsLazyPagingItems()
+
+        LaunchedEffect(Unit) {
+            pagingInteractor(ObservePagedRecommendedShows.Params(PAGING_CONFIG))
+        }
+
+        return RecommendedShowsViewState(
+            items = items,
+        )
     }
 
     companion object {

--- a/ui/recommended/src/main/java/app/tivi/home/recommended/RecommendedShowsViewState.kt
+++ b/ui/recommended/src/main/java/app/tivi/home/recommended/RecommendedShowsViewState.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.tivi.home.recommended
+
+import androidx.paging.compose.LazyPagingItems
+import app.tivi.data.compoundmodels.RecommendedEntryWithShow
+
+data class RecommendedShowsViewState(
+    val items: LazyPagingItems<RecommendedEntryWithShow>,
+)

--- a/ui/search/src/main/java/app/tivi/home/search/Search.kt
+++ b/ui/search/src/main/java/app/tivi/home/search/Search.kt
@@ -46,7 +46,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDismissState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -90,13 +89,12 @@ internal fun Search(
     viewModel: SearchViewModel,
     openShowDetails: (showId: Long) -> Unit,
 ) {
-    val viewState by viewModel.state.collectAsState()
-
+    val viewState = viewModel.presenter()
     Search(
         state = viewState,
         openShowDetails = openShowDetails,
-        onSearchQueryChanged = viewModel::search,
-        onMessageShown = viewModel::clearMessage,
+        onSearchQueryChanged = { viewState.eventSink(SearchUiEvent.UpdateQuery(it)) },
+        onMessageShown = { viewState.eventSink(SearchUiEvent.ClearMessage(it)) },
     )
 }
 

--- a/ui/search/src/main/java/app/tivi/home/search/SearchViewState.kt
+++ b/ui/search/src/main/java/app/tivi/home/search/SearchViewState.kt
@@ -24,8 +24,10 @@ data class SearchViewState(
     val searchResults: List<TiviShow> = emptyList(),
     val refreshing: Boolean = false,
     val message: UiMessage? = null,
-) {
-    companion object {
-        val Empty = SearchViewState()
-    }
+    val eventSink: (SearchUiEvent) -> Unit,
+)
+
+sealed interface SearchUiEvent {
+    data class ClearMessage(val id: Long) : SearchUiEvent
+    data class UpdateQuery(val query: String) : SearchUiEvent
 }

--- a/ui/show/details/src/main/java/app/tivi/showdetails/details/ShowDetails.kt
+++ b/ui/show/details/src/main/java/app/tivi/showdetails/details/ShowDetails.kt
@@ -83,7 +83,6 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberDismissState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -165,21 +164,21 @@ internal fun ShowDetails(
     openEpisodeDetails: (episodeId: Long) -> Unit,
     openSeasons: (showId: Long, seasonId: Long) -> Unit,
 ) {
-    val viewState by viewModel.state.collectAsState()
+    val viewState = viewModel.presenter()
     ShowDetails(
         viewState = viewState,
         navigateUp = navigateUp,
         openShowDetails = openShowDetails,
         openEpisodeDetails = openEpisodeDetails,
-        refresh = viewModel::refresh,
-        onMessageShown = viewModel::clearMessage,
+        refresh = { viewState.eventSink(ShowDetailsUiEvent.Refresh(true)) },
+        onMessageShown = { viewState.eventSink(ShowDetailsUiEvent.ClearMessage(it)) },
         openSeason = { openSeasons(viewState.show.id, it) },
-        onSeasonFollowed = { viewModel.setSeasonFollowed(it, true) },
-        onSeasonUnfollowed = { viewModel.setSeasonFollowed(it, false) },
-        unfollowPreviousSeasons = viewModel::unfollowPreviousSeasons,
-        onMarkSeasonWatched = { viewModel.setSeasonWatched(it, onlyAired = true) },
-        onMarkSeasonUnwatched = viewModel::setSeasonUnwatched,
-        onToggleShowFollowed = viewModel::toggleFollowShow,
+        onSeasonFollowed = { viewState.eventSink(ShowDetailsUiEvent.FollowSeason(it)) },
+        onSeasonUnfollowed = { viewState.eventSink(ShowDetailsUiEvent.UnfollowSeason(it)) },
+        unfollowPreviousSeasons = { viewState.eventSink(ShowDetailsUiEvent.UnfollowPreviousSeasons(it)) },
+        onMarkSeasonWatched = { viewState.eventSink(ShowDetailsUiEvent.MarkSeasonWatched(it, onlyAired = true)) },
+        onMarkSeasonUnwatched = { viewState.eventSink(ShowDetailsUiEvent.MarkSeasonUnwatched(it)) },
+        onToggleShowFollowed = { viewState.eventSink(ShowDetailsUiEvent.ToggleShowFollowed) },
     )
 }
 

--- a/ui/show/details/src/main/java/app/tivi/showdetails/details/ShowDetailsViewState.kt
+++ b/ui/show/details/src/main/java/app/tivi/showdetails/details/ShowDetailsViewState.kt
@@ -21,6 +21,7 @@ import app.tivi.api.UiMessage
 import app.tivi.data.compoundmodels.EpisodeWithSeason
 import app.tivi.data.compoundmodels.RelatedShowEntryWithShow
 import app.tivi.data.compoundmodels.SeasonWithEpisodesAndWatches
+import app.tivi.data.models.ActionDate
 import app.tivi.data.models.TiviShow
 import app.tivi.data.views.ShowsWatchStats
 
@@ -34,8 +35,23 @@ data class ShowDetailsViewState(
     val seasons: List<SeasonWithEpisodesAndWatches> = emptyList(),
     val refreshing: Boolean = false,
     val message: UiMessage? = null,
-) {
-    companion object {
-        val Empty = ShowDetailsViewState()
-    }
+    val eventSink: (ShowDetailsUiEvent) -> Unit,
+)
+
+sealed interface ShowDetailsUiEvent {
+    data class ClearMessage(val id: Long) : ShowDetailsUiEvent
+    data class Refresh(val fromUser: Boolean = true) : ShowDetailsUiEvent
+    object ToggleShowFollowed : ShowDetailsUiEvent
+    data class MarkSeasonWatched(
+        val seasonId: Long,
+        val onlyAired: Boolean = false,
+        val date: ActionDate = ActionDate.NOW,
+    ) : ShowDetailsUiEvent
+
+    data class MarkSeasonUnwatched(val seasonId: Long) : ShowDetailsUiEvent
+
+    data class UnfollowSeason(val seasonId: Long) : ShowDetailsUiEvent
+
+    data class FollowSeason(val seasonId: Long) : ShowDetailsUiEvent
+    data class UnfollowPreviousSeasons(val seasonId: Long) : ShowDetailsUiEvent
 }

--- a/ui/show/seasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasons.kt
+++ b/ui/show/seasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasons.kt
@@ -61,7 +61,6 @@ import androidx.compose.material3.contentColorFor
 import androidx.compose.material3.rememberDismissState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -121,14 +120,14 @@ internal fun ShowSeasons(
     openEpisodeDetails: (episodeId: Long) -> Unit,
     initialSeasonId: Long?,
 ) {
-    val viewState by viewModel.state.collectAsState()
+    val viewState = viewModel.presenter()
 
     ShowSeasons(
         viewState = viewState,
         navigateUp = navigateUp,
         openEpisodeDetails = openEpisodeDetails,
-        refresh = viewModel::refresh,
-        onMessageShown = viewModel::clearMessage,
+        refresh = { viewState.eventSink(ShowSeasonsUiEvent.Refresh()) },
+        onMessageShown = { viewState.eventSink(ShowSeasonsUiEvent.ClearMessage(it)) },
         initialSeasonId = initialSeasonId,
     )
 }

--- a/ui/show/seasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasonsViewModel.kt
+++ b/ui/show/seasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasonsViewModel.kt
@@ -16,20 +16,24 @@
 
 package app.tivi.showdetails.seasons
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.tivi.api.UiMessageManager
+import app.tivi.data.models.TiviShow
 import app.tivi.domain.interactors.UpdateShowSeasons
 import app.tivi.domain.observers.ObserveShowDetails
 import app.tivi.domain.observers.ObserveShowSeasonsEpisodesWatches
 import app.tivi.util.Logger
 import app.tivi.util.ObservableLoadingCounter
 import app.tivi.util.collectStatus
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
@@ -37,52 +41,56 @@ import me.tatarka.inject.annotations.Inject
 @Inject
 class ShowSeasonsViewModel(
     @Assisted savedStateHandle: SavedStateHandle,
-    observeShowDetails: ObserveShowDetails,
-    observeShowSeasons: ObserveShowSeasonsEpisodesWatches,
+    private val observeShowDetails: ObserveShowDetails,
+    private val observeShowSeasons: ObserveShowSeasonsEpisodesWatches,
     private val updateShowSeasons: UpdateShowSeasons,
     private val logger: Logger,
 ) : ViewModel() {
     private val showId: Long = savedStateHandle["showId"]!!
 
-    private val loadingState = ObservableLoadingCounter()
-    private val uiMessageManager = UiMessageManager()
+    @Composable
+    fun presenter(): ShowSeasonsViewState {
+        val scope = rememberCoroutineScope()
 
-    val state: StateFlow<ShowSeasonsViewState> = combine(
-        observeShowSeasons.flow,
-        observeShowDetails.flow,
-        loadingState.observable,
-        uiMessageManager.message,
-    ) { seasons, show, refreshing, message ->
-        ShowSeasonsViewState(
+        val loadingState = remember { ObservableLoadingCounter() }
+        val uiMessageManager = remember { UiMessageManager() }
+
+        val seasons by observeShowSeasons.flow.collectAsState(emptyList())
+        val show by observeShowDetails.flow.collectAsState(TiviShow.EMPTY_SHOW)
+        val refreshing by loadingState.observable.collectAsState(false)
+        val message by uiMessageManager.message.collectAsState(null)
+
+        fun eventSink(event: ShowSeasonsUiEvent) {
+            when (event) {
+                is ShowSeasonsUiEvent.ClearMessage -> {
+                    viewModelScope.launch {
+                        uiMessageManager.clearMessage(event.id)
+                    }
+                }
+
+                is ShowSeasonsUiEvent.Refresh -> {
+                    scope.launch {
+                        updateShowSeasons(
+                            UpdateShowSeasons.Params(showId, event.fromUser),
+                        ).collectStatus(loadingState, logger, uiMessageManager)
+                    }
+                }
+            }
+        }
+
+        LaunchedEffect(Unit) {
+            observeShowDetails(ObserveShowDetails.Params(showId))
+            observeShowSeasons(ObserveShowSeasonsEpisodesWatches.Params(showId))
+
+            eventSink(ShowSeasonsUiEvent.Refresh(false))
+        }
+
+        return ShowSeasonsViewState(
             show = show,
             seasons = seasons,
             refreshing = refreshing,
             message = message,
+            eventSink = ::eventSink,
         )
-    }.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(),
-        initialValue = ShowSeasonsViewState.Empty,
-    )
-
-    init {
-        observeShowDetails(ObserveShowDetails.Params(showId))
-        observeShowSeasons(ObserveShowSeasonsEpisodesWatches.Params(showId))
-
-        refresh(false)
-    }
-
-    fun refresh(fromUser: Boolean = true) {
-        viewModelScope.launch {
-            updateShowSeasons(
-                UpdateShowSeasons.Params(showId, fromUser),
-            ).collectStatus(loadingState, logger, uiMessageManager)
-        }
-    }
-
-    fun clearMessage(id: Long) {
-        viewModelScope.launch {
-            uiMessageManager.clearMessage(id)
-        }
     }
 }

--- a/ui/show/seasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasonsViewState.kt
+++ b/ui/show/seasons/src/main/java/app/tivi/showdetails/seasons/ShowSeasonsViewState.kt
@@ -27,8 +27,10 @@ data class ShowSeasonsViewState(
     val seasons: List<SeasonWithEpisodesAndWatches> = emptyList(),
     val refreshing: Boolean = false,
     val message: UiMessage? = null,
-) {
-    companion object {
-        val Empty = ShowSeasonsViewState()
-    }
+    val eventSink: (ShowSeasonsUiEvent) -> Unit,
+)
+
+sealed interface ShowSeasonsUiEvent {
+    data class ClearMessage(val id: Long) : ShowSeasonsUiEvent
+    data class Refresh(val fromUser: Boolean = true) : ShowSeasonsUiEvent
 }

--- a/ui/trending/src/main/java/app/tivi/home/trending/Trending.kt
+++ b/ui/trending/src/main/java/app/tivi/home/trending/Trending.kt
@@ -19,7 +19,6 @@ package app.tivi.home.trending
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.paging.compose.collectAsLazyPagingItems
 import app.tivi.common.compose.EntryGrid
 import app.tivi.common.compose.viewModel
 import app.tivi.common.ui.resources.MR
@@ -52,8 +51,9 @@ internal fun TrendingShows(
     openShowDetails: (showId: Long) -> Unit,
     navigateUp: () -> Unit,
 ) {
+    val viewState = viewModel.presenter()
     EntryGrid(
-        lazyPagingItems = viewModel.pagedList.collectAsLazyPagingItems(),
+        lazyPagingItems = viewState.items,
         title = stringResource(MR.strings.discover_trending_title),
         onOpenShowDetails = openShowDetails,
         onNavigateUp = navigateUp,

--- a/ui/trending/src/main/java/app/tivi/home/trending/TrendingShowsViewModel.kt
+++ b/ui/trending/src/main/java/app/tivi/home/trending/TrendingShowsViewModel.kt
@@ -16,26 +16,30 @@
 
 package app.tivi.home.trending
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingConfig
-import androidx.paging.PagingData
-import androidx.paging.cachedIn
-import app.tivi.data.compoundmodels.TrendingEntryWithShow
+import androidx.paging.compose.collectAsLazyPagingItems
 import app.tivi.domain.observers.ObservePagedTrendingShows
-import kotlinx.coroutines.flow.Flow
 import me.tatarka.inject.annotations.Inject
 
 @Inject
 class TrendingShowsViewModel(
-    pagingInteractor: ObservePagedTrendingShows,
+    private val pagingInteractor: ObservePagedTrendingShows,
 ) : ViewModel() {
 
-    val pagedList: Flow<PagingData<TrendingEntryWithShow>> =
-        pagingInteractor.flow.cachedIn(viewModelScope)
+    @Composable
+    fun presenter(): TrendingShowsViewState {
+        val items = pagingInteractor.flow.collectAsLazyPagingItems()
 
-    init {
-        pagingInteractor(ObservePagedTrendingShows.Params(PAGING_CONFIG))
+        LaunchedEffect(Unit) {
+            pagingInteractor(ObservePagedTrendingShows.Params(PAGING_CONFIG))
+        }
+
+        return TrendingShowsViewState(
+            items = items,
+        )
     }
 
     companion object {

--- a/ui/trending/src/main/java/app/tivi/home/trending/TrendingShowsViewState.kt
+++ b/ui/trending/src/main/java/app/tivi/home/trending/TrendingShowsViewState.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.tivi.home.trending
+
+import androidx.paging.compose.LazyPagingItems
+import app.tivi.data.compoundmodels.TrendingEntryWithShow
+
+data class TrendingShowsViewState(
+    val items: LazyPagingItems<TrendingEntryWithShow>,
+)

--- a/ui/upnext/src/main/java/app/tivi/home/upnext/UpNextViewState.kt
+++ b/ui/upnext/src/main/java/app/tivi/home/upnext/UpNextViewState.kt
@@ -16,12 +16,15 @@
 
 package app.tivi.home.upnext
 
+import androidx.paging.compose.LazyPagingItems
 import app.tivi.api.UiMessage
+import app.tivi.data.compoundmodels.UpNextEntry
 import app.tivi.data.models.SortOption
 import app.tivi.data.models.TraktUser
 import app.tivi.data.traktauth.TraktAuthState
 
 data class UpNextViewState(
+    val items: LazyPagingItems<UpNextEntry>,
     val user: TraktUser? = null,
     val authState: TraktAuthState = TraktAuthState.LOGGED_OUT,
     val isLoading: Boolean = false,
@@ -29,8 +32,12 @@ data class UpNextViewState(
     val sort: SortOption = SortOption.LAST_WATCHED,
     val message: UiMessage? = null,
     val followedShowsOnly: Boolean = false,
-) {
-    companion object {
-        val Empty = UpNextViewState()
-    }
+    val eventSink: (UpNextUiEvent) -> Unit,
+)
+
+sealed interface UpNextUiEvent {
+    data class ClearMessage(val id: Long) : UpNextUiEvent
+    data class Refresh(val fromUser: Boolean = false) : UpNextUiEvent
+    data class ChangeSort(val sort: SortOption) : UpNextUiEvent
+    object ToggleFollowedShowsOnly : UpNextUiEvent
 }


### PR DESCRIPTION
This performs much of the work necessary in our (future) migration to Slack's [Circuit](https://slackhq.github.io/circuit/).

When we do come to migrate to Circuit, migrating the presenters should only require adding interfaces/annotations. Hopefully.