### PR TITLE
Validate empty results

### DIFF
--- a/data/models/src/commonMain/kotlin/app/tivi/data/models/ShowImages.kt
+++ b/data/models/src/commonMain/kotlin/app/tivi/data/models/ShowImages.kt
@@ -9,9 +9,9 @@ data class ShowImages(
     val showId: Long,
     val images: List<ShowTmdbImage>,
 ) {
-    val backdrop by unsafeLazy { findHighestRatedForType(ImageType.BACKDROP) }
+    val backdrop: ShowTmdbImage? by unsafeLazy { findHighestRatedForType(ImageType.BACKDROP) }
 
-    val poster by unsafeLazy { findHighestRatedForType(ImageType.POSTER) }
+    val poster: ShowTmdbImage? by unsafeLazy { findHighestRatedForType(ImageType.POSTER) }
 
     private fun findHighestRatedForType(type: ImageType): ShowTmdbImage? {
         return images.filter { it.type == type }

--- a/data/popularshows/src/commonMain/kotlin/app/tivi/data/popularshows/PopularShowsStore.kt
+++ b/data/popularshows/src/commonMain/kotlin/app/tivi/data/popularshows/PopularShowsStore.kt
@@ -14,6 +14,7 @@ import app.tivi.data.util.usingDispatchers
 import app.tivi.inject.ApplicationScope
 import app.tivi.util.AppCoroutineDispatchers
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 import me.tatarka.inject.annotations.Inject
 import org.mobilenativefoundation.store.store5.Fetcher
 import org.mobilenativefoundation.store.store5.SourceOfTruth
@@ -62,5 +63,11 @@ class PopularShowsStore(
         writeDispatcher = dispatchers.databaseWrite,
     ),
 ).validator(
-    Validator.by { lastRequestStore.isRequestValid(3.hours) },
+    Validator.by { result ->
+        if (result.isNotEmpty()) {
+            lastRequestStore.isRequestValid(3.hours)
+        } else {
+            lastRequestStore.isRequestValid(30.minutes)
+        }
+    },
 ).build()

--- a/data/recommendedshows/src/commonMain/kotlin/app/tivi/data/recommendedshows/RecommendedShowsStore.kt
+++ b/data/recommendedshows/src/commonMain/kotlin/app/tivi/data/recommendedshows/RecommendedShowsStore.kt
@@ -14,6 +14,7 @@ import app.tivi.data.util.usingDispatchers
 import app.tivi.inject.ApplicationScope
 import app.tivi.util.AppCoroutineDispatchers
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.minutes
 import me.tatarka.inject.annotations.Inject
 import org.mobilenativefoundation.store.store5.Fetcher
 import org.mobilenativefoundation.store.store5.SourceOfTruth
@@ -65,5 +66,11 @@ class RecommendedShowsStore(
         writeDispatcher = dispatchers.databaseWrite,
     ),
 ).validator(
-    Validator.by { lastRequestStore.isRequestValid(3.days) },
+    Validator.by { result ->
+        if (result.isNotEmpty()) {
+            lastRequestStore.isRequestValid(3.days)
+        } else {
+            lastRequestStore.isRequestValid(30.minutes)
+        }
+    },
 ).build()

--- a/data/relatedshows/src/commonMain/kotlin/app/tivi/data/relatedshows/RelatedShowsStore.kt
+++ b/data/relatedshows/src/commonMain/kotlin/app/tivi/data/relatedshows/RelatedShowsStore.kt
@@ -13,6 +13,7 @@ import app.tivi.data.util.usingDispatchers
 import app.tivi.inject.ApplicationScope
 import app.tivi.util.AppCoroutineDispatchers
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import me.tatarka.inject.annotations.Inject
@@ -75,7 +76,13 @@ class RelatedShowsStore(
         writeDispatcher = dispatchers.databaseWrite,
     ),
 ).validator(
-    Validator.by { lastRequestStore.isRequestValid(it.showId, 28.days) },
+    Validator.by { result ->
+        if (result.related.isNotEmpty()) {
+            lastRequestStore.isRequestValid(result.showId, 28.days)
+        } else {
+            lastRequestStore.isRequestValid(result.showId, 1.hours)
+        }
+    },
 ).build()
 
 data class RelatedShows(val showId: Long, val related: List<RelatedShowEntry>)

--- a/data/trendingshows/src/commonMain/kotlin/app/tivi/data/trendingshows/TrendingShowsStore.kt
+++ b/data/trendingshows/src/commonMain/kotlin/app/tivi/data/trendingshows/TrendingShowsStore.kt
@@ -14,6 +14,7 @@ import app.tivi.data.util.usingDispatchers
 import app.tivi.inject.ApplicationScope
 import app.tivi.util.AppCoroutineDispatchers
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.withContext
 import me.tatarka.inject.annotations.Inject
 import org.mobilenativefoundation.store.store5.Fetcher
@@ -65,5 +66,11 @@ class TrendingShowsStore(
         writeDispatcher = dispatchers.databaseWrite,
     ),
 ).validator(
-    Validator.by { lastRequestStore.isRequestValid(3.hours) },
+    Validator.by { result ->
+        if (result.isNotEmpty()) {
+            lastRequestStore.isRequestValid(3.hours)
+        } else {
+            lastRequestStore.isRequestValid(30.minutes)
+        }
+    },
 ).build()

--- a/data/watchedshows/src/commonMain/kotlin/app/tivi/data/watchedshows/WatchedShowsStore.kt
+++ b/data/watchedshows/src/commonMain/kotlin/app/tivi/data/watchedshows/WatchedShowsStore.kt
@@ -15,6 +15,7 @@ import app.tivi.inject.ApplicationScope
 import app.tivi.util.AppCoroutineDispatchers
 import app.tivi.util.Logger
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 import me.tatarka.inject.annotations.Inject
 import org.mobilenativefoundation.store.store5.Fetcher
 import org.mobilenativefoundation.store.store5.SourceOfTruth
@@ -71,5 +72,11 @@ class WatchedShowsStore(
         writeDispatcher = dispatchers.databaseWrite,
     ),
 ).validator(
-    Validator.by { lastRequestStore.isRequestValid(6.hours) },
+    Validator.by { result ->
+        if (result.isNotEmpty()) {
+            lastRequestStore.isRequestValid(6.hours)
+        } else {
+            lastRequestStore.isRequestValid(30.minutes)
+        }
+    },
 ).build()


### PR DESCRIPTION
Currently we only validate the timestamp of the last 'valid' response, but we should also look at the currently stored value. If the list is empty then it's safe to assume that we should try again with a short TTL.