### PR TITLE
Dismiss the keyboard when clearing search field

### DIFF
--- a/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/ui/SearchTextField.kt
+++ b/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/ui/SearchTextField.kt
@@ -3,9 +3,6 @@
 
 package app.tivi.common.compose.ui
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -17,12 +14,14 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.TextFieldValue
 import app.tivi.common.ui.resources.MR
 import dev.icerock.moko.resources.compose.stringResource
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun SearchTextField(
     value: TextFieldValue,
@@ -31,9 +30,10 @@ fun SearchTextField(
     modifier: Modifier = Modifier,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions(),
-    showClearButton: Boolean = value.text.isNotEmpty(),
     onCleared: (() -> Unit) = { onValueChange(TextFieldValue()) },
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+
     TextField(
         value = value,
         onValueChange = onValueChange,
@@ -44,17 +44,18 @@ fun SearchTextField(
             )
         },
         trailingIcon = {
-            AnimatedVisibility(
-                visible = showClearButton,
-                enter = fadeIn(),
-                exit = fadeOut(),
+            IconButton(
+                onClick = {
+                    onCleared()
+                    // This is mostly for iOS, otherwise there is no way to dismiss the iOS
+                    // keyboard once opened.
+                    keyboardController?.hide()
+                },
             ) {
-                IconButton(onClick = onCleared) {
-                    Icon(
-                        imageVector = Icons.Default.Clear,
-                        contentDescription = stringResource(MR.strings.cd_clear_text),
-                    )
-                }
+                Icon(
+                    imageVector = Icons.Default.Clear,
+                    contentDescription = stringResource(MR.strings.cd_clear_text),
+                )
             }
         },
         placeholder = { Text(text = hint) },

--- a/ui/library/src/commonMain/kotlin/app/tivi/home/library/Library.kt
+++ b/ui/library/src/commonMain/kotlin/app/tivi/home/library/Library.kt
@@ -285,7 +285,6 @@ private fun LibraryGrid(
                         },
                         hint = stringResource(MR.strings.filter_shows, lazyPagingItems.itemCount),
                         modifier = Modifier.fillMaxWidth(),
-                        showClearButton = true,
                         onCleared = {
                             filter = TextFieldValue()
                             onFilterChanged("")


### PR DESCRIPTION
At the moment there is no way to dismiss the keyboard on iOS once opened from Search.