### PR TITLE
Fix Spotless configuration

### DIFF
--- a/desktop-app/build.gradle.kts
+++ b/desktop-app/build.gradle.kts
@@ -1,3 +1,7 @@
+// Copyright 2023, Google LLC, Christopher Banes and the Tivi project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 
 // Copyright 2023, Google LLC, Christopher Banes and the Tivi project contributors

--- a/gradle/build-logic/convention/src/main/kotlin/app/tivi/gradle/Spotless.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/app/tivi/gradle/Spotless.kt
@@ -21,9 +21,8 @@ fun Project.configureSpotless() {
 
     spotless {
         kotlin {
-            target("src/**/*.kt")
-            targetExclude("$buildDir/**/*.kt")
-            targetExclude("bin/**/*.kt")
+            target("**/*.kt")
+            targetExclude("thirdparty/**/*.kt")
             ktlint(ktlintVersion)
             licenseHeaderFile(rootProject.file("spotless/google-copyright.txt"))
                 .named("google")
@@ -37,8 +36,8 @@ fun Project.configureSpotless() {
         }
 
         kotlinGradle {
-            target("src/**/*.kts")
-            targetExclude("$buildDir/**/*.kts")
+            target("**/*.kts")
+            targetExclude("thirdparty/**/*.kts")
             ktlint(ktlintVersion)
             licenseHeaderFile(rootProject.file("spotless/google-copyright.txt"), "(^(?![\\/ ]\\**).*$)")
                 .named("google")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,6 +1,7 @@
 // Copyright 2023, Google LLC, Christopher Banes and the Tivi project contributors
 // SPDX-License-Identifier: Apache-2.0
 
+
 import app.tivi.gradle.addKspDependencyForAllTargets
 import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget


### PR DESCRIPTION
- Setting Kotlin target to `"src/**/*.kt"` is correct, but it breaks Spotless for the convention plugins. This part will be fixed soon and target reverted
- Using multiple `targetExclude` is not supported, only the last call has any effect. This also means that calls to exclude `buildDir` didn't really do anything. And since there's no `"bin"` directory, removing both excludes
- There are no Gradle Kotlin scripts under the `src` directories