### PR TITLE
Reduce the scope of spotless tasks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
 
+      - name: Check convention plugins code style with Spotless
+        run: ./gradlew -p gradle/build-logic spotlessCheck
+
       - name: Check code style with Spotless
         run: ./gradlew spotlessCheck
 

--- a/gradle/build-logic/convention/build.gradle.kts
+++ b/gradle/build-logic/convention/build.gradle.kts
@@ -4,11 +4,26 @@
 
 plugins {
     `kotlin-dsl`
+    alias(libs.plugins.spotless)
 }
 
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
+spotless {
+    kotlin {
+        target("src/**/*.kt")
+        ktlint(libs.versions.ktlint.get())
+        licenseHeaderFile(rootProject.file("../../spotless/cb-copyright.txt"))
+    }
+
+    kotlinGradle {
+        target("*.kts")
+        ktlint(libs.versions.ktlint.get())
+        licenseHeaderFile(rootProject.file("../../spotless/cb-copyright.txt"), "(^(?![\\/ ]\\**).*$)")
     }
 }
 

--- a/gradle/build-logic/convention/src/main/kotlin/app/tivi/gradle/Spotless.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/app/tivi/gradle/Spotless.kt
@@ -21,8 +21,7 @@ fun Project.configureSpotless() {
 
     spotless {
         kotlin {
-            target("**/*.kt")
-            targetExclude("thirdparty/**/*.kt")
+            target("src/**/*.kt")
             ktlint(ktlintVersion)
             licenseHeaderFile(rootProject.file("spotless/google-copyright.txt"))
                 .named("google")
@@ -36,8 +35,7 @@ fun Project.configureSpotless() {
         }
 
         kotlinGradle {
-            target("**/*.kts")
-            targetExclude("thirdparty/**/*.kts")
+            target("*.kts")
             ktlint(ktlintVersion)
             licenseHeaderFile(rootProject.file("spotless/google-copyright.txt"), "(^(?![\\/ ]\\**).*$)")
                 .named("google")


### PR DESCRIPTION
Otherwise running Spotless on the root project will analyze 54 Gradle build files and 474 Kotlin files, which will then be re-analyzed by their modules. This is redundant but it also results in long fingerprinting times. For example, it took 18s on CI to fingerprint task inputs for an UP-TO-DATE `:spotlessKotlin` task (on the root project) https://scans.gradle.com/s/sqjswckwfddis/timeline?details=oajzimjzgvapi&expanded=WyI3Il0&toggled=WyIxNzciXQ&view=by-type