### PR TITLE
Use new property name for configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ org.gradle.jvmargs=-Xmx3072m -Dfile.encoding=UTF-8
 # https://docs.gradle.org/7.6/userguide/configuration_cache.html
 # Disabled due to KMP plugin. Should be fixed in Kotlin 1.9:
 #   https://youtrack.jetbrains.com/issue/KT-49933/Support-Gradle-Configuration-caching-with-HMPP
-org.gradle.unsafe.configuration-cache=false
+org.gradle.configuration-cache=false
 
 # AndroidX
 android.useAndroidX=true


### PR DESCRIPTION
In Gradle 8.0 release the configuration cache feature was promoted from incubating to stable, and the properties were renamed accordingly. The original properties continue to be honored and no warnings are produced if they are used, but they will be deprecated and removed in a future release.

More details
https://docs.gradle.org/8.1/userguide/upgrading_version_8.html#configuration_caching_options_renamed