### PR TITLE
Use IMDb ID when fetching show info

### DIFF
--- a/data/db-sqldelight/src/commonMain/kotlin/app/tivi/data/daos/SqlDelightTiviShowDao.kt
+++ b/data/db-sqldelight/src/commonMain/kotlin/app/tivi/data/daos/SqlDelightTiviShowDao.kt
@@ -68,6 +68,11 @@ class SqlDelightTiviShowDao(
             .executeAsOneOrNull()?.tmdb_id
     }
 
+    override fun getImdbIdForShowId(id: Long): String? {
+        return db.showQueries.getImdbIdForShowId(id)
+            .executeAsOneOrNull()?.imdb_id
+    }
+
     override fun getIdForTraktId(traktId: Int): Long? {
         return db.showQueries.getIdForTraktId(traktId)
             .executeAsOneOrNull()

--- a/data/db-sqldelight/src/commonMain/sqldelight/app/tivi/data/show.sq
+++ b/data/db-sqldelight/src/commonMain/sqldelight/app/tivi/data/show.sq
@@ -45,6 +45,9 @@ SELECT * FROM shows WHERE tmdb_id = :id;
 getTraktIdForShowId:
 SELECT trakt_id FROM shows WHERE id = :id;
 
+getImdbIdForShowId:
+SELECT imdb_id FROM shows WHERE id = :id;
+
 getTmdbIdForShowId:
 SELECT tmdb_id FROM shows WHERE id = :id;
 

--- a/data/db/src/commonMain/kotlin/app/tivi/data/daos/TiviShowDao.kt
+++ b/data/db/src/commonMain/kotlin/app/tivi/data/daos/TiviShowDao.kt
@@ -36,6 +36,8 @@ interface TiviShowDao : EntityDao<TiviShow> {
 
     fun getTmdbIdForShowId(id: Long): Int?
 
+    fun getImdbIdForShowId(id: Long): String?
+
     fun getIdForTraktId(traktId: Int): Long?
 
     fun getIdForTmdbId(tmdbId: Int): Long?

--- a/data/episodes/src/commonMain/kotlin/app/tivi/data/episodes/TraktEpisodeDataSourceImpl.kt
+++ b/data/episodes/src/commonMain/kotlin/app/tivi/data/episodes/TraktEpisodeDataSourceImpl.kt
@@ -17,14 +17,14 @@
 package app.tivi.data.episodes
 
 import app.moviebase.trakt.api.TraktEpisodesApi
-import app.tivi.data.mappers.ShowIdToTraktIdMapper
+import app.tivi.data.mappers.ShowIdToTraktOrImdbIdMapper
 import app.tivi.data.mappers.TraktEpisodeToEpisode
 import app.tivi.data.models.Episode
 import me.tatarka.inject.annotations.Inject
 
 @Inject
 class TraktEpisodeDataSourceImpl(
-    private val traktIdMapper: ShowIdToTraktIdMapper,
+    private val idMapper: ShowIdToTraktOrImdbIdMapper,
     private val service: Lazy<TraktEpisodesApi>,
     private val episodeMapper: TraktEpisodeToEpisode,
 ) : EpisodeDataSource {
@@ -34,11 +34,10 @@ class TraktEpisodeDataSourceImpl(
         seasonNumber: Int,
         episodeNumber: Int,
     ): Episode {
-        val traktId = traktIdMapper.map(showId)
-            ?: throw IllegalArgumentException("No Trakt ID for show with ID: $showId")
+        val id = idMapper.map(showId) ?: error("No Trakt allowed ID for show with ID: $showId")
 
         return service.value
-            .getSummary(traktId.toString(), seasonNumber, episodeNumber)
+            .getSummary(id, seasonNumber, episodeNumber)
             .let { episodeMapper.map(it) }
     }
 }

--- a/data/episodes/src/commonMain/kotlin/app/tivi/data/episodes/TraktSeasonsEpisodesDataSource.kt
+++ b/data/episodes/src/commonMain/kotlin/app/tivi/data/episodes/TraktSeasonsEpisodesDataSource.kt
@@ -27,6 +27,7 @@ import app.moviebase.trakt.model.TraktSyncItems
 import app.tivi.data.mappers.EpisodeIdToTraktIdMapper
 import app.tivi.data.mappers.SeasonIdToTraktIdMapper
 import app.tivi.data.mappers.ShowIdToTraktIdMapper
+import app.tivi.data.mappers.ShowIdToTraktOrImdbIdMapper
 import app.tivi.data.mappers.TraktHistoryEntryToEpisode
 import app.tivi.data.mappers.TraktHistoryItemToEpisodeWatchEntry
 import app.tivi.data.mappers.TraktSeasonToSeasonWithEpisodes
@@ -40,6 +41,7 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class TraktSeasonsEpisodesDataSource(
+    private val showIdToAnyIdMapper: ShowIdToTraktOrImdbIdMapper,
     private val showIdToTraktIdMapper: ShowIdToTraktIdMapper,
     private val seasonIdToTraktIdMapper: SeasonIdToTraktIdMapper,
     private val episodeIdToTraktIdMapper: EpisodeIdToTraktIdMapper,
@@ -55,7 +57,7 @@ class TraktSeasonsEpisodesDataSource(
 
     override suspend fun getSeasonsEpisodes(showId: Long): List<Pair<Season, List<Episode>>> {
         return seasonsService.value.getSummary(
-            showId = showIdToTraktIdMapper.map(showId)?.toString()
+            showId = showIdToAnyIdMapper.map(showId)
                 ?: error("No Trakt ID for show with ID: $showId"),
             extended = TraktExtended.FULL_EPISODES,
         ).let { seasonMapper.map(it) }

--- a/data/legacy/src/commonMain/kotlin/app/tivi/data/mappers/ShowIdToTraktOrImdbIdMapper.kt
+++ b/data/legacy/src/commonMain/kotlin/app/tivi/data/mappers/ShowIdToTraktOrImdbIdMapper.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.tivi.data.mappers
+
+import app.tivi.data.daos.TiviShowDao
+import app.tivi.data.db.DatabaseTransactionRunner
+import me.tatarka.inject.annotations.Inject
+
+@Inject
+class ShowIdToTraktOrImdbIdMapper(
+    private val showDao: TiviShowDao,
+    private val transactionRunner: DatabaseTransactionRunner,
+) : Mapper<Long, String?> {
+    override fun map(from: Long): String? = transactionRunner {
+        showDao.getTraktIdForShowId(from)?.toString()
+            ?: showDao.getImdbIdForShowId(from)
+    }
+}


### PR DESCRIPTION
Many of the Trakt APIs allow sending a string containing: "Trakt ID, Trakt slug, or IMDB ID"

We don't store slugs (and we'd have a Trakt ID any time we had a slug), but we can use IMDb Ids.