### PR TITLE
Tidy up Android Trakt login code

### DIFF
--- a/data/traktauth/src/androidMain/kotlin/app/tivi/data/traktauth/AndroidLoginToTraktInteractor.kt
+++ b/data/traktauth/src/androidMain/kotlin/app/tivi/data/traktauth/AndroidLoginToTraktInteractor.kt
@@ -26,10 +26,10 @@ import net.openid.appauth.AuthorizationService
 import net.openid.appauth.ClientAuthentication
 
 @Inject
-class LoginToTraktInteractorImpl(
+class AndroidLoginToTraktInteractor(
     private val activity: Activity,
-    private val loginTraktActivityResultContract: LoginTraktActivityResultContract,
-    private val traktAuthRepository: TraktAuthRepository,
+    private val loginTraktActivityResultContract: Lazy<LoginTraktActivityResultContract>,
+    private val traktAuthRepository: Lazy<TraktAuthRepository>,
     private val clientAuth: Lazy<ClientAuthentication>,
     private val logger: Logger,
     private val authService: Lazy<AuthorizationService>,
@@ -40,7 +40,9 @@ class LoginToTraktInteractorImpl(
     override fun register() {
         require(activity is ComponentActivity)
 
-        launcher = activity.registerForActivityResult(loginTraktActivityResultContract) { result ->
+        launcher = activity.registerForActivityResult(
+            loginTraktActivityResultContract.value,
+        ) { result ->
             if (result != null) {
                 onLoginResult(result)
             }
@@ -60,7 +62,7 @@ class LoginToTraktInteractorImpl(
                     val state = AuthState()
                         .apply { update(tokenResponse, ex) }
                         .let(::AppAuthAuthStateWrapper)
-                    traktAuthRepository.onNewAuthState(state)
+                    traktAuthRepository.value.onNewAuthState(state)
                 }
             }
 

--- a/data/traktauth/src/androidMain/kotlin/app/tivi/data/traktauth/LoginTraktActivityResultContract.kt
+++ b/data/traktauth/src/androidMain/kotlin/app/tivi/data/traktauth/LoginTraktActivityResultContract.kt
@@ -19,19 +19,33 @@ package app.tivi.data.traktauth
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.net.toUri
 import me.tatarka.inject.annotations.Inject
 import net.openid.appauth.AuthorizationException
 import net.openid.appauth.AuthorizationRequest
 import net.openid.appauth.AuthorizationResponse
 import net.openid.appauth.AuthorizationService
+import net.openid.appauth.AuthorizationServiceConfiguration
+import net.openid.appauth.ResponseTypeValues
 
 @Inject
 class LoginTraktActivityResultContract(
-    private val authService: AuthorizationService,
-    private val request: AuthorizationRequest,
+    private val authService: Lazy<AuthorizationService>,
+    private val authServiceConfig: Lazy<AuthorizationServiceConfiguration>,
+    private val oAuthInfo: TraktOAuthInfo,
 ) : ActivityResultContract<Unit, LoginTraktActivityResultContract.Result?>() {
     override fun createIntent(context: Context, input: Unit): Intent {
-        return authService.getAuthorizationRequestIntent(request)
+        return authService.value.getAuthorizationRequestIntent(
+            AuthorizationRequest.Builder(
+                authServiceConfig.value,
+                oAuthInfo.clientId,
+                ResponseTypeValues.CODE,
+                oAuthInfo.redirectUri.toUri(),
+            ).apply {
+                // Disable PKCE since Trakt does not support it
+                setCodeVerifier(null)
+            }.build(),
+        )
     }
 
     override fun parseResult(

--- a/data/traktauth/src/androidMain/kotlin/app/tivi/data/traktauth/TraktAuthComponent.kt
+++ b/data/traktauth/src/androidMain/kotlin/app/tivi/data/traktauth/TraktAuthComponent.kt
@@ -19,20 +19,16 @@ package app.tivi.data.traktauth
 import android.app.Application
 import android.content.Context
 import android.net.Uri
-import androidx.core.net.toUri
-import app.tivi.app.ApplicationInfo
 import app.tivi.data.traktauth.store.AuthSharedPreferences
 import app.tivi.data.traktauth.store.AuthStore
 import app.tivi.data.traktauth.store.TiviAuthStore
 import app.tivi.inject.ActivityScope
 import app.tivi.inject.ApplicationScope
 import me.tatarka.inject.annotations.Provides
-import net.openid.appauth.AuthorizationRequest
 import net.openid.appauth.AuthorizationService
 import net.openid.appauth.AuthorizationServiceConfiguration
 import net.openid.appauth.ClientAuthentication
 import net.openid.appauth.ClientSecretBasic
-import net.openid.appauth.ResponseTypeValues
 
 interface TraktAuthComponent {
     @ApplicationScope
@@ -42,23 +38,6 @@ interface TraktAuthComponent {
             Uri.parse("https://trakt.tv/oauth/authorize"),
             Uri.parse("https://trakt.tv/oauth/token"),
         )
-    }
-
-    @Provides
-    fun provideAuthRequest(
-        serviceConfig: AuthorizationServiceConfiguration,
-        oauthInfo: TraktOAuthInfo,
-        appInfo: ApplicationInfo,
-    ): AuthorizationRequest {
-        return AuthorizationRequest.Builder(
-            serviceConfig,
-            oauthInfo.clientId,
-            ResponseTypeValues.CODE,
-            oauthInfo.redirectUri.toUri(),
-        ).apply {
-            // Disable PKCE since Trakt does not support it
-            setCodeVerifier(null)
-        }.build()
     }
 
     @ApplicationScope
@@ -83,7 +62,7 @@ interface TraktAuthComponent {
 
     @ApplicationScope
     @Provides
-    fun provideRefreshTraktTokensInteractor(impl: RefreshTraktTokensInteractorImpl): RefreshTraktTokensInteractor = impl
+    fun provideRefreshTraktTokensInteractor(impl: AndroidRefreshTraktTokensInteractor): RefreshTraktTokensInteractor = impl
 
     @ApplicationScope
     @Provides
@@ -93,5 +72,5 @@ interface TraktAuthComponent {
 interface TraktAuthActivityComponent {
     @ActivityScope
     @Provides
-    fun provideLoginToTraktInteractor(impl: LoginToTraktInteractorImpl): LoginToTraktInteractor = impl
+    fun provideLoginToTraktInteractor(impl: AndroidLoginToTraktInteractor): LoginToTraktInteractor = impl
 }


### PR DESCRIPTION
- Lazily fetch dependencies. No point creating it all upfront.
- Manually create refresh token request. createTokenRefreshRequest() requires the AuthState to be pre-populated from an auth response which we don't have.