### PR TITLE
Fix Android back navigation

### DIFF
--- a/android-app/app/src/main/kotlin/app/tivi/home/MainActivity.kt
+++ b/android-app/app/src/main/kotlin/app/tivi/home/MainActivity.kt
@@ -29,7 +29,11 @@ import app.tivi.inject.ActivityComponent
 import app.tivi.inject.ActivityScope
 import app.tivi.inject.AndroidApplicationComponent
 import app.tivi.inject.UiComponent
+import app.tivi.screens.DiscoverScreen
 import app.tivi.settings.SettingsActivity
+import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.foundation.push
+import com.slack.circuit.foundation.rememberCircuitNavigator
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Provides
 
@@ -55,12 +59,12 @@ class MainActivity : TiviActivity() {
 
         val composeView = ComposeView(this).apply {
             setContent {
+                val backstack = rememberSaveableBackStack { push(DiscoverScreen) }
+                val navigator = rememberCircuitNavigator(backstack)
+
                 component.tiviContent(
-                    onRootPop = {
-                        if (onBackPressedDispatcher.hasEnabledCallbacks()) {
-                            onBackPressedDispatcher.onBackPressed()
-                        }
-                    },
+                    backstack = backstack,
+                    navigator = navigator,
                     onOpenSettings = {
                         context.startActivity(Intent(context, SettingsActivity::class.java))
                     },

--- a/desktop-app/src/jvmMain/kotlin/app/tivi/Main.kt
+++ b/desktop-app/src/jvmMain/kotlin/app/tivi/Main.kt
@@ -11,6 +11,10 @@ import androidx.compose.ui.window.application
 import app.tivi.inject.DesktopApplicationComponent
 import app.tivi.inject.WindowComponent
 import app.tivi.inject.create
+import app.tivi.screens.DiscoverScreen
+import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.foundation.push
+import com.slack.circuit.foundation.rememberCircuitNavigator
 
 fun main() = application {
     val applicationComponent = remember {
@@ -29,13 +33,13 @@ fun main() = application {
             WindowComponent.create(applicationComponent)
         }
 
+        val backstack = rememberSaveableBackStack { push(DiscoverScreen) }
+        val navigator = rememberCircuitNavigator(backstack) { /* no-op */ }
+
         component.tiviContent(
-            onRootPop = {
-                // TODO
-            },
-            onOpenSettings = {
-                // TODO
-            },
+            backstack = backstack,
+            navigator = navigator,
+            onOpenSettings = { /* no-op for now */ },
             modifier = Modifier,
         )
     }

--- a/ui/root/src/commonMain/kotlin/app/tivi/home/TiviContent.kt
+++ b/ui/root/src/commonMain/kotlin/app/tivi/home/TiviContent.kt
@@ -18,7 +18,6 @@ import app.tivi.common.compose.shouldUseDynamicColors
 import app.tivi.common.compose.theme.TiviTheme
 import app.tivi.core.analytics.Analytics
 import app.tivi.overlays.LocalNavigator
-import app.tivi.screens.DiscoverScreen
 import app.tivi.screens.SettingsScreen
 import app.tivi.screens.TiviScreen
 import app.tivi.settings.TiviPreferences
@@ -27,11 +26,8 @@ import app.tivi.util.TiviTextCreator
 import com.seiko.imageloader.ImageLoader
 import com.seiko.imageloader.LocalImageLoader
 import com.slack.circuit.backstack.SaveableBackStack
-import com.slack.circuit.backstack.rememberSaveableBackStack
 import com.slack.circuit.foundation.CircuitCompositionLocals
 import com.slack.circuit.foundation.CircuitConfig
-import com.slack.circuit.foundation.push
-import com.slack.circuit.foundation.rememberCircuitNavigator
 import com.slack.circuit.foundation.screen
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.Screen
@@ -39,7 +35,8 @@ import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 
 typealias TiviContent = @Composable (
-    onRootPop: () -> Unit,
+    backstack: SaveableBackStack,
+    navigator: Navigator,
     onOpenSettings: () -> Unit,
     modifier: Modifier,
 ) -> Unit
@@ -48,7 +45,8 @@ typealias TiviContent = @Composable (
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun TiviContent(
-    @Assisted onRootPop: () -> Unit,
+    @Assisted backstack: SaveableBackStack,
+    @Assisted navigator: Navigator,
     @Assisted onOpenSettings: () -> Unit,
     circuitConfig: CircuitConfig,
     analytics: Analytics,
@@ -58,11 +56,8 @@ fun TiviContent(
     imageLoader: ImageLoader,
     @Assisted modifier: Modifier = Modifier,
 ) {
-    val backstack: SaveableBackStack = rememberSaveableBackStack { push(DiscoverScreen) }
-    val circuitNavigator = rememberCircuitNavigator(backstack, onRootPop)
-
-    val navigator: Navigator = remember(circuitNavigator) {
-        TiviNavigator(circuitNavigator, onOpenSettings)
+    val tiviNavigator: Navigator = remember(navigator) {
+        TiviNavigator(navigator, onOpenSettings)
     }
 
     // Launch an effect to track changes to the current back stack entry, and push them
@@ -76,7 +71,7 @@ fun TiviContent(
     }
 
     CompositionLocalProvider(
-        LocalNavigator provides navigator,
+        LocalNavigator provides tiviNavigator,
         LocalImageLoader provides imageLoader,
         LocalTiviDateFormatter provides tiviDateFormatter,
         LocalTiviTextCreator provides tiviTextCreator,
@@ -89,7 +84,7 @@ fun TiviContent(
             ) {
                 Home(
                     backstack = backstack,
-                    navigator = navigator,
+                    navigator = tiviNavigator,
                     modifier = modifier,
                 )
             }

--- a/ui/root/src/iosMain/kotlin/app/tivi/home/TiviUiViewController.kt
+++ b/ui/root/src/iosMain/kotlin/app/tivi/home/TiviUiViewController.kt
@@ -5,6 +5,10 @@ package app.tivi.home
 
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.ComposeUIViewController
+import app.tivi.screens.DiscoverScreen
+import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.foundation.push
+import com.slack.circuit.foundation.rememberCircuitNavigator
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 import platform.UIKit.UIViewController
@@ -20,8 +24,12 @@ fun TiviUiViewController(
     @Assisted onOpenSettings: () -> Unit,
     tiviContent: TiviContent,
 ): UIViewController = ComposeUIViewController {
+    val backstack = rememberSaveableBackStack { push(DiscoverScreen) }
+    val navigator = rememberCircuitNavigator(backstack, onRootPop)
+
     tiviContent(
-        onRootPop = onRootPop,
+        backstack = backstack,
+        navigator = navigator,
         onOpenSettings = onOpenSettings,
         modifier = Modifier,
     )


### PR DESCRIPTION
The common implementation of Circuit's rememberCircuitNavigator doesn't do any back handling. Hoisting the backstack and navigator up to each platform fixes it.