### PR TITLE
Fix images not loading

### DIFF
--- a/common/imageloading/src/androidMain/kotlin/app/tivi/common/imageloading/AndroidImageLoaderFactory.kt
+++ b/common/imageloading/src/androidMain/kotlin/app/tivi/common/imageloading/AndroidImageLoaderFactory.kt
@@ -28,7 +28,9 @@ internal class AndroidImageLoaderFactory(
                 maxSizePercent(context.applicationContext)
             }
             diskCacheConfig {
-                directory(context.cacheDir.resolve("image_cache").toOkioPath())
+                // We can't use `image_cache` as that is what Coil uses, and therefore users
+                // migrating from old versions will have a broken cache.
+                directory(context.cacheDir.resolve("image_loader_cache").toOkioPath())
                 maxSizeBytes(512L * 1024 * 1024) // 512MB
             }
         }

--- a/common/imageloading/src/androidMain/kotlin/app/tivi/common/imageloading/CoilCleanupInitializer.kt
+++ b/common/imageloading/src/androidMain/kotlin/app/tivi/common/imageloading/CoilCleanupInitializer.kt
@@ -1,0 +1,32 @@
+// Copyright 2023, Christopher Banes and the Tivi project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package app.tivi.common.imageloading
+
+import android.app.Application
+import app.tivi.appinitializers.AppInitializer
+import app.tivi.util.AppCoroutineDispatchers
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import me.tatarka.inject.annotations.Inject
+
+@Inject
+class CoilCleanupInitializer(
+    private val application: Application,
+    private val dispatchers: AppCoroutineDispatchers,
+) : AppInitializer {
+    @OptIn(DelicateCoroutinesApi::class)
+    override fun initialize() {
+        GlobalScope.launch {
+            withContext(dispatchers.io) {
+                // We delete Coil's image_cache folder to claim back space for the user
+                val coilCache = application.cacheDir.resolve("image_cache")
+                if (coilCache.exists()) {
+                    coilCache.deleteRecursively()
+                }
+            }
+        }
+    }
+}

--- a/common/imageloading/src/androidMain/kotlin/app/tivi/common/imageloading/ImageLoadingPlatformComponent.kt
+++ b/common/imageloading/src/androidMain/kotlin/app/tivi/common/imageloading/ImageLoadingPlatformComponent.kt
@@ -4,9 +4,11 @@
 package app.tivi.common.imageloading
 
 import android.app.Application
+import app.tivi.appinitializers.AppInitializer
 import app.tivi.util.Logger
 import com.seiko.imageloader.ImageLoader
 import com.seiko.imageloader.intercept.Interceptor
+import me.tatarka.inject.annotations.IntoSet
 import me.tatarka.inject.annotations.Provides
 
 actual interface ImageLoadingPlatformComponent {
@@ -22,4 +24,10 @@ actual interface ImageLoadingPlatformComponent {
             addInterceptors(interceptors)
         }
     }
+
+    @Provides
+    @IntoSet
+    fun bindCoilCleanupInitializer(
+        initializer: CoilCleanupInitializer,
+    ): AppInitializer = initializer
 }


### PR DESCRIPTION
Caused by us using the same disk cache location on Android as the previous Coil implementation. This results in any existing Coil-originated disk cache being incompatible with Compose Image Loader. Fixed by using a different cache folder, and deleting the remaining Coil cache folder (if exists).

Fixes #1465