### PR TITLE
Move database operations to specific dispatchers

### DIFF
--- a/core/base/src/commonMain/kotlin/app/tivi/util/AppCoroutineDispatchers.kt
+++ b/core/base/src/commonMain/kotlin/app/tivi/util/AppCoroutineDispatchers.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.CoroutineDispatcher
 
 data class AppCoroutineDispatchers(
     val io: CoroutineDispatcher,
+    val databaseWrite: CoroutineDispatcher,
+    val databaseRead: CoroutineDispatcher,
     val computation: CoroutineDispatcher,
     val main: CoroutineDispatcher,
 )

--- a/data/db-sqldelight/src/iosMain/kotlin/app/tivi/data/SqlDelightDatabasePlatformComponent.kt
+++ b/data/db-sqldelight/src/iosMain/kotlin/app/tivi/data/SqlDelightDatabasePlatformComponent.kt
@@ -15,7 +15,13 @@ actual interface SqlDelightDatabasePlatformComponent {
     fun provideDriverFactory(configuration: DatabaseConfiguration): SqlDriver {
         return when {
             configuration.inMemory -> inMemoryDriver(Database.Schema)
-            else -> NativeSqliteDriver(schema = Database.Schema, name = "tivi.db")
+            else -> {
+                NativeSqliteDriver(
+                    schema = Database.Schema,
+                    name = "tivi.db",
+                    maxReaderConnections = 4,
+                )
+            }
         }.also { driver ->
             driver.execute(null, "PRAGMA foreign_keys=ON", 0)
         }

--- a/data/test/src/commonTest/kotlin/app/tivi/data/TestDatabaseInject.kt
+++ b/data/test/src/commonTest/kotlin/app/tivi/data/TestDatabaseInject.kt
@@ -90,6 +90,8 @@ abstract class TestDataSourceComponent :
         val testDispatcher = UnconfinedTestDispatcher()
         return AppCoroutineDispatchers(
             io = testDispatcher,
+            databaseRead = testDispatcher,
+            databaseWrite = testDispatcher,
             computation = testDispatcher,
             main = testDispatcher,
         )

--- a/shared/src/commonMain/kotlin/app/tivi/inject/SharedApplicationComponent.kt
+++ b/shared/src/commonMain/kotlin/app/tivi/inject/SharedApplicationComponent.kt
@@ -29,6 +29,7 @@ import app.tivi.util.AppCoroutineDispatchers
 import app.tivi.util.LoggerComponent
 import app.tivi.util.PowerControllerComponent
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.IO
 import me.tatarka.inject.annotations.IntoSet
 import me.tatarka.inject.annotations.Provides
@@ -52,10 +53,13 @@ interface CoreComponent :
     /**
      * Need to wait to upgrade to Coroutines 1.7.x so we can reference IO from common
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     @ApplicationScope
     @Provides
     fun provideCoroutineDispatchers(): AppCoroutineDispatchers = AppCoroutineDispatchers(
         io = Dispatchers.IO,
+        databaseWrite = Dispatchers.IO.limitedParallelism(1),
+        databaseRead = Dispatchers.IO.limitedParallelism(4),
         computation = Dispatchers.Default,
         main = Dispatchers.Main,
     )

--- a/ui/settings/src/main/kotlin/app/tivi/settings/SettingsActivity.kt
+++ b/ui/settings/src/main/kotlin/app/tivi/settings/SettingsActivity.kt
@@ -51,6 +51,8 @@ abstract class SettingsActivityComponent(
     @Provides
     fun provideCoroutineDispatchers(): AppCoroutineDispatchers = AppCoroutineDispatchers(
         io = Dispatchers.IO,
+        databaseWrite = Dispatchers.IO,
+        databaseRead = Dispatchers.IO,
         computation = Dispatchers.Default,
         main = Dispatchers.Main,
     )


### PR DESCRIPTION
Reads are limited to a dispatcher with a parallelism of 4, which is equal to the newly set maximum connection readers on the SQLite driver.

Writes are limited to a parallelism of 1, since that is what SQLDelight will do under the hood anyway. This seems to fix concurrency issues which result in crashes, such as https://github.com/cashapp/sqldelight/issues/4376.