### PR TITLE
Declare dependency repositories in dependencyResolutionManagement block

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,22 +33,6 @@ plugins {
 }
 
 allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        mavenLocal()
-
-        // Needed when using the 'dev' Compose Compiler
-        // maven("https://androidx.dev/storage/compose-compiler/repository/")
-
-        // Jetpack Compose SNAPSHOTs if needed
-        // maven("https://androidx.dev/snapshots/builds/$composeSnapshot/artifacts/repository/")
-
-        // Used for snapshots if needed
-        // maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-        // maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-    }
-
     apply(plugin = rootProject.libs.plugins.spotless.get().pluginId)
     configure<SpotlessExtension> {
         kotlin {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,26 @@ pluginManagement {
     }
 }
 
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+
+    repositories {
+        google()
+        mavenCentral()
+        mavenLocal()
+
+        // Needed when using the 'dev' Compose Compiler
+        // maven("https://androidx.dev/storage/compose-compiler/repository/")
+
+        // Jetpack Compose SNAPSHOTs if needed
+        // maven("https://androidx.dev/snapshots/builds/$composeSnapshot/artifacts/repository/")
+
+        // Used for snapshots if needed
+        // maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        // maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+    }
+}
+
 plugins {
     id("com.gradle.enterprise") version "3.13.2"
 }


### PR DESCRIPTION
Usages of `allprojects` is discouraged and the recommended way to share the build logic is by using convention plugins (see #1243). This will be done later (#1247). For now, removing some of the code from the `allprojects` block.

More details
https://docs.gradle.org/current/userguide/dependency_management.html#sub:centralized-repository-declaration