### PR TITLE
Use gmazzo/gradle-buildconfig-plugin

### DIFF
--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -81,10 +81,6 @@ android {
             signingConfig = signingConfigs["debug"]
             versionNameSuffix = "-dev"
             applicationIdSuffix = ".debug"
-
-            buildConfigField("String", "TRAKT_CLIENT_ID", "\"" + propOrDef("TIVI_DEBUG_TRAKT_CLIENT_ID", "TIVI_TRAKT_CLIENT_ID", "") + "\"")
-            buildConfigField("String", "TRAKT_CLIENT_SECRET", "\"" + propOrDef("TIVI_DEBUG_TRAKT_CLIENT_SECRET", "TIVI_TRAKT_CLIENT_SECRET", "") + "\"")
-            buildConfigField("String", "TMDB_API_KEY", "\"" + propOrDef("TIVI_DEBUG_TMDB_API_KEY", "TIVI_TMDB_API_KEY", "") + "\"")
         }
 
         release {
@@ -92,10 +88,6 @@ android {
             isShrinkResources = true
             isMinifyEnabled = true
             proguardFiles("proguard-rules.pro")
-
-            buildConfigField("String", "TRAKT_CLIENT_ID", "\"" + propOrDef("TIVI_TRAKT_CLIENT_ID", "") + "\"")
-            buildConfigField("String", "TRAKT_CLIENT_SECRET", "\"" + propOrDef("TIVI_TRAKT_CLIENT_SECRET", "") + "\"")
-            buildConfigField("String", "TMDB_API_KEY", "\"" + propOrDef("TIVI_TMDB_API_KEY", "") + "\"")
         }
 
         create("benchmark") {

--- a/android-app/app/src/main/java/app/tivi/inject/AndroidApplicationComponent.kt
+++ b/android-app/app/src/main/java/app/tivi/inject/AndroidApplicationComponent.kt
@@ -13,10 +13,8 @@ import app.tivi.appinitializers.AppInitializer
 import app.tivi.appinitializers.AppInitializers
 import app.tivi.appinitializers.EmojiInitializer
 import app.tivi.common.imageloading.ImageLoadingComponent
-import app.tivi.data.traktauth.TraktOAuthInfo
 import app.tivi.home.ContentViewSetterComponent
 import app.tivi.tasks.TiviWorkerFactory
-import app.tivi.tmdb.TmdbOAuthInfo
 import java.io.File
 import java.util.concurrent.TimeUnit
 import me.tatarka.inject.annotations.Component
@@ -50,20 +48,6 @@ abstract class AndroidApplicationComponent(
             "qa" -> Flavor.Qa
             else -> Flavor.Standard
         },
-    )
-
-    @ApplicationScope
-    @Provides
-    fun provideTmdbApiKey(): TmdbOAuthInfo = TmdbOAuthInfo(BuildConfig.TMDB_API_KEY)
-
-    @ApplicationScope
-    @Provides
-    fun provideTraktOAuthInfo(
-        appInfo: ApplicationInfo,
-    ): TraktOAuthInfo = TraktOAuthInfo(
-        clientId = BuildConfig.TRAKT_CLIENT_ID,
-        clientSecret = BuildConfig.TRAKT_CLIENT_SECRET,
-        redirectUri = "${appInfo.packageName}://auth/oauth2callback",
     )
 
     @Provides

--- a/api/tmdb/build.gradle.kts
+++ b/api/tmdb/build.gradle.kts
@@ -4,6 +4,14 @@
 
 plugins {
     id("app.tivi.kotlin.multiplatform")
+    alias(libs.plugins.buildConfig)
+}
+
+buildConfig {
+    packageName("app.tivi.tmdb")
+
+    buildConfigField("String", "TMDB_DEBUG_API_KEY", "\"${propOrDef("TIVI_DEBUG_TMDB_API_KEY", "")}\"")
+    buildConfigField("String", "TMDB_API_KEY", "\"${propOrDef("TIVI_TMDB_API_KEY", "")}\"")
 }
 
 kotlin {
@@ -34,4 +42,9 @@ kotlin {
             }
         }
     }
+}
+
+fun <T : Any> propOrDef(propertyName: String, defaultValue: T): T {
+    @Suppress("UNCHECKED_CAST")
+    return project.properties[propertyName] as T? ?: defaultValue
 }

--- a/api/tmdb/src/commonMain/kotlin/app/tivi/tmdb/TmdbComponent.kt
+++ b/api/tmdb/src/commonMain/kotlin/app/tivi/tmdb/TmdbComponent.kt
@@ -3,6 +3,7 @@
 
 package app.tivi.tmdb
 
+import app.tivi.app.ApplicationInfo
 import app.tivi.inject.ApplicationScope
 import me.tatarka.inject.annotations.Provides
 
@@ -11,6 +12,20 @@ interface TmdbComponent : TmdbCommonComponent, TmdbPlatformComponent
 expect interface TmdbPlatformComponent
 
 interface TmdbCommonComponent {
+    @ApplicationScope
+    @Provides
+    fun provideTmdbApiKey(
+        appInfo: ApplicationInfo,
+    ): TmdbOAuthInfo = TmdbOAuthInfo(
+        apiKey = when {
+            appInfo.debugBuild -> {
+                BuildConfig.TMDB_DEBUG_API_KEY.ifEmpty { BuildConfig.TMDB_API_KEY }
+            }
+
+            else -> BuildConfig.TMDB_API_KEY
+        },
+    )
+
     @ApplicationScope
     @Provides
     fun provideTmdbImageUrlProvider(tmdbManager: TmdbManager): TmdbImageUrlProvider {

--- a/api/trakt/build.gradle.kts
+++ b/api/trakt/build.gradle.kts
@@ -4,6 +4,16 @@
 
 plugins {
     id("app.tivi.kotlin.multiplatform")
+    alias(libs.plugins.buildConfig)
+}
+
+buildConfig {
+    packageName("app.tivi.trakt")
+
+    buildConfigField("String", "TRAKT_DEBUG_CLIENT_SECRET", "\"${propOrDef("TIVI_DEBUG_TRAKT_CLIENT_SECRET", "")}\"")
+    buildConfigField("String", "TRAKT_DEBUG_CLIENT_ID", "\"${propOrDef("TIVI_DEBUG_TRAKT_CLIENT_ID", "")}\"")
+    buildConfigField("String", "TRAKT_CLIENT_SECRET", "\"${propOrDef("TIVI_TRAKT_CLIENT_SECRET", "")}\"")
+    buildConfigField("String", "TRAKT_CLIENT_ID", "\"${propOrDef("TIVI_TRAKT_CLIENT_ID", "")}\"")
 }
 
 kotlin {
@@ -37,4 +47,9 @@ kotlin {
             }
         }
     }
+}
+
+fun <T : Any> propOrDef(propertyName: String, defaultValue: T): T {
+    @Suppress("UNCHECKED_CAST")
+    return project.properties[propertyName] as T? ?: defaultValue
 }

--- a/api/trakt/src/commonMain/kotlin/app/tivi/trakt/TraktComponent.kt
+++ b/api/trakt/src/commonMain/kotlin/app/tivi/trakt/TraktComponent.kt
@@ -11,6 +11,9 @@ import app.moviebase.trakt.api.TraktSeasonsApi
 import app.moviebase.trakt.api.TraktShowsApi
 import app.moviebase.trakt.api.TraktSyncApi
 import app.moviebase.trakt.api.TraktUsersApi
+import app.tivi.app.ApplicationInfo
+import app.tivi.data.traktauth.TraktOAuthInfo
+import app.tivi.inject.ApplicationScope
 import me.tatarka.inject.annotations.Provides
 
 interface TraktComponent : TraktCommonComponent, TraktPlatformComponent
@@ -18,6 +21,30 @@ interface TraktComponent : TraktCommonComponent, TraktPlatformComponent
 expect interface TraktPlatformComponent
 
 interface TraktCommonComponent {
+
+    @ApplicationScope
+    @Provides
+    fun provideTraktOAuthInfo(
+        appInfo: ApplicationInfo,
+    ): TraktOAuthInfo = TraktOAuthInfo(
+        clientId = when {
+            appInfo.debugBuild -> {
+                BuildConfig.TRAKT_DEBUG_CLIENT_ID.ifEmpty { BuildConfig.TRAKT_CLIENT_ID }
+            }
+
+            else -> BuildConfig.TRAKT_CLIENT_ID
+        },
+        clientSecret = when {
+            appInfo.debugBuild -> {
+                BuildConfig.TRAKT_DEBUG_CLIENT_SECRET
+                    .ifEmpty { BuildConfig.TRAKT_CLIENT_SECRET }
+            }
+
+            else -> BuildConfig.TRAKT_CLIENT_SECRET
+        },
+        redirectUri = "${appInfo.packageName}://auth/oauth2callback",
+    )
+
     @Provides
     fun provideTraktUsersService(trakt: Trakt): TraktUsersApi = trakt.users
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,6 +31,7 @@ kapt.include.compile.classpath=false
 # Disable buildFeatures flags by default
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
+android.defaults.buildFeatures.buildConfig=false
 
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.mpp.androidGradlePluginCompatibility.nowarn=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 android-lint = { id = "com.android.lint", version.ref = "agp" }
 android-test = { id = "com.android.test", version.ref = "agp" }
+buildConfig = "com.github.gmazzo.buildconfig:4.1.1"
 cacheFixPlugin = { id = "org.gradle.android.cache-fix", version = "2.7.2" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }


### PR DESCRIPTION
This allows us to move inject build config into respective modules. We use build config for injecting API keys, so we can stop using the AGP functionality in `:android-app` as a proxy.