### PR TITLE
Fix IllegalStateException when Firebase config isn't available

### DIFF
--- a/core/logging/implementation/src/androidMain/kotlin/app/tivi/util/TimberLogger.kt
+++ b/core/logging/implementation/src/androidMain/kotlin/app/tivi/util/TimberLogger.kt
@@ -21,7 +21,11 @@ internal object TimberLogger : Logger {
     }
 
     override fun setUserId(id: String) {
-        CrashlyticsKotlin.setCustomValue("username", id)
+        try {
+            CrashlyticsKotlin.setCustomValue("username", id)
+        } catch (t: Throwable) {
+            // Firebase might not be setup
+        }
     }
 
     override fun v(throwable: Throwable?, message: () -> String) {


### PR DESCRIPTION
Caused by a Crashlytics call which is called outside of a try catch.

Fixes #1445