### PR TITLE
Add Gradle convention plugins

### DIFF
--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -18,7 +18,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
-    alias(libs.plugins.android.application)
+    id("app.tivi.android.application")
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)

--- a/android-app/benchmark/build.gradle.kts
+++ b/android-app/benchmark/build.gradle.kts
@@ -18,7 +18,7 @@
 import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
-    alias(libs.plugins.android.test)
+    id("app.tivi.android.test")
     alias(libs.plugins.kotlin.android)
 }
 

--- a/api/tmdb/build.gradle.kts
+++ b/api/tmdb/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.ksp)
     alias(libs.plugins.cacheFixPlugin)
 }

--- a/api/trakt/build.gradle.kts
+++ b/api/trakt/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.ksp)
     alias(libs.plugins.cacheFixPlugin)
 }

--- a/common/imageloading/build.gradle.kts
+++ b/common/imageloading/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)

--- a/common/ui/compose/build.gradle.kts
+++ b/common/ui/compose/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
 }

--- a/common/ui/resources-compose/build.gradle.kts
+++ b/common/ui/resources-compose/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
 }

--- a/common/ui/resources/build.gradle.kts
+++ b/common/ui/resources/build.gradle.kts
@@ -16,9 +16,9 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.cacheFixPlugin)
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.moko.resources) // needs to be enabled after AGP
 }
 

--- a/common/ui/view/build.gradle.kts
+++ b/common/ui/view/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
 }

--- a/core/analytics/build.gradle.kts
+++ b/core/analytics/build.gradle.kts
@@ -16,8 +16,8 @@
 
 
 plugins {
-    kotlin("multiplatform")
-    alias(libs.plugins.android.library)
+    id("app.tivi.multiplatform")
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/core/base/build.gradle.kts
+++ b/core/base/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
 }
 
 kotlin {

--- a/core/logging/build.gradle.kts
+++ b/core/logging/build.gradle.kts
@@ -16,8 +16,8 @@
 
 
 plugins {
-    kotlin("multiplatform")
-    alias(libs.plugins.android.library)
+    id("app.tivi.multiplatform")
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/core/performance/build.gradle.kts
+++ b/core/performance/build.gradle.kts
@@ -16,8 +16,8 @@
 
 
 plugins {
-    kotlin("multiplatform")
-    alias(libs.plugins.android.library)
+    id("app.tivi.multiplatform")
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/core/powercontroller/build.gradle.kts
+++ b/core/powercontroller/build.gradle.kts
@@ -16,8 +16,8 @@
 
 
 plugins {
-    kotlin("multiplatform")
-    alias(libs.plugins.android.library)
+    id("app.tivi.multiplatform")
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/core/preferences/build.gradle.kts
+++ b/core/preferences/build.gradle.kts
@@ -16,8 +16,8 @@
 
 
 plugins {
-    kotlin("multiplatform")
-    alias(libs.plugins.android.library)
+    id("app.tivi.multiplatform")
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/data/db-sqldelight/build.gradle.kts
+++ b/data/db-sqldelight/build.gradle.kts
@@ -34,8 +34,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
  */
 
 plugins {
-    kotlin("multiplatform")
-    alias(libs.plugins.android.library)
+    id("app.tivi.multiplatform")
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
     alias(libs.plugins.sqldelight)

--- a/data/db/build.gradle.kts
+++ b/data/db/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.cacheFixPlugin)
 }
 

--- a/data/episodes/build.gradle.kts
+++ b/data/episodes/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/data/followedshows/build.gradle.kts
+++ b/data/followedshows/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/data/legacy/build.gradle.kts
+++ b/data/legacy/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/data/models/build.gradle.kts
+++ b/data/models/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.cacheFixPlugin)
 }
 

--- a/data/popularshows/build.gradle.kts
+++ b/data/popularshows/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/data/recommendedshows/build.gradle.kts
+++ b/data/recommendedshows/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/data/relatedshows/build.gradle.kts
+++ b/data/relatedshows/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/data/search/build.gradle.kts
+++ b/data/search/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/data/showimages/build.gradle.kts
+++ b/data/showimages/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/data/shows/build.gradle.kts
+++ b/data/shows/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/data/test/build.gradle.kts
+++ b/data/test/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/data/traktauth/build.gradle.kts
+++ b/data/traktauth/build.gradle.kts
@@ -34,8 +34,8 @@ import org.gradle.android.Versions.android
  */
 
 plugins {
-    kotlin("multiplatform")
-    alias(libs.plugins.android.library)
+    id("app.tivi.multiplatform")
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/data/traktusers/build.gradle.kts
+++ b/data/traktusers/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/data/trendingshows/build.gradle.kts
+++ b/data/trendingshows/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/data/watchedshows/build.gradle.kts
+++ b/data/watchedshows/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.ksp)
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    kotlin("multiplatform")
+    id("app.tivi.multiplatform")
     alias(libs.plugins.ksp)
     alias(libs.plugins.cacheFixPlugin)
 }

--- a/gradle/build-logic/convention/build.gradle.kts
+++ b/gradle/build-logic/convention/build.gradle.kts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+plugins {
+    `kotlin-dsl`
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
+dependencies {
+    compileOnly(libs.android.gradlePlugin)
+    compileOnly(libs.kotlin.gradlePlugin)
+}
+
+gradlePlugin {
+    plugins {
+        register("kotlinMultiplatform") {
+            id = "app.tivi.multiplatform"
+            implementationClass = "app.tivi.gradle.KotlinMultiplatformConventionPlugin"
+        }
+
+        register("androidApplication") {
+            id = "app.tivi.android.application"
+            implementationClass = "app.tivi.gradle.AndroidApplicationConventionPlugin"
+        }
+
+        register("androidLibrary") {
+            id = "app.tivi.android.library"
+            implementationClass = "app.tivi.gradle.AndroidLibraryConventionPlugin"
+        }
+
+        register("androidTest") {
+            id = "app.tivi.android.test"
+            implementationClass = "app.tivi.gradle.AndroidTestConventionPlugin"
+        }
+    }
+}

--- a/gradle/build-logic/convention/src/main/java/app/tivi/gradle/AndroidApplicationConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/java/app/tivi/gradle/AndroidApplicationConventionPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,16 @@
  * limitations under the License.
  */
 
+package app.tivi.gradle
 
-plugins {
-    id("app.tivi.multiplatform")
-    alias(libs.plugins.cacheFixPlugin)
-}
+import org.gradle.api.Plugin
+import org.gradle.api.Project
 
-kotlin {
-    jvm()
-
-    sourceSets {
-        val commonMain by getting {
-            dependencies {
-                implementation(projects.core.base)
+class AndroidApplicationConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("com.android.application")
             }
         }
     }

--- a/gradle/build-logic/convention/src/main/java/app/tivi/gradle/AndroidLibraryConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/java/app/tivi/gradle/AndroidLibraryConventionPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,16 @@
  * limitations under the License.
  */
 
+package app.tivi.gradle
 
-plugins {
-    id("app.tivi.multiplatform")
-    alias(libs.plugins.cacheFixPlugin)
-}
+import org.gradle.api.Plugin
+import org.gradle.api.Project
 
-kotlin {
-    jvm()
-
-    sourceSets {
-        val commonMain by getting {
-            dependencies {
-                implementation(projects.core.base)
+class AndroidLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("com.android.library")
             }
         }
     }

--- a/gradle/build-logic/convention/src/main/java/app/tivi/gradle/AndroidTestConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/java/app/tivi/gradle/AndroidTestConventionPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,16 @@
  * limitations under the License.
  */
 
+package app.tivi.gradle
 
-plugins {
-    id("app.tivi.multiplatform")
-    alias(libs.plugins.cacheFixPlugin)
-}
+import org.gradle.api.Plugin
+import org.gradle.api.Project
 
-kotlin {
-    jvm()
-
-    sourceSets {
-        val commonMain by getting {
-            dependencies {
-                implementation(projects.core.base)
+class AndroidTestConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("com.android.test")
             }
         }
     }

--- a/gradle/build-logic/convention/src/main/java/app/tivi/gradle/KotlinMultiplatformConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/java/app/tivi/gradle/KotlinMultiplatformConventionPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,16 @@
  * limitations under the License.
  */
 
+package app.tivi.gradle
 
-plugins {
-    id("app.tivi.multiplatform")
-    alias(libs.plugins.cacheFixPlugin)
-}
+import org.gradle.api.Plugin
+import org.gradle.api.Project
 
-kotlin {
-    jvm()
-
-    sourceSets {
-        val commonMain by getting {
-            dependencies {
-                implementation(projects.core.base)
+class KotlinMultiplatformConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("org.jetbrains.kotlin.multiplatform")
             }
         }
     }

--- a/gradle/build-logic/gradle.properties
+++ b/gradle/build-logic/gradle.properties
@@ -1,0 +1,4 @@
+# Gradle properties are not passed to included builds https://github.com/gradle/gradle/issues/2534
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configureondemand=true

--- a/gradle/build-logic/settings.gradle.kts
+++ b/gradle/build-logic/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,17 @@
  */
 
 
-plugins {
-    id("app.tivi.multiplatform")
-    alias(libs.plugins.cacheFixPlugin)
-}
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
 
-kotlin {
-    jvm()
-
-    sourceSets {
-        val commonMain by getting {
-            dependencies {
-                implementation(projects.core.base)
-            }
+    versionCatalogs {
+        create("libs") {
+            from(files("../libs.versions.toml"))
         }
     }
 }
+
+include(":convention")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -169,3 +169,7 @@ trakt-api = "app.moviebase:trakt-api:0.4.0"
 truth = "com.google.truth:truth:1.1.3"
 
 turbine = "app.cash.turbine:turbine:0.13.0"
+
+# Build logic dependencies
+android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,8 @@
 
 
 pluginManagement {
+    includeBuild("gradle/build-logic")
+
     repositories {
         gradlePluginPortal()
         google()

--- a/tasks/android/build.gradle.kts
+++ b/tasks/android/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)

--- a/ui/account/build.gradle.kts
+++ b/ui/account/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)

--- a/ui/discover/build.gradle.kts
+++ b/ui/discover/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)

--- a/ui/episode/details/build.gradle.kts
+++ b/ui/episode/details/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)

--- a/ui/episode/track/build.gradle.kts
+++ b/ui/episode/track/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)

--- a/ui/library/build.gradle.kts
+++ b/ui/library/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)

--- a/ui/popular/build.gradle.kts
+++ b/ui/popular/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)

--- a/ui/recommended/build.gradle.kts
+++ b/ui/recommended/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)

--- a/ui/search/build.gradle.kts
+++ b/ui/search/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)

--- a/ui/settings/build.gradle.kts
+++ b/ui/settings/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)

--- a/ui/show/details/build.gradle.kts
+++ b/ui/show/details/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)

--- a/ui/show/seasons/build.gradle.kts
+++ b/ui/show/seasons/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)

--- a/ui/trending/build.gradle.kts
+++ b/ui/trending/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.cacheFixPlugin)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)

--- a/ui/upnext/build.gradle.kts
+++ b/ui/upnext/build.gradle.kts
@@ -16,7 +16,7 @@
 
 
 plugins {
-    alias(libs.plugins.android.library)
+    id("app.tivi.android.library")
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
 }


### PR DESCRIPTION
Tivi Gradle modules share some common build logic. This is either done by duplicating it in every module (e.g. applying the cache fix plugin) or using the allprojects block.

Gradle's recommended way to do this is to use [convention plugins](https://docs.gradle.org/current/userguide/sharing_build_logic_between_subprojects.html). The idea is to have plugins like app.tivi.android.library, app.tivi.android.application (and apply these instead of the com.android.library and com.android.application). These plugins can then configure the common build logic. If needed, the modules can override these defaults (which is trickier to do with the allprojects block).

Here are a few examples using it
https://github.com/android/nowinandroid/tree/main/build-logic https://github.com/dropbox/focus/blob/main/settings.gradle#L2 https://github.com/jjohannes/gradle-project-setup-howto/blob/main/settings.gradle.kts#L2

Fixes #1243