### PR TITLE
Tweaks for iOS Gesture Navigation

### DIFF
--- a/ui/episode/details/src/commonMain/kotlin/app/tivi/episodedetails/EpisodeDetails.kt
+++ b/ui/episode/details/src/commonMain/kotlin/app/tivi/episodedetails/EpisodeDetails.kt
@@ -162,7 +162,7 @@ internal fun EpisodeDetails(
 
     Surface(
         modifier = modifier
-            .fillMaxWidth()
+            .fillMaxSize()
             .testTag("episode_details"),
     ) {
         Column {


### PR DESCRIPTION
- Reduce the swipeable area to the start-most `16.dp`
- Add nested scrolling support. This is useful for Show Seasons where the content is a `HorizontalPager`
- Fix `EpisodeDetails` not filling the entire window. This caused weirdness with the swipe gesture.