### PR TITLE
Fix crash reported from searching

### DIFF
--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/SearchShows.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/SearchShows.kt
@@ -21,7 +21,6 @@ import app.tivi.data.models.TiviShow
 import app.tivi.data.search.SearchRepository
 import app.tivi.domain.SuspendingWorkInteractor
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
 import me.tatarka.inject.annotations.Inject
 
@@ -37,10 +36,7 @@ class SearchShows(
             remoteResults.isNotEmpty() -> remoteResults
             params.query.isNotBlank() -> {
                 try {
-                    showDao.search("%$params.query%")
-                } catch (ce: CancellationException) {
-                    // Cancellation exceptions should be re-thrown
-                    throw ce
+                    showDao.search("%${params.query}%")
                 } catch (e: Exception) {
                     // Re-throw wrapped exception with the query
                     throw Exception("Error while searching database with query: ${params.query}", e)

--- a/ui/search/src/main/java/app/tivi/home/search/SearchViewModel.kt
+++ b/ui/search/src/main/java/app/tivi/home/search/SearchViewModel.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Inject
@@ -56,8 +57,7 @@ class SearchViewModel(
     init {
         viewModelScope.launch {
             searchQuery.debounce(300)
-                .catch { throwable -> uiMessageManager.emitMessage(UiMessage(throwable)) }
-                .collect { query ->
+                .onEach { query ->
                     launch {
                         loadingState.addLoader()
                         searchShows(SearchShows.Params(query))
@@ -65,6 +65,10 @@ class SearchViewModel(
                         loadingState.removeLoader()
                     }
                 }
+                .catch { throwable ->
+                    uiMessageManager.emitMessage(UiMessage(throwable))
+                }
+                .collect()
         }
     }
 


### PR DESCRIPTION
Two issues:
- Search query wasn't being passed to the DAO correctly
- The catch() on the flow in SearchViewModel doesn't catch anything from the collect(). Moved to using onEach instead.