### PR TITLE
Remove unnecessary Android system version judgment logic.

### DIFF
--- a/core/logging/implementation/src/androidMain/kotlin/app/tivi/util/TimberLogger.kt
+++ b/core/logging/implementation/src/androidMain/kotlin/app/tivi/util/TimberLogger.kt
@@ -3,7 +3,6 @@
 
 package app.tivi.util
 
-import android.os.Build
 import android.util.Log
 import app.tivi.app.ApplicationInfo
 import app.tivi.app.Flavor
@@ -76,10 +75,7 @@ private class TiviDebugTree : Timber.DebugTree() {
         }
         tag = tag.substring(tag.lastIndexOf('.') + 1)
         // Tag length limit was removed in API 24.
-        return when {
-            Build.VERSION.SDK_INT >= 24 || tag.length <= MAX_TAG_LENGTH -> tag
-            else -> tag.substring(0, MAX_TAG_LENGTH)
-        }
+        return tag
     }
 
     companion object {

--- a/core/powercontroller/src/androidMain/kotlin/app/tivi/util/AndroidPowerController.kt
+++ b/core/powercontroller/src/androidMain/kotlin/app/tivi/util/AndroidPowerController.kt
@@ -3,11 +3,10 @@
 
 package app.tivi.util
 
+import android.annotation.SuppressLint
 import android.app.Application
 import android.net.ConnectivityManager
-import android.os.Build
 import android.os.PowerManager
-import androidx.annotation.RequiresApi
 import androidx.core.content.getSystemService
 import app.tivi.settings.TiviPreferences
 import me.tatarka.inject.annotations.Inject
@@ -29,14 +28,14 @@ class AndroidPowerController(
             SaveData.Enabled(SaveDataReason.SYSTEM_POWER_SAVER)
         }
 
-        Build.VERSION.SDK_INT >= 24 && isBackgroundDataRestricted() -> {
+        isBackgroundDataRestricted() -> {
             SaveData.Enabled(SaveDataReason.SYSTEM_DATA_SAVER)
         }
 
         else -> SaveData.Disabled
     }
 
-    @RequiresApi(24)
+    @SuppressLint("NewApi")
     private fun isBackgroundDataRestricted(): Boolean {
         return connectivityManager.restrictBackgroundStatus ==
             ConnectivityManager.RESTRICT_BACKGROUND_STATUS_ENABLED


### PR DESCRIPTION
Current minSdkVersion is 24, so the relative system version judgment logic is no need any more.