### PR TITLE
Add iOS implementation of ShowTasks

### DIFF
--- a/ios-app/Tivi/Tivi/Info.plist
+++ b/ios-app/Tivi/Tivi/Info.plist
@@ -2,9 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>app.tivi.tasks.libraryshows.nightly</string>
+	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>processing</string>
+	</array>
 </dict>
 </plist>

--- a/tasks/build.gradle.kts
+++ b/tasks/build.gradle.kts
@@ -12,13 +12,14 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(projects.core.base)
+                implementation(projects.core.logging)
+                implementation(projects.domain)
                 implementation(libs.kotlininject.runtime)
             }
         }
 
         val androidMain by getting {
             dependencies {
-                implementation(projects.domain)
                 api(libs.androidx.work.runtime)
             }
         }

--- a/tasks/src/androidMain/kotlin/app/tivi/tasks/AndroidShowTasks.kt
+++ b/tasks/src/androidMain/kotlin/app/tivi/tasks/AndroidShowTasks.kt
@@ -6,10 +6,8 @@ package app.tivi.tasks
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
-import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
-import app.tivi.extensions.fluentIf
 import java.util.concurrent.TimeUnit
 import me.tatarka.inject.annotations.Inject
 
@@ -17,21 +15,7 @@ import me.tatarka.inject.annotations.Inject
 class AndroidShowTasks(
     private val workManager: WorkManager,
 ) : ShowTasks {
-    override fun syncLibraryShows(deferUntilIdle: Boolean) {
-        val request = OneTimeWorkRequestBuilder<SyncLibraryShows>()
-            .addTag(SyncLibraryShows.TAG)
-            .fluentIf(deferUntilIdle) {
-                setConstraints(
-                    Constraints.Builder()
-                        .setRequiresDeviceIdle(true)
-                        .build(),
-                )
-            }
-            .build()
-        workManager.enqueue(request)
-    }
-
-    override fun setupNightSyncs() {
+    override fun register() {
         val nightlyConstraints = Constraints.Builder()
             .setRequiredNetworkType(NetworkType.UNMETERED)
             .setRequiresCharging(true)

--- a/tasks/src/androidMain/kotlin/app/tivi/tasks/SyncLibraryShows.kt
+++ b/tasks/src/androidMain/kotlin/app/tivi/tasks/SyncLibraryShows.kt
@@ -15,17 +15,16 @@ import me.tatarka.inject.annotations.Inject
 class SyncLibraryShows(
     @Assisted context: Context,
     @Assisted params: WorkerParameters,
-    private val updateLibraryShows: UpdateLibraryShows,
+    private val updateLibraryShows: Lazy<UpdateLibraryShows>,
     private val logger: Logger,
 ) : CoroutineWorker(context, params) {
     companion object {
-        internal const val TAG = "sync-all-followed-shows"
         internal const val NIGHTLY_SYNC_TAG = "night-sync-all-followed-shows"
     }
 
     override suspend fun doWork(): Result {
         logger.d { "$tags worker running" }
-        val result = updateLibraryShows(UpdateLibraryShows.Params(true))
+        val result = updateLibraryShows.value(UpdateLibraryShows.Params(true))
         return when {
             result.isSuccess -> Result.success()
             else -> Result.failure()

--- a/tasks/src/commonMain/kotlin/app/tivi/tasks/ShowTasks.kt
+++ b/tasks/src/commonMain/kotlin/app/tivi/tasks/ShowTasks.kt
@@ -4,6 +4,5 @@
 package app.tivi.tasks
 
 interface ShowTasks {
-    fun syncLibraryShows(deferUntilIdle: Boolean = false)
-    fun setupNightSyncs()
+    fun register()
 }

--- a/tasks/src/commonMain/kotlin/app/tivi/tasks/ShowTasksInitializer.kt
+++ b/tasks/src/commonMain/kotlin/app/tivi/tasks/ShowTasksInitializer.kt
@@ -11,6 +11,6 @@ class ShowTasksInitializer(
     private val showTasks: Lazy<ShowTasks>,
 ) : AppInitializer {
     override fun initialize() {
-        showTasks.value.setupNightSyncs()
+        showTasks.value.register()
     }
 }

--- a/tasks/src/iosMain/kotlin/app/tivi/tasks/IosShowTasks.kt
+++ b/tasks/src/iosMain/kotlin/app/tivi/tasks/IosShowTasks.kt
@@ -1,0 +1,114 @@
+// Copyright 2023, Christopher Banes and the Tivi project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package app.tivi.tasks
+
+import app.tivi.domain.interactors.UpdateLibraryShows
+import app.tivi.util.Logger
+import kotlin.time.Duration.Companion.hours
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import kotlinx.datetime.toNSDate
+import me.tatarka.inject.annotations.Inject
+import platform.BackgroundTasks.BGProcessingTaskRequest
+import platform.BackgroundTasks.BGTask
+import platform.BackgroundTasks.BGTaskScheduler
+import platform.Foundation.NSCalendar
+import platform.Foundation.NSCalendarMatchStrictly
+import platform.Foundation.NSDate
+
+@Inject
+class IosShowTasks(
+    private val updateLibraryShows: Lazy<UpdateLibraryShows>,
+    private val logger: Logger,
+) : ShowTasks {
+    private val taskScheduler by lazy { BGTaskScheduler.sharedScheduler }
+    private val scope by lazy { MainScope() + CoroutineName("app.tivi.tasks.IosShowTasks") }
+
+    override fun register() {
+        taskScheduler.registerForTaskWithIdentifier(
+            identifier = ID_LIBRARY_SHOWS_NIGHTLY,
+            usingQueue = null,
+            launchHandler = { task -> handleTask(task!!) },
+        )
+        logger.d { "Registered task [$ID_LIBRARY_SHOWS_NIGHTLY] with BGTaskScheduler" }
+
+        // Now schedule the next nightly sync
+        scheduleTask(id = ID_LIBRARY_SHOWS_NIGHTLY, earliest = nextEarliestNightlySyncDate())
+    }
+
+    private fun handleTask(task: BGTask) = when (task.identifier) {
+        ID_LIBRARY_SHOWS_NIGHTLY -> {
+            task.runInteractor {
+                updateLibraryShows.value(UpdateLibraryShows.Params(true))
+            }
+            // Now schedule another task
+            scheduleTask(
+                id = ID_LIBRARY_SHOWS_NIGHTLY,
+                earliest = (Clock.System.now() + 22.hours).toNSDate(),
+            )
+        }
+
+        else -> Unit
+    }
+
+    private fun scheduleTask(
+        id: String,
+        earliest: NSDate,
+        requireNetwork: Boolean = true,
+    ) {
+        val request = BGProcessingTaskRequest(identifier = id).apply {
+            earliestBeginDate = earliest
+            requiresNetworkConnectivity = requireNetwork
+        }
+
+        try {
+            BGTaskScheduler.sharedScheduler.submitTaskRequest(taskRequest = request, error = null)
+            logger.d { "Scheduled task $id. Earliest date: $earliest" }
+        } catch (t: Throwable) {
+            logger.e(t) { "Error whilst submitting BGTaskScheduler request: $request" }
+        }
+    }
+
+    private fun BGTask.runInteractor(block: suspend () -> Unit) {
+        logger.d { "Starting to run task [$identifier]" }
+
+        val job = scope.launch { block() }
+
+        expirationHandler = {
+            logger.d { "Expiration handler called for task [$identifier]" }
+            setTaskCompletedWithSuccess(false)
+            job.cancel()
+        }
+
+        runBlocking {
+            try {
+                job.join()
+                setTaskCompletedWithSuccess(true)
+                logger.d { "Task [$identifier] finished successfully" }
+            } catch (e: Throwable) {
+                setTaskCompletedWithSuccess(false)
+                logger.d(e) { "Exception thrown whilst running task [$identifier]" }
+            }
+        }
+    }
+
+    companion object {
+        const val ID_LIBRARY_SHOWS_NIGHTLY = "app.tivi.tasks.libraryshows.nightly"
+    }
+}
+
+/**
+ * Returns the next date at 03:00
+ */
+private fun nextEarliestNightlySyncDate(): NSDate = NSCalendar.currentCalendar().nextDateAfterDate(
+    date = NSDate(),
+    matchingHour = 3,
+    minute = 0,
+    second = 0,
+    options = NSCalendarMatchStrictly,
+)!!

--- a/tasks/src/iosMain/kotlin/app/tivi/tasks/TasksPlatformComponent.kt
+++ b/tasks/src/iosMain/kotlin/app/tivi/tasks/TasksPlatformComponent.kt
@@ -9,13 +9,5 @@ import me.tatarka.inject.annotations.Provides
 actual interface TasksPlatformComponent {
     @ApplicationScope
     @Provides
-    fun provideShowTasks(): ShowTasks = EmptyShowTasks
-}
-
-object EmptyShowTasks : ShowTasks {
-    override fun syncLibraryShows(deferUntilIdle: Boolean) {
-    }
-
-    override fun setupNightSyncs() {
-    }
+    fun provideShowTasks(bind: IosShowTasks): ShowTasks = bind
 }

--- a/tasks/src/jvmMain/kotlin/app/tivi/tasks/TasksPlatformComponent.kt
+++ b/tasks/src/jvmMain/kotlin/app/tivi/tasks/TasksPlatformComponent.kt
@@ -13,9 +13,5 @@ actual interface TasksPlatformComponent {
 }
 
 object EmptyShowTasks : ShowTasks {
-    override fun syncLibraryShows(deferUntilIdle: Boolean) {
-    }
-
-    override fun setupNightSyncs() {
-    }
+    override fun register() = Unit
 }


### PR DESCRIPTION
This uses `BGTaskScheduler` and `BGProcessingTask` to implement a nightly sync of user data. We probably could have got away with BGAppRefreshTask but the extra functionality of `requiresNetworkConnectivity` makes using BGProcessingTask worth it.

Fixes #1381