### PR TITLE
Use native date/time pickers on iOS

### DIFF
--- a/common/ui/compose/build.gradle.kts
+++ b/common/ui/compose/build.gradle.kts
@@ -30,17 +30,27 @@ kotlin {
                 implementation(compose.animation)
 
                 api(libs.insetsx)
-
-                implementation(libs.materialdialogs.core)
-                implementation(projects.thirdparty.composeMaterialDialogs.datetime)
-
                 implementation(libs.uuid)
 
                 implementation(libs.paging.compose)
             }
         }
 
+        val jvmCommon by creating {
+            dependsOn(commonMain)
+
+            dependencies {
+                implementation(projects.thirdparty.composeMaterialDialogs.datetime)
+            }
+        }
+
+        val jvmMain by getting {
+            dependsOn(jvmCommon)
+        }
+
         val androidMain by getting {
+            dependsOn(jvmCommon)
+
             dependencies {
                 implementation(libs.androidx.activity.compose)
             }

--- a/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/ui/DateTimeDialogs.kt
+++ b/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/ui/DateTimeDialogs.kt
@@ -1,0 +1,39 @@
+// Copyright 2023, Christopher Banes and the Tivi project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package app.tivi.common.compose.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import app.tivi.common.ui.resources.MR
+import dev.icerock.moko.resources.compose.stringResource
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+@Composable
+expect fun DatePickerDialog(
+    onDismissRequest: () -> Unit,
+    onDateChanged: (LocalDate) -> Unit,
+    selectedDate: LocalDate = remember {
+        Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+    },
+    confirmLabel: String = stringResource(MR.strings.button_confirm),
+    minimumDate: LocalDate? = null,
+    maximumDate: LocalDate? = null,
+    title: String = "",
+)
+
+@Composable
+expect fun TimePickerDialog(
+    onDismissRequest: () -> Unit,
+    onTimeChanged: (LocalTime) -> Unit,
+    selectedTime: LocalTime = remember {
+        Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).time
+    },
+    confirmLabel: String = stringResource(MR.strings.button_confirm),
+    title: String = "",
+    is24Hour: Boolean = false,
+)

--- a/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/ui/DateTimeTextFields.kt
+++ b/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/ui/DateTimeTextFields.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -26,16 +25,11 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
 import app.tivi.common.compose.LocalTiviDateFormatter
 import app.tivi.common.ui.resources.MR
-import com.vanpra.composematerialdialogs.datetime.date.DatePicker
-import com.vanpra.composematerialdialogs.datetime.time.TimePicker
 import dev.icerock.moko.resources.compose.stringResource
 import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -64,41 +58,25 @@ fun DateTextField(
         )
 
         if (showDialog) {
-            AlertDialog(
+            DatePickerDialog(
                 onDismissRequest = { showDialog = false },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            date?.let(lastOnDateSelected)
-                            showDialog = false
-                        },
-                    ) {
-                        Text(text = stringResource(MR.strings.button_confirm))
-                    }
+                selectedDate = selectedDate ?: remember {
+                    Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
                 },
-                text = {
-                    DatePicker(
-                        title = dialogTitle,
-                        initialDate = selectedDate ?: remember {
-                            Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
-                        },
-                        allowedDateValidator = { date ->
-                            // Only allow dates in the past
-                            date.toInstant() < Clock.System.now()
-                        },
-                        onDateChange = { date = it },
-                    )
+                onDateChanged = {
+                    date = it
+                    lastOnDateSelected(it)
                 },
+                maximumDate = remember {
+                    Clock.System.now()
+                        .toLocalDateTime(TimeZone.currentSystemDefault())
+                        .date
+                },
+                title = dialogTitle,
             )
         }
     }
 }
-
-private fun LocalDate.toInstant(): Instant {
-    return LocalDateTime(this, midday).toInstant(TimeZone.currentSystemDefault())
-}
-
-private val midday: LocalTime by lazy { LocalTime(12, 0, 0, 0) }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -107,7 +85,7 @@ fun TimeTextField(
     onTimeSelected: (LocalTime) -> Unit,
     dialogTitle: String,
     modifier: Modifier = Modifier,
-    is24Hour: Boolean = false,
+    @Suppress("UNUSED_PARAMETER") is24Hour: Boolean = false,
 ) {
     Box(modifier) {
         val dateFormatter = LocalTiviDateFormatter.current
@@ -127,28 +105,16 @@ fun TimeTextField(
         )
 
         if (showDialog) {
-            AlertDialog(
+            TimePickerDialog(
                 onDismissRequest = { showDialog = false },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            time?.let(lastOnTimeSelected)
-                            showDialog = false
-                        },
-                    ) {
-                        Text(text = stringResource(MR.strings.button_confirm))
-                    }
+                selectedTime = selectedTime ?: remember {
+                    Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).time
                 },
-                text = {
-                    TimePicker(
-                        title = dialogTitle,
-                        initialTime = selectedTime ?: remember {
-                            Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).time
-                        },
-                        is24HourClock = is24Hour,
-                        onTimeChange = { time = it },
-                    )
+                onTimeChanged = {
+                    time = it
+                    lastOnTimeSelected(it)
                 },
+                title = dialogTitle,
             )
         }
     }

--- a/common/ui/compose/src/iosMain/kotlin/app/tivi/common/compose/ui/DateTimeDialogs.kt
+++ b/common/ui/compose/src/iosMain/kotlin/app/tivi/common/compose/ui/DateTimeDialogs.kt
@@ -1,0 +1,277 @@
+// Copyright 2023, Christopher Banes and the Tivi project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package app.tivi.common.compose.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.surfaceColorAtElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.interop.LocalUIViewController
+import androidx.compose.ui.unit.dp
+import kotlinx.cinterop.ExportObjCClass
+import kotlinx.cinterop.ObjCAction
+import kotlinx.cinterop.cstr
+import kotlinx.coroutines.DisposableHandle
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toKotlinInstant
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.toNSDateComponents
+import platform.Foundation.NSCalendar
+import platform.Foundation.NSDate
+import platform.Foundation.NSSelectorFromString
+import platform.UIKit.NSLayoutConstraint
+import platform.UIKit.UIButton
+import platform.UIKit.UIButtonConfiguration
+import platform.UIKit.UIColor
+import platform.UIKit.UIControl
+import platform.UIKit.UIControlEventTouchUpInside
+import platform.UIKit.UIControlEventValueChanged
+import platform.UIKit.UIControlEvents
+import platform.UIKit.UIControlStateNormal
+import platform.UIKit.UIDatePicker
+import platform.UIKit.UIDatePickerMode
+import platform.UIKit.UIDatePickerStyle
+import platform.UIKit.UIEdgeInsetsMake
+import platform.UIKit.UILayoutConstraintAxisVertical
+import platform.UIKit.UISheetPresentationControllerDetent
+import platform.UIKit.UIStackView
+import platform.UIKit.UIViewController
+import platform.UIKit.sheetPresentationController
+import platform.darwin.NSObject
+import platform.objc.OBJC_ASSOCIATION_RETAIN
+import platform.objc.objc_removeAssociatedObjects
+import platform.objc.objc_setAssociatedObject
+
+@Composable
+actual fun TimePickerDialog(
+    onDismissRequest: () -> Unit,
+    onTimeChanged: (LocalTime) -> Unit,
+    selectedTime: LocalTime,
+    confirmLabel: String,
+    title: String,
+    is24Hour: Boolean,
+) {
+    DatePickerViewController(
+        selectedDate = NSCalendar.currentCalendar().dateBySettingHour(
+            h = selectedTime.hour.toLong(),
+            minute = selectedTime.minute.toLong(),
+            second = 0,
+            ofDate = NSDate(),
+            options = 0,
+        )!!,
+        confirmLabel = confirmLabel,
+        onDateChanged = { date ->
+            onTimeChanged(
+                date.toKotlinInstant()
+                    .toLocalDateTime(TimeZone.currentSystemDefault())
+                    .time,
+            )
+        },
+        datePickerCustomizer = {
+            setPreferredDatePickerStyle(UIDatePickerStyle.UIDatePickerStyleWheels)
+            datePickerMode = UIDatePickerMode.UIDatePickerModeTime
+            maximumDate = NSDate() // has to be in past
+        },
+        onDismissRequest = onDismissRequest,
+    )
+}
+
+@Composable
+actual fun DatePickerDialog(
+    onDismissRequest: () -> Unit,
+    onDateChanged: (LocalDate) -> Unit,
+    selectedDate: LocalDate,
+    confirmLabel: String,
+    minimumDate: LocalDate?,
+    maximumDate: LocalDate?,
+    title: String,
+) {
+    DatePickerViewController(
+        selectedDate = NSCalendar.currentCalendar().dateFromComponents(
+            LocalDateTime(selectedDate, midday).toNSDateComponents(),
+        )!!,
+        confirmLabel = confirmLabel,
+        onDateChanged = { date ->
+            onDateChanged(
+                date.toKotlinInstant()
+                    .toLocalDateTime(TimeZone.currentSystemDefault())
+                    .date,
+            )
+        },
+        datePickerCustomizer = {
+            setPreferredDatePickerStyle(UIDatePickerStyle.UIDatePickerStyleInline)
+            datePickerMode = UIDatePickerMode.UIDatePickerModeDate
+
+            val cal = NSCalendar.currentCalendar()
+            this.minimumDate = minimumDate?.toNSDateComponents()?.let { comps ->
+                cal.dateFromComponents(comps)
+            }
+            this.maximumDate = maximumDate?.toNSDateComponents()?.let { comps ->
+                cal.dateFromComponents(comps)
+            }
+        },
+        onDismissRequest = onDismissRequest,
+    )
+}
+
+@Composable
+internal fun DatePickerViewController(
+    confirmLabel: String,
+    selectedDate: NSDate,
+    onDateChanged: (NSDate) -> Unit,
+    onDismissRequest: () -> Unit,
+    datePickerCustomizer: UIDatePicker.() -> Unit = {},
+    backgroundColor: Color = MaterialTheme.colorScheme.surfaceColorAtElevation(6.dp),
+) {
+    val viewController = LocalUIViewController.current
+
+    val lastOnDateChanged by rememberUpdatedState(onDateChanged)
+    val lastOnDismissRequest by rememberUpdatedState(onDismissRequest)
+
+    val datePickerViewController = remember {
+        DatePickerViewController(backgroundColor).apply {
+            datePickerCustomizer(datePicker)
+
+            confirmButton.setTitle(confirmLabel, UIControlStateNormal)
+        }
+    }
+
+    DisposableEffect(datePickerViewController) {
+        val handle = datePickerViewController.datePicker
+            .addEventHandler(UIControlEventValueChanged) {
+                lastOnDateChanged(date)
+            }
+        onDispose {
+            handle.dispose()
+        }
+    }
+
+    DisposableEffect(datePickerViewController) {
+        val handle = datePickerViewController.confirmButton
+            .addEventHandler(UIControlEventTouchUpInside) {
+                lastOnDismissRequest()
+            }
+        onDispose {
+            handle.dispose()
+        }
+    }
+
+    LaunchedEffect(datePickerViewController, selectedDate) {
+        datePickerViewController.datePicker.setDate(selectedDate)
+    }
+
+    DisposableEffect(viewController, datePickerViewController) {
+        datePickerViewController.sheetPresentationController?.apply {
+            detents = listOf(UISheetPresentationControllerDetent.mediumDetent())
+        }
+
+        viewController.presentViewController(datePickerViewController, true, null)
+
+        datePickerViewController.onViewDisappeared = { lastOnDismissRequest() }
+
+        onDispose {
+            datePickerViewController.dismissViewControllerAnimated(true) {
+                lastOnDismissRequest()
+            }
+        }
+    }
+}
+
+private class DatePickerViewController(
+    private val backgroundColor: Color,
+) : UIViewController(nibName = null, bundle = null) {
+    val datePicker = UIDatePicker().apply {
+        translatesAutoresizingMaskIntoConstraints = false
+    }
+    val confirmButton = UIButton().apply {
+        configuration = UIButtonConfiguration.borderlessButtonConfiguration()
+        translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    val stack = UIStackView().apply {
+        axis = UILayoutConstraintAxisVertical
+        spacing = 16.0
+        layoutMarginsRelativeArrangement = true
+        layoutMargins = UIEdgeInsetsMake(24.0, 24.0, 24.0, 24.0)
+        translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    var onViewDisappeared: () -> Unit = {}
+
+    override fun viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = UIColor(
+            red = backgroundColor.red.toDouble(),
+            green = backgroundColor.green.toDouble(),
+            blue = backgroundColor.blue.toDouble(),
+            alpha = backgroundColor.alpha.toDouble(),
+        )
+
+        view.addSubview(stack)
+
+        NSLayoutConstraint.activateConstraints(
+            listOf(
+                stack.topAnchor.constraintEqualToAnchor(view.topAnchor),
+                stack.trailingAnchor.constraintEqualToAnchor(view.trailingAnchor),
+                stack.leadingAnchor.constraintEqualToAnchor(view.leadingAnchor),
+            ),
+        )
+
+        stack.insertArrangedSubview(datePicker, 0)
+        stack.insertArrangedSubview(confirmButton, 1)
+    }
+
+    override fun viewDidDisappear(animated: Boolean) {
+        super.viewDidDisappear(animated)
+        onViewDisappeared()
+    }
+}
+
+private val midday by lazy { LocalTime(12, 0, 0, 0) }
+
+fun <T : UIControl> T.addEventHandler(
+    event: UIControlEvents,
+    lambda: T.() -> Unit,
+): DisposableHandle {
+    val lambdaTarget = ControlLambdaTarget(lambda)
+    val action = NSSelectorFromString("action:")
+
+    addTarget(
+        target = lambdaTarget,
+        action = action,
+        forControlEvents = event,
+    )
+
+    objc_setAssociatedObject(
+        `object` = this,
+        key = "event$event".cstr,
+        value = lambdaTarget,
+        policy = OBJC_ASSOCIATION_RETAIN,
+    )
+
+    return DisposableHandle {
+        removeTarget(target = lambdaTarget, action = action, forControlEvents = event)
+        objc_removeAssociatedObjects(this@addEventHandler)
+    }
+}
+
+@ExportObjCClass
+private class ControlLambdaTarget<T : UIControl>(
+    private val lambda: T.() -> Unit,
+) : NSObject() {
+    @ObjCAction
+    fun action(sender: UIControl) {
+        @Suppress("UNCHECKED_CAST")
+        lambda(sender as T)
+    }
+}

--- a/common/ui/compose/src/jvmCommon/kotlin/app/tivi/common/compose/ui/DateTimeDialogs.kt
+++ b/common/ui/compose/src/jvmCommon/kotlin/app/tivi/common/compose/ui/DateTimeDialogs.kt
@@ -1,0 +1,76 @@
+// Copyright 2023, Christopher Banes and the Tivi project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package app.tivi.common.compose.ui
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.vanpra.composematerialdialogs.datetime.date.DatePicker
+import com.vanpra.composematerialdialogs.datetime.time.TimePicker
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
+
+@Composable
+actual fun TimePickerDialog(
+    onDismissRequest: () -> Unit,
+    onTimeChanged: (LocalTime) -> Unit,
+    selectedTime: LocalTime,
+    confirmLabel: String,
+    title: String,
+    is24Hour: Boolean,
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            Button(onClick = onDismissRequest) {
+                Text(text = confirmLabel)
+            }
+        },
+        text = {
+            TimePicker(
+                title = title,
+                initialTime = selectedTime,
+                is24HourClock = false,
+                onTimeChange = onTimeChanged,
+            )
+        },
+    )
+}
+
+@Composable
+actual fun DatePickerDialog(
+    onDismissRequest: () -> Unit,
+    onDateChanged: (LocalDate) -> Unit,
+    selectedDate: LocalDate,
+    confirmLabel: String,
+    minimumDate: LocalDate?,
+    maximumDate: LocalDate?,
+    title: String,
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            Button(onClick = onDismissRequest) {
+                Text(text = confirmLabel)
+            }
+        },
+        text = {
+            DatePicker(
+                title = title,
+                initialDate = selectedDate,
+                onDateChange = onDateChanged,
+                allowedDateValidator = { date ->
+                    when {
+                        minimumDate != null && date < minimumDate -> false
+                        maximumDate != null && date > maximumDate -> false
+                        else -> true
+                    }
+                },
+            )
+        },
+    )
+}


### PR DESCRIPTION
This PR moves the existing date/picker Compose based implementation to `jvmCommon` and used for Android + Desktop.

We add a new implementation for iOS which uses a Modal `UIViewController` with an appropriately configured `UIDatePicker` view, all driven from Compose.


https://github.com/chrisbanes/tivi/assets/227486/88628032-1269-493a-aca0-40547348f03b

