### PR TITLE
Increase touch slop on iOS

### DIFF
--- a/ui/root/src/iosMain/kotlin/app/tivi/home/TiviUiViewController.kt
+++ b/ui/root/src/iosMain/kotlin/app/tivi/home/TiviUiViewController.kt
@@ -35,7 +35,7 @@ fun TiviUiViewController(
     // Android default value of 8.dp
     // https://github.com/JetBrains/compose-multiplatform/issues/3397
     val vc = LocalViewConfiguration.current.withTouchSlop(
-        with(LocalDensity.current) { 8.dp.toPx() }
+        with(LocalDensity.current) { 8.dp.toPx() },
     )
 
     CompositionLocalProvider(LocalViewConfiguration provides vc) {
@@ -52,7 +52,7 @@ fun TiviUiViewController(
 }
 
 private fun ViewConfiguration.withTouchSlop(
-    touchSlop: Float
+    touchSlop: Float,
 ): ViewConfiguration = object : ViewConfiguration by this {
     override val touchSlop: Float = touchSlop
 }

--- a/ui/root/src/iosMain/kotlin/app/tivi/home/TiviUiViewController.kt
+++ b/ui/root/src/iosMain/kotlin/app/tivi/home/TiviUiViewController.kt
@@ -3,8 +3,13 @@
 
 package app.tivi.home
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.interop.LocalUIViewController
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.platform.ViewConfiguration
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ComposeUIViewController
 import app.tivi.screens.DiscoverScreen
 import com.slack.circuit.backstack.rememberSaveableBackStack
@@ -26,13 +31,28 @@ fun TiviUiViewController(
 
     val uiViewController = LocalUIViewController.current
 
-    tiviContent(
-        backstack = backstack,
-        navigator = navigator,
-        onOpenUrl = { url ->
-            val safari = SFSafariViewController(NSURL(string = url))
-            uiViewController.presentViewController(safari, animated = true, completion = null)
-        },
-        modifier = Modifier,
+    // Increase the touch slop. The default value of 3.dp is a bit low imo, so we use the
+    // Android default value of 8.dp
+    // https://github.com/JetBrains/compose-multiplatform/issues/3397
+    val vc = LocalViewConfiguration.current.withTouchSlop(
+        with(LocalDensity.current) { 8.dp.toPx() }
     )
+
+    CompositionLocalProvider(LocalViewConfiguration provides vc) {
+        tiviContent(
+            backstack = backstack,
+            navigator = navigator,
+            onOpenUrl = { url ->
+                val safari = SFSafariViewController(NSURL(string = url))
+                uiViewController.presentViewController(safari, animated = true, completion = null)
+            },
+            modifier = Modifier,
+        )
+    }
+}
+
+private fun ViewConfiguration.withTouchSlop(
+    touchSlop: Float
+): ViewConfiguration = object : ViewConfiguration by this {
+    override val touchSlop: Float = touchSlop
 }


### PR DESCRIPTION
The default value of 3.dp is a bit low imo, so we use the Android default value of 8.dp.

https://github.com/JetBrains/compose-multiplatform/issues/3397