### PR TITLE
Small performance improvements

### DIFF
--- a/android-app/app/src/main/kotlin/app/tivi/TiviApplication.kt
+++ b/android-app/app/src/main/kotlin/app/tivi/TiviApplication.kt
@@ -4,6 +4,7 @@
 package app.tivi
 
 import android.app.Application
+import android.os.Build
 import android.os.StrictMode
 import android.os.StrictMode.ThreadPolicy
 import android.os.StrictMode.VmPolicy
@@ -21,23 +22,9 @@ class TiviApplication : Application(), Configuration.Provider {
   private lateinit var workerFactory: WorkerFactory
 
   override fun onCreate() {
-    StrictMode.setThreadPolicy(
-      ThreadPolicy.Builder()
-        .detectAll()
-        .penaltyLog()
-        .build(),
-    )
-    StrictMode.setVmPolicy(
-      VmPolicy.Builder()
-        .detectAll()
-        .penaltyLog()
-        .build(),
-    )
-
     super.onCreate()
-
+    setupStrictMode()
     workerFactory = component.workerFactory
-
     component.initializers.initialize()
   }
 
@@ -45,4 +32,36 @@ class TiviApplication : Application(), Configuration.Provider {
     get() = Configuration.Builder()
       .setWorkerFactory(workerFactory)
       .build()
+}
+
+private fun setupStrictMode() {
+  StrictMode.setThreadPolicy(
+    ThreadPolicy.Builder()
+      .detectAll()
+      .penaltyLog()
+      .build(),
+  )
+  StrictMode.setVmPolicy(
+    VmPolicy.Builder()
+      .detectLeakedSqlLiteObjects()
+      .detectActivityLeaks()
+      .detectLeakedClosableObjects()
+      .detectLeakedRegistrationObjects()
+      .detectFileUriExposure()
+      .detectCleartextNetwork()
+      .apply {
+        if (Build.VERSION.SDK_INT >= 26) {
+          detectContentUriWithoutPermission()
+        }
+        if (Build.VERSION.SDK_INT >= 29) {
+          detectCredentialProtectedWhileLocked()
+        }
+        if (Build.VERSION.SDK_INT >= 31) {
+          detectIncorrectContextUse()
+          detectUnsafeIntentLaunch()
+        }
+      }
+      .penaltyLog()
+      .build(),
+  )
 }

--- a/android-app/app/src/main/kotlin/app/tivi/TiviApplication.kt
+++ b/android-app/app/src/main/kotlin/app/tivi/TiviApplication.kt
@@ -25,14 +25,13 @@ class TiviApplication : Application(), Configuration.Provider {
       ThreadPolicy.Builder()
         .detectAll()
         .penaltyLog()
-        .build()
+        .build(),
     )
     StrictMode.setVmPolicy(
       VmPolicy.Builder()
         .detectAll()
         .penaltyLog()
-        .penaltyDeath()
-        .build()
+        .build(),
     )
 
     super.onCreate()

--- a/android-app/app/src/main/kotlin/app/tivi/TiviApplication.kt
+++ b/android-app/app/src/main/kotlin/app/tivi/TiviApplication.kt
@@ -4,6 +4,9 @@
 package app.tivi
 
 import android.app.Application
+import android.os.StrictMode
+import android.os.StrictMode.ThreadPolicy
+import android.os.StrictMode.VmPolicy
 import androidx.work.Configuration
 import androidx.work.WorkerFactory
 import app.tivi.extensions.unsafeLazy
@@ -18,6 +21,20 @@ class TiviApplication : Application(), Configuration.Provider {
   private lateinit var workerFactory: WorkerFactory
 
   override fun onCreate() {
+    StrictMode.setThreadPolicy(
+      ThreadPolicy.Builder()
+        .detectAll()
+        .penaltyLog()
+        .build()
+    )
+    StrictMode.setVmPolicy(
+      VmPolicy.Builder()
+        .detectAll()
+        .penaltyLog()
+        .penaltyDeath()
+        .build()
+    )
+
     super.onCreate()
 
     workerFactory = component.workerFactory

--- a/android-app/app/src/main/kotlin/app/tivi/home/MainActivity.kt
+++ b/android-app/app/src/main/kotlin/app/tivi/home/MainActivity.kt
@@ -30,6 +30,7 @@ import app.tivi.settings.TiviPreferences
 import com.slack.circuit.backstack.rememberSaveableBackStack
 import com.slack.circuit.foundation.rememberCircuitNavigator
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class MainActivity : TiviActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -43,9 +44,10 @@ class MainActivity : TiviActivity() {
 
     lifecycle.coroutineScope.launch {
       repeatOnLifecycle(Lifecycle.State.STARTED) {
-        applicationComponent.preferences.observeTheme().collect { theme ->
-          enableEdgeToEdgeForTheme(theme)
+        val prefs = withContext(applicationComponent.dispatchers.io) {
+          applicationComponent.preferences.observeTheme()
         }
+        prefs.collect(::enableEdgeToEdgeForTheme)
       }
     }
 

--- a/api/tmdb/src/commonMain/kotlin/app/tivi/tmdb/TmdbInitializer.kt
+++ b/api/tmdb/src/commonMain/kotlin/app/tivi/tmdb/TmdbInitializer.kt
@@ -10,12 +10,12 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class TmdbInitializer(
-  private val tmdbManager: TmdbManager,
+  private val tmdbManager: Lazy<TmdbManager>,
   private val scope: ApplicationCoroutineScope,
 ) : AppInitializer {
   override fun initialize() {
     scope.launch {
-      tmdbManager.refreshConfiguration()
+      tmdbManager.value.refreshConfiguration()
     }
   }
 }

--- a/api/tmdb/src/commonMain/kotlin/app/tivi/tmdb/TmdbManager.kt
+++ b/api/tmdb/src/commonMain/kotlin/app/tivi/tmdb/TmdbManager.kt
@@ -14,7 +14,7 @@ import me.tatarka.inject.annotations.Inject
 @ApplicationScope
 @Inject
 class TmdbManager(
-  private val tmdbClient: Tmdb3,
+  private val tmdbClient: Lazy<Tmdb3>,
   private val dispatchers: AppCoroutineDispatchers,
 ) {
   private val imageProvider = MutableStateFlow(TmdbImageUrlProvider())
@@ -24,7 +24,7 @@ class TmdbManager(
   suspend fun refreshConfiguration() {
     val response = withContext(dispatchers.io) {
       runCatching {
-        tmdbClient.configuration.getApiConfiguration()
+        tmdbClient.value.configuration.getApiConfiguration()
       }
     }
 

--- a/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/EpisodeImageModelInterceptor.kt
+++ b/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/EpisodeImageModelInterceptor.kt
@@ -7,16 +7,19 @@ import app.tivi.data.episodes.SeasonsEpisodesRepository
 import app.tivi.data.imagemodels.EpisodeImageModel
 import app.tivi.data.util.inPast
 import app.tivi.tmdb.TmdbImageUrlProvider
+import app.tivi.util.AppCoroutineDispatchers
 import coil3.intercept.Interceptor
 import coil3.request.ImageResult
 import coil3.size.pxOrElse
 import kotlin.time.Duration.Companion.days
+import kotlinx.coroutines.withContext
 import me.tatarka.inject.annotations.Inject
 
 @Inject
 class EpisodeImageModelInterceptor(
   private val tmdbImageUrlProvider: Lazy<TmdbImageUrlProvider>,
   private val repository: SeasonsEpisodesRepository,
+  private val dispatchers: AppCoroutineDispatchers,
 ) : Interceptor {
   override suspend fun intercept(
     chain: Interceptor.Chain,
@@ -29,11 +32,14 @@ class EpisodeImageModelInterceptor(
     chain: Interceptor.Chain,
     model: EpisodeImageModel,
   ): Interceptor.Chain {
-    if (repository.needEpisodeUpdate(model.id, expiry = 180.days.inPast)) {
-      runCatching { repository.updateEpisode(model.id) }
+    val episode = withContext(dispatchers.io) {
+      if (repository.needEpisodeUpdate(model.id, expiry = 180.days.inPast)) {
+        runCatching { repository.updateEpisode(model.id) }
+      }
+      repository.getEpisode(model.id)
     }
 
-    return repository.getEpisode(model.id)?.tmdbBackdropPath?.let { backdropPath ->
+    return episode?.tmdbBackdropPath?.let { backdropPath ->
       val url = tmdbImageUrlProvider.value.getBackdropUrl(
         path = backdropPath,
         imageWidth = chain.request.sizeResolver.size().width.pxOrElse { 0 },

--- a/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/EpisodeImageModelInterceptor.kt
+++ b/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/EpisodeImageModelInterceptor.kt
@@ -18,7 +18,7 @@ import me.tatarka.inject.annotations.Inject
 @Inject
 class EpisodeImageModelInterceptor(
   private val tmdbImageUrlProvider: Lazy<TmdbImageUrlProvider>,
-  private val repository: SeasonsEpisodesRepository,
+  private val repository: Lazy<SeasonsEpisodesRepository>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interceptor {
   override suspend fun intercept(
@@ -33,10 +33,10 @@ class EpisodeImageModelInterceptor(
     model: EpisodeImageModel,
   ): Interceptor.Chain {
     val episode = withContext(dispatchers.io) {
-      if (repository.needEpisodeUpdate(model.id, expiry = 180.days.inPast)) {
-        runCatching { repository.updateEpisode(model.id) }
+      if (repository.value.needEpisodeUpdate(model.id, expiry = 180.days.inPast)) {
+        runCatching { repository.value.updateEpisode(model.id) }
       }
-      repository.getEpisode(model.id)
+      repository.value.getEpisode(model.id)
     }
 
     return episode?.tmdbBackdropPath?.let { backdropPath ->

--- a/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/HideArtworkInterceptor.kt
+++ b/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/HideArtworkInterceptor.kt
@@ -17,13 +17,13 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class HideArtworkInterceptor(
-  private val preferences: TiviPreferences,
+  private val preferences: Lazy<TiviPreferences>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interceptor {
   @OptIn(ExperimentalCoilApi::class)
   override suspend fun intercept(chain: Interceptor.Chain): ImageResult = withContext(dispatchers.io) {
     when {
-      preferences.developerHideArtwork && isArtwork(chain.request.data) -> {
+      preferences.value.developerHideArtwork && isArtwork(chain.request.data) -> {
         ErrorResult(
           image = null,
           request = chain.request,

--- a/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/HideArtworkInterceptor.kt
+++ b/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/HideArtworkInterceptor.kt
@@ -23,7 +23,7 @@ class HideArtworkInterceptor(
   @OptIn(ExperimentalCoilApi::class)
   override suspend fun intercept(chain: Interceptor.Chain): ImageResult = withContext(dispatchers.io) {
     when {
-      preferences.value.developerHideArtwork && isArtwork(chain.request.data) -> {
+      preferences.value.getDeveloperHideArtwork() && isArtwork(chain.request.data) -> {
         ErrorResult(
           image = null,
           request = chain.request,

--- a/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/HideArtworkInterceptor.kt
+++ b/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/HideArtworkInterceptor.kt
@@ -7,27 +7,32 @@ import app.tivi.data.imagemodels.EpisodeImageModel
 import app.tivi.data.imagemodels.ShowImageModel
 import app.tivi.data.models.TmdbImageEntity
 import app.tivi.settings.TiviPreferences
+import app.tivi.util.AppCoroutineDispatchers
 import coil3.annotation.ExperimentalCoilApi
 import coil3.intercept.Interceptor
 import coil3.request.ErrorResult
 import coil3.request.ImageResult
+import kotlinx.coroutines.withContext
 import me.tatarka.inject.annotations.Inject
 
 @Inject
 class HideArtworkInterceptor(
   private val preferences: TiviPreferences,
+  private val dispatchers: AppCoroutineDispatchers,
 ) : Interceptor {
   @OptIn(ExperimentalCoilApi::class)
-  override suspend fun intercept(chain: Interceptor.Chain): ImageResult = when {
-    preferences.developerHideArtwork && isArtwork(chain.request.data) -> {
-      ErrorResult(
-        image = null,
-        request = chain.request,
-        throwable = Exception("Developer setting: hide artwork enabled"),
-      )
-    }
+  override suspend fun intercept(chain: Interceptor.Chain): ImageResult = withContext(dispatchers.io) {
+    when {
+      preferences.developerHideArtwork && isArtwork(chain.request.data) -> {
+        ErrorResult(
+          image = null,
+          request = chain.request,
+          throwable = Exception("Developer setting: hide artwork enabled"),
+        )
+      }
 
-    else -> chain.proceed()
+      else -> chain.proceed()
+    }
   }
 
   private fun isArtwork(data: Any): Boolean = when (data) {

--- a/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/ImageLoader.kt
+++ b/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/ImageLoader.kt
@@ -31,7 +31,7 @@ internal fun newImageLoader(
     }
     .diskCache {
       DiskCache.Builder()
-        .directory(applicationInfo.cachePath.toPath().resolve("coil_cache"))
+        .directory(applicationInfo.cachePath().toPath().resolve("coil_cache"))
         .build()
     }
     .apply {

--- a/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/ImageLoaderCleanupInitializer.kt
+++ b/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/ImageLoaderCleanupInitializer.kt
@@ -17,18 +17,19 @@ class ImageLoaderCleanupInitializer(
   private val scope: ApplicationCoroutineScope,
   private val dispatchers: AppCoroutineDispatchers,
   private val applicationInfo: ApplicationInfo,
-  private val fileSystem: FileSystem,
+  private val fileSystem: Lazy<FileSystem>,
 ) : AppInitializer {
 
   override fun initialize() {
     scope.launch(dispatchers.io) {
       // We delete ImageLoader's disk cache folder to claim back space for the user
-      val cachePath = applicationInfo.cachePath.toPath()
+      val cachePath = applicationInfo.cachePath().toPath()
+      val fs = fileSystem.value
 
       for (folder in FOLDERS) {
         val path = cachePath.resolve(folder)
-        if (fileSystem.exists(path)) {
-          fileSystem.deleteRecursively(path)
+        if (fs.exists(path)) {
+          fs.deleteRecursively(path)
         }
       }
     }

--- a/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/SeasonImageModelInterceptor.kt
+++ b/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/SeasonImageModelInterceptor.kt
@@ -18,7 +18,7 @@ import me.tatarka.inject.annotations.Inject
 @Inject
 class SeasonImageModelInterceptor(
   private val tmdbImageUrlProvider: Lazy<TmdbImageUrlProvider>,
-  private val repository: SeasonsEpisodesRepository,
+  private val repository: Lazy<SeasonsEpisodesRepository>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interceptor {
   override suspend fun intercept(
@@ -33,10 +33,10 @@ class SeasonImageModelInterceptor(
     model: SeasonImageModel,
   ): Interceptor.Chain {
     val season = withContext(dispatchers.io) {
-      if (repository.needSeasonUpdate(model.id, expiry = 180.days.inPast)) {
-        runCatching { repository.updateSeason(model.id) }
+      if (repository.value.needSeasonUpdate(model.id, expiry = 180.days.inPast)) {
+        runCatching { repository.value.updateSeason(model.id) }
       }
-      repository.getSeason(model.id)
+      repository.value.getSeason(model.id)
     }
     return season?.tmdbPosterPath?.let { posterPath ->
       val url = tmdbImageUrlProvider.value.getPosterUrl(

--- a/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/ShowImageModelInterceptor.kt
+++ b/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/ShowImageModelInterceptor.kt
@@ -21,8 +21,8 @@ import org.mobilenativefoundation.store.store5.impl.extensions.get
 @Inject
 class ShowImageModelInterceptor(
   private val tmdbImageUrlProvider: Lazy<TmdbImageUrlProvider>,
-  private val showImagesStore: ShowImagesStore,
-  private val powerController: PowerController,
+  private val showImagesStore: Lazy<ShowImagesStore>,
+  private val powerController: Lazy<PowerController>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interceptor {
   override suspend fun intercept(
@@ -38,13 +38,13 @@ class ShowImageModelInterceptor(
   ): Interceptor.Chain {
     val entity = withContext(dispatchers.io) {
       runCatching {
-        findHighestRatedForType(showImagesStore.get(model.id).images, model.imageType)
+        findHighestRatedForType(showImagesStore.value.get(model.id).images, model.imageType)
       }.getOrNull()
     } ?: return chain
 
     val requestWidth = chain.request.sizeResolver.size().width.pxOrElse { 0 }
 
-    val width = when (powerController.shouldSaveData()) {
+    val width = when (powerController.value.shouldSaveData()) {
       is SaveData.Disabled -> requestWidth
       // If we can't download hi-res images, we load half-width images (so ~1/4 in size)
       is SaveData.Enabled -> requestWidth / 2

--- a/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/ShowImageModelInterceptor.kt
+++ b/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/ShowImageModelInterceptor.kt
@@ -8,11 +8,13 @@ import app.tivi.data.models.ImageType
 import app.tivi.data.models.TmdbImageEntity
 import app.tivi.data.showimages.ShowImagesStore
 import app.tivi.tmdb.TmdbImageUrlProvider
+import app.tivi.util.AppCoroutineDispatchers
 import app.tivi.util.PowerController
 import app.tivi.util.SaveData
 import coil3.intercept.Interceptor
 import coil3.request.ImageResult
 import coil3.size.pxOrElse
+import kotlinx.coroutines.withContext
 import me.tatarka.inject.annotations.Inject
 import org.mobilenativefoundation.store.store5.impl.extensions.get
 
@@ -21,6 +23,7 @@ class ShowImageModelInterceptor(
   private val tmdbImageUrlProvider: Lazy<TmdbImageUrlProvider>,
   private val showImagesStore: ShowImagesStore,
   private val powerController: PowerController,
+  private val dispatchers: AppCoroutineDispatchers,
 ) : Interceptor {
   override suspend fun intercept(
     chain: Interceptor.Chain,
@@ -33,9 +36,11 @@ class ShowImageModelInterceptor(
     chain: Interceptor.Chain,
     model: ShowImageModel,
   ): Interceptor.Chain {
-    val entity = runCatching {
-      findHighestRatedForType(showImagesStore.get(model.id).images, model.imageType)
-    }.getOrNull() ?: return chain
+    val entity = withContext(dispatchers.io) {
+      runCatching {
+        findHighestRatedForType(showImagesStore.get(model.id).images, model.imageType)
+      }.getOrNull()
+    } ?: return chain
 
     val requestWidth = chain.request.sizeResolver.size().width.pxOrElse { 0 }
 

--- a/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/TmdbImageEntityCoilInterceptor.kt
+++ b/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/TmdbImageEntityCoilInterceptor.kt
@@ -34,7 +34,7 @@ class TmdbImageEntityCoilInterceptor(
     else -> chain.proceed()
   }
 
-  private fun map(data: TmdbImageEntity, requestWidth: Int): String {
+  private suspend fun map(data: TmdbImageEntity, requestWidth: Int): String {
     val width = when (powerController.value.shouldSaveData()) {
       is SaveData.Disabled -> requestWidth
       // If we can't download hi-res images, we load half-width images (so ~1/4 in size)

--- a/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/TmdbImageEntityCoilInterceptor.kt
+++ b/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/TmdbImageEntityCoilInterceptor.kt
@@ -15,7 +15,7 @@ import me.tatarka.inject.annotations.Inject
 @Inject
 class TmdbImageEntityCoilInterceptor(
   private val tmdbImageUrlProvider: Lazy<TmdbImageUrlProvider>,
-  private val powerController: PowerController,
+  private val powerController: Lazy<PowerController>,
 ) : Interceptor {
   override suspend fun intercept(
     chain: Interceptor.Chain,
@@ -35,7 +35,7 @@ class TmdbImageEntityCoilInterceptor(
   }
 
   private fun map(data: TmdbImageEntity, requestWidth: Int): String {
-    val width = when (powerController.shouldSaveData()) {
+    val width = when (powerController.value.shouldSaveData()) {
       is SaveData.Disabled -> requestWidth
       // If we can't download hi-res images, we load half-width images (so ~1/4 in size)
       is SaveData.Enabled -> requestWidth / 2

--- a/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/TiviPreferenceExtensions.kt
+++ b/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/TiviPreferenceExtensions.kt
@@ -11,7 +11,9 @@ import app.tivi.settings.TiviPreferences
 
 @Composable
 fun TiviPreferences.shouldUseDarkColors(): Boolean {
-  val themePreference = remember { observeTheme() }.collectAsState(initial = theme)
+  val themePreference = remember { observeTheme() }
+    .collectAsState(initial = TiviPreferences.Theme.SYSTEM)
+
   return when (themePreference.value) {
     TiviPreferences.Theme.LIGHT -> false
     TiviPreferences.Theme.DARK -> true
@@ -22,6 +24,6 @@ fun TiviPreferences.shouldUseDarkColors(): Boolean {
 @Composable
 fun TiviPreferences.shouldUseDynamicColors(): Boolean {
   return remember { observeUseDynamicColors() }
-    .collectAsState(initial = useDynamicColors)
+    .collectAsState(initial = true)
     .value
 }

--- a/core/analytics/src/commonMain/kotlin/app/tivi/core/analytics/AnalyticsInitializer.kt
+++ b/core/analytics/src/commonMain/kotlin/app/tivi/core/analytics/AnalyticsInitializer.kt
@@ -6,20 +6,24 @@ package app.tivi.core.analytics
 import app.tivi.appinitializers.AppInitializer
 import app.tivi.inject.ApplicationCoroutineScope
 import app.tivi.settings.TiviPreferences
+import app.tivi.util.AppCoroutineDispatchers
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Inject
 
 @Inject
 class AnalyticsInitializer(
-  private val preferences: TiviPreferences,
+  private val preferences: Lazy<TiviPreferences>,
   private val scope: ApplicationCoroutineScope,
   private val analytics: Analytics,
+  private val dispatchers: AppCoroutineDispatchers,
 ) : AppInitializer {
   override fun initialize() {
     scope.launch {
-      preferences.observeReportAnalytics().collect { enabled ->
-        analytics.setEnabled(enabled)
-      }
+      preferences.value
+        .observeReportAnalytics()
+        .flowOn(dispatchers.io)
+        .collect { enabled -> analytics.setEnabled(enabled) }
     }
   }
 }

--- a/core/base/src/commonMain/kotlin/app/tivi/app/ApplicationInfo.kt
+++ b/core/base/src/commonMain/kotlin/app/tivi/app/ApplicationInfo.kt
@@ -9,7 +9,7 @@ data class ApplicationInfo(
   val flavor: Flavor,
   val versionName: String,
   val versionCode: Int,
-  val cachePath: String,
+  val cachePath: () -> String,
 )
 
 enum class Flavor {

--- a/core/logging/implementation/src/commonMain/kotlin/app/tivi/util/CrashReportingInitializer.kt
+++ b/core/logging/implementation/src/commonMain/kotlin/app/tivi/util/CrashReportingInitializer.kt
@@ -6,20 +6,22 @@ package app.tivi.util
 import app.tivi.appinitializers.AppInitializer
 import app.tivi.inject.ApplicationCoroutineScope
 import app.tivi.settings.TiviPreferences
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Inject
 
 @Inject
 class CrashReportingInitializer(
-  private val preferences: TiviPreferences,
+  private val preferences: Lazy<TiviPreferences>,
   private val scope: ApplicationCoroutineScope,
   private val action: SetCrashReportingEnabledAction,
+  private val dispatchers: AppCoroutineDispatchers,
 ) : AppInitializer {
   override fun initialize() {
     scope.launch {
-      preferences.observeReportAppCrashes().collect { enabled ->
-        action(enabled)
-      }
+      preferences.value.observeReportAppCrashes()
+        .flowOn(dispatchers.io)
+        .collect(action::invoke)
     }
   }
 }

--- a/core/powercontroller/src/androidMain/kotlin/app/tivi/util/AndroidPowerController.kt
+++ b/core/powercontroller/src/androidMain/kotlin/app/tivi/util/AndroidPowerController.kt
@@ -14,13 +14,13 @@ import me.tatarka.inject.annotations.Inject
 @Inject
 class AndroidPowerController(
   private val context: Application,
-  private val preferences: TiviPreferences,
+  private val preferences: Lazy<TiviPreferences>,
 ) : PowerController {
   private val powerManager: PowerManager by lazy { context.getSystemService()!! }
   private val connectivityManager: ConnectivityManager by lazy { context.getSystemService()!! }
 
-  override fun shouldSaveData(): SaveData = when {
-    preferences.useLessData -> {
+  override suspend fun shouldSaveData(): SaveData = when {
+    preferences.value.useLessData -> {
       SaveData.Enabled(SaveDataReason.PREFERENCE)
     }
 

--- a/core/powercontroller/src/androidMain/kotlin/app/tivi/util/AndroidPowerController.kt
+++ b/core/powercontroller/src/androidMain/kotlin/app/tivi/util/AndroidPowerController.kt
@@ -20,7 +20,7 @@ class AndroidPowerController(
   private val connectivityManager: ConnectivityManager by lazy { context.getSystemService()!! }
 
   override suspend fun shouldSaveData(): SaveData = when {
-    preferences.value.useLessData -> {
+    preferences.value.getUseLessData() -> {
       SaveData.Enabled(SaveDataReason.PREFERENCE)
     }
 

--- a/core/powercontroller/src/commonMain/kotlin/app/tivi/util/PowerController.kt
+++ b/core/powercontroller/src/commonMain/kotlin/app/tivi/util/PowerController.kt
@@ -7,7 +7,7 @@ import app.tivi.settings.TiviPreferences
 import me.tatarka.inject.annotations.Inject
 
 interface PowerController {
-  fun shouldSaveData(): SaveData
+  suspend fun shouldSaveData(): SaveData
 }
 
 sealed class SaveData {
@@ -23,10 +23,10 @@ enum class SaveDataReason {
 
 @Inject
 class DefaultPowerController(
-  private val preferences: TiviPreferences,
+  private val preferences: Lazy<TiviPreferences>,
 ) : PowerController {
-  override fun shouldSaveData(): SaveData = when {
-    preferences.useLessData -> SaveData.Enabled(SaveDataReason.PREFERENCE)
+  override suspend fun shouldSaveData(): SaveData = when {
+    preferences.value.useLessData -> SaveData.Enabled(SaveDataReason.PREFERENCE)
     else -> SaveData.Disabled
   }
 }

--- a/core/powercontroller/src/commonMain/kotlin/app/tivi/util/PowerController.kt
+++ b/core/powercontroller/src/commonMain/kotlin/app/tivi/util/PowerController.kt
@@ -26,7 +26,7 @@ class DefaultPowerController(
   private val preferences: Lazy<TiviPreferences>,
 ) : PowerController {
   override suspend fun shouldSaveData(): SaveData = when {
-    preferences.value.useLessData -> SaveData.Enabled(SaveDataReason.PREFERENCE)
+    preferences.value.getUseLessData() -> SaveData.Enabled(SaveDataReason.PREFERENCE)
     else -> SaveData.Disabled
   }
 }

--- a/core/preferences/src/commonMain/kotlin/app/tivi/settings/TiviPreferences.kt
+++ b/core/preferences/src/commonMain/kotlin/app/tivi/settings/TiviPreferences.kt
@@ -3,39 +3,45 @@
 
 package app.tivi.settings
 
-import kotlin.reflect.KMutableProperty0
 import kotlinx.coroutines.flow.Flow
 
 interface TiviPreferences {
-
-  var theme: Theme
+  suspend fun setTheme(theme: Theme)
   fun observeTheme(): Flow<Theme>
 
-  var useDynamicColors: Boolean
+  suspend fun toggleUseDynamicColors()
+
   fun observeUseDynamicColors(): Flow<Boolean>
 
-  var useLessData: Boolean
+  suspend fun getUseLessData(): Boolean
+
+  suspend fun toggleUseLessData()
+
   fun observeUseLessData(): Flow<Boolean>
 
-  var libraryFollowedActive: Boolean
+  suspend fun toggleLibraryFollowedActive()
+
   fun observeLibraryFollowedActive(): Flow<Boolean>
 
-  var libraryWatchedActive: Boolean
+  suspend fun toggleLibraryWatchedActive()
+
   fun observeLibraryWatchedActive(): Flow<Boolean>
 
-  var upNextFollowedOnly: Boolean
+  suspend fun toggleUpNextFollowedOnly()
+
   fun observeUpNextFollowedOnly(): Flow<Boolean>
 
-  var ignoreSpecials: Boolean
+  suspend fun toggleIgnoreSpecials()
   fun observeIgnoreSpecials(): Flow<Boolean>
 
-  var reportAppCrashes: Boolean
+  suspend fun toggleReportAppCrashes()
   fun observeReportAppCrashes(): Flow<Boolean>
 
-  var reportAnalytics: Boolean
+  suspend fun toggleReportAnalytics()
   fun observeReportAnalytics(): Flow<Boolean>
 
-  var developerHideArtwork: Boolean
+  suspend fun toggleDeveloperHideArtwork()
+  suspend fun getDeveloperHideArtwork(): Boolean
   fun observeDeveloperHideArtwork(): Flow<Boolean>
 
   enum class Theme {
@@ -43,8 +49,4 @@ interface TiviPreferences {
     DARK,
     SYSTEM,
   }
-}
-
-fun KMutableProperty0<Boolean>.toggle() {
-  set(!get())
 }

--- a/core/preferences/src/commonMain/kotlin/app/tivi/settings/TiviPreferencesImpl.kt
+++ b/core/preferences/src/commonMain/kotlin/app/tivi/settings/TiviPreferencesImpl.kt
@@ -18,10 +18,11 @@ import me.tatarka.inject.annotations.Inject
 @OptIn(ExperimentalSettingsApi::class)
 @Inject
 class TiviPreferencesImpl(
-  private val settings: ObservableSettings,
+  settings: Lazy<ObservableSettings>,
   dispatchers: AppCoroutineDispatchers,
 ) : TiviPreferences {
-  private val flowSettings by lazy { settings.toFlowSettings(dispatchers.io) }
+  private val settings: ObservableSettings by settings
+  private val flowSettings by lazy { settings.value.toFlowSettings(dispatchers.io) }
 
   override var theme: Theme
     get() = getThemeForStorageValue(settings.getString(KEY_THEME, THEME_SYSTEM_VALUE))

--- a/core/preferences/src/commonMain/kotlin/app/tivi/settings/TiviPreferencesImpl.kt
+++ b/core/preferences/src/commonMain/kotlin/app/tivi/settings/TiviPreferencesImpl.kt
@@ -9,99 +9,122 @@ import com.russhwolf.settings.ExperimentalSettingsApi
 import com.russhwolf.settings.ObservableSettings
 import com.russhwolf.settings.coroutines.getStringFlow
 import com.russhwolf.settings.coroutines.toFlowSettings
-import kotlin.properties.ReadWriteProperty
-import kotlin.reflect.KProperty
+import com.russhwolf.settings.get
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import me.tatarka.inject.annotations.Inject
 
 @OptIn(ExperimentalSettingsApi::class)
 @Inject
 class TiviPreferencesImpl(
   settings: Lazy<ObservableSettings>,
-  dispatchers: AppCoroutineDispatchers,
+  private val dispatchers: AppCoroutineDispatchers,
 ) : TiviPreferences {
   private val settings: ObservableSettings by settings
   private val flowSettings by lazy { settings.value.toFlowSettings(dispatchers.io) }
 
-  override var theme: Theme
-    get() = getThemeForStorageValue(settings.getString(KEY_THEME, THEME_SYSTEM_VALUE))
-    set(value) = settings.putString(KEY_THEME, value.storageKey)
+  override suspend fun setTheme(theme: Theme) = withContext(dispatchers.io) {
+    settings.putString(KEY_THEME, theme.storageKey)
+  }
 
   override fun observeTheme(): Flow<Theme> {
     return settings.getStringFlow(KEY_THEME, THEME_SYSTEM_VALUE)
       .map(::getThemeForStorageValue)
   }
 
-  override var useDynamicColors: Boolean by BooleanDelegate(KEY_USE_DYNAMIC_COLORS, true)
+  override suspend fun toggleUseDynamicColors() = withContext(dispatchers.io) {
+    settings.toggleBoolean(KEY_USE_DYNAMIC_COLORS, true)
+  }
 
   override fun observeUseDynamicColors(): Flow<Boolean> {
     return flowSettings.getBooleanFlow(KEY_USE_DYNAMIC_COLORS, true)
   }
 
-  override var useLessData: Boolean by BooleanDelegate(KEY_DATA_SAVER, false)
+  override suspend fun getUseLessData(): Boolean = withContext(dispatchers.io) {
+    settings[KEY_DATA_SAVER, false]
+  }
+
+  override suspend fun toggleUseLessData() = withContext(dispatchers.io) {
+    settings.toggleBoolean(KEY_DATA_SAVER)
+  }
 
   override fun observeUseLessData(): Flow<Boolean> {
     return flowSettings.getBooleanFlow(KEY_DATA_SAVER, false)
   }
 
-  override var libraryFollowedActive: Boolean by BooleanDelegate(KEY_LIBRARY_FOLLOWED_ACTIVE, true)
+  override suspend fun toggleLibraryFollowedActive() {
+    withContext(dispatchers.io) {
+      settings.toggleBoolean(KEY_LIBRARY_FOLLOWED_ACTIVE, true)
+    }
+  }
 
   override fun observeLibraryFollowedActive(): Flow<Boolean> {
     return flowSettings.getBooleanFlow(KEY_LIBRARY_FOLLOWED_ACTIVE, true)
   }
 
-  override var libraryWatchedActive: Boolean by BooleanDelegate(KEY_LIBRARY_WATCHED_ACTIVE, true)
+  override suspend fun toggleLibraryWatchedActive() {
+    withContext(dispatchers.io) {
+      settings.toggleBoolean(KEY_LIBRARY_WATCHED_ACTIVE, true)
+    }
+  }
 
   override fun observeLibraryWatchedActive(): Flow<Boolean> {
     return flowSettings.getBooleanFlow(KEY_LIBRARY_WATCHED_ACTIVE, true)
   }
 
-  override var upNextFollowedOnly: Boolean by BooleanDelegate(KEY_UPNEXT_FOLLOWED_ONLY, false)
+  override suspend fun toggleUpNextFollowedOnly() {
+    withContext(dispatchers.io) {
+      settings.toggleBoolean(KEY_UPNEXT_FOLLOWED_ONLY, false)
+    }
+  }
 
   override fun observeUpNextFollowedOnly(): Flow<Boolean> {
     return flowSettings.getBooleanFlow(KEY_UPNEXT_FOLLOWED_ONLY, false)
   }
 
-  override var ignoreSpecials: Boolean by BooleanDelegate(KEY_IGNORE_SPECIALS, true)
+  override suspend fun toggleIgnoreSpecials() {
+    withContext(dispatchers.io) {
+      settings.toggleBoolean(KEY_IGNORE_SPECIALS, true)
+    }
+  }
 
   override fun observeIgnoreSpecials(): Flow<Boolean> {
     return flowSettings.getBooleanFlow(KEY_IGNORE_SPECIALS, true)
   }
 
-  override var reportAppCrashes: Boolean by BooleanDelegate(KEY_OPT_IN_CRASH_REPORTING, true)
+  override suspend fun toggleReportAppCrashes() {
+    withContext(dispatchers.io) {
+      settings.toggleBoolean(KEY_OPT_IN_CRASH_REPORTING, true)
+    }
+  }
 
   override fun observeReportAppCrashes(): Flow<Boolean> {
     return flowSettings.getBooleanFlow(KEY_OPT_IN_CRASH_REPORTING, true)
   }
 
-  override var reportAnalytics: Boolean by BooleanDelegate(KEY_OPT_IN_ANALYTICS_REPORTING, true)
+  override suspend fun toggleReportAnalytics() {
+    withContext(dispatchers.io) {
+      settings.toggleBoolean(KEY_OPT_IN_ANALYTICS_REPORTING, true)
+    }
+  }
 
   override fun observeReportAnalytics(): Flow<Boolean> {
     return flowSettings.getBooleanFlow(KEY_OPT_IN_ANALYTICS_REPORTING, true)
   }
 
-  override var developerHideArtwork: Boolean by BooleanDelegate(KEY_DEV_HIDE_ARTWORK, false)
+  override suspend fun toggleDeveloperHideArtwork() {
+    withContext(dispatchers.io) {
+      settings.toggleBoolean(KEY_DEV_HIDE_ARTWORK)
+    }
+  }
+
+  override suspend fun getDeveloperHideArtwork(): Boolean = withContext(dispatchers.io) {
+    settings.getBoolean(KEY_DEV_HIDE_ARTWORK, false)
+  }
 
   override fun observeDeveloperHideArtwork(): Flow<Boolean> {
     return flowSettings.getBooleanFlow(KEY_DEV_HIDE_ARTWORK, false)
-  }
-
-  private class BooleanDelegate(
-    private val key: String,
-    private val defaultValue: Boolean,
-  ) : ReadWriteProperty<TiviPreferencesImpl, Boolean> {
-    override fun getValue(thisRef: TiviPreferencesImpl, property: KProperty<*>): Boolean {
-      return thisRef.settings.getBoolean(key, defaultValue)
-    }
-
-    override fun setValue(
-      thisRef: TiviPreferencesImpl,
-      property: KProperty<*>,
-      value: Boolean,
-    ) {
-      thisRef.settings.putBoolean(key, value)
-    }
   }
 }
 
@@ -134,3 +157,7 @@ internal const val KEY_DEV_HIDE_ARTWORK = "pref_dev_hide_artwork"
 internal const val THEME_LIGHT_VALUE = "light"
 internal const val THEME_DARK_VALUE = "dark"
 internal const val THEME_SYSTEM_VALUE = "system"
+
+private fun ObservableSettings.toggleBoolean(key: String, defaultValue: Boolean = false) {
+  putBoolean(key, !getBoolean(key, defaultValue))
+}

--- a/data/popularshows/src/commonMain/kotlin/app/tivi/data/popularshows/PopularShowsStore.kt
+++ b/data/popularshows/src/commonMain/kotlin/app/tivi/data/popularshows/PopularShowsStore.kt
@@ -15,6 +15,7 @@ import app.tivi.inject.ApplicationScope
 import app.tivi.util.AppCoroutineDispatchers
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.withContext
 import me.tatarka.inject.annotations.Inject
 import org.mobilenativefoundation.store.store5.Fetcher
 import org.mobilenativefoundation.store.store5.SourceOfTruth
@@ -64,10 +65,10 @@ class PopularShowsStore(
   ),
 ).validator(
   Validator.by { result ->
-    if (result.isNotEmpty()) {
-      lastRequestStore.isRequestValid(3.hours)
-    } else {
-      lastRequestStore.isRequestValid(30.minutes)
+    withContext(dispatchers.io) {
+      lastRequestStore.isRequestValid(
+        threshold = if (result.isNotEmpty()) 3.hours else 30.minutes,
+      )
     }
   },
 ).build()

--- a/data/recommendedshows/src/commonMain/kotlin/app/tivi/data/recommendedshows/RecommendedShowsStore.kt
+++ b/data/recommendedshows/src/commonMain/kotlin/app/tivi/data/recommendedshows/RecommendedShowsStore.kt
@@ -15,6 +15,7 @@ import app.tivi.inject.ApplicationScope
 import app.tivi.util.AppCoroutineDispatchers
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.withContext
 import me.tatarka.inject.annotations.Inject
 import org.mobilenativefoundation.store.store5.Fetcher
 import org.mobilenativefoundation.store.store5.SourceOfTruth
@@ -67,10 +68,10 @@ class RecommendedShowsStore(
   ),
 ).validator(
   Validator.by { result ->
-    if (result.isNotEmpty()) {
-      lastRequestStore.isRequestValid(3.days)
-    } else {
-      lastRequestStore.isRequestValid(30.minutes)
+    withContext(dispatchers.io) {
+      lastRequestStore.isRequestValid(
+        threshold = if (result.isNotEmpty()) 3.days else 30.minutes,
+      )
     }
   },
 ).build()

--- a/data/relatedshows/src/commonMain/kotlin/app/tivi/data/relatedshows/RelatedShowsStore.kt
+++ b/data/relatedshows/src/commonMain/kotlin/app/tivi/data/relatedshows/RelatedShowsStore.kt
@@ -77,10 +77,11 @@ class RelatedShowsStore(
   ),
 ).validator(
   Validator.by { result ->
-    if (result.related.isNotEmpty()) {
-      lastRequestStore.isRequestValid(result.showId, 28.days)
-    } else {
-      lastRequestStore.isRequestValid(result.showId, 1.hours)
+    withContext(dispatchers.io) {
+      lastRequestStore.isRequestValid(
+        entityId = result.showId,
+        threshold = if (result.related.isNotEmpty()) 28.days else 1.hours,
+      )
     }
   },
 ).build()

--- a/data/showimages/src/commonMain/kotlin/app/tivi/data/showimages/ShowImagesStore.kt
+++ b/data/showimages/src/commonMain/kotlin/app/tivi/data/showimages/ShowImagesStore.kt
@@ -15,6 +15,7 @@ import app.tivi.util.AppCoroutineDispatchers
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import me.tatarka.inject.annotations.Inject
 import org.mobilenativefoundation.store.store5.Fetcher
 import org.mobilenativefoundation.store.store5.SourceOfTruth
@@ -59,10 +60,11 @@ class ShowImagesStore(
   ),
 ).validator(
   Validator.by { result ->
-    if (result.images.isNotEmpty()) {
-      lastRequestStore.isRequestValid(result.showId, 180.days)
-    } else {
-      lastRequestStore.isRequestValid(result.showId, 1.hours)
+    withContext(dispatchers.io) {
+      lastRequestStore.isRequestValid(
+        entityId = result.showId,
+        threshold = if (result.images.isNotEmpty()) 180.days else 1.hours,
+      )
     }
   },
 ).build()

--- a/data/shows/src/commonMain/kotlin/app/tivi/data/shows/ShowStore.kt
+++ b/data/shows/src/commonMain/kotlin/app/tivi/data/shows/ShowStore.kt
@@ -66,5 +66,9 @@ class ShowStore(
     writeDispatcher = dispatchers.databaseWrite,
   ),
 ).validator(
-  Validator.by { lastRequestStore.isRequestValid(it.id, 14.days) },
+  Validator.by {
+    withContext(dispatchers.io) {
+      lastRequestStore.isRequestValid(it.id, 14.days)
+    }
+  },
 ).build()

--- a/data/traktauth/src/androidMain/kotlin/app/tivi/data/traktauth/TraktAuthInitializer.kt
+++ b/data/traktauth/src/androidMain/kotlin/app/tivi/data/traktauth/TraktAuthInitializer.kt
@@ -8,9 +8,9 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class TraktAuthInitializer(
-  private val traktLoginAction: AndroidTraktLoginAction,
+  private val traktLoginAction: Lazy<AndroidTraktLoginAction>,
 ) : AppInitializer {
   override fun initialize() {
-    traktLoginAction.registerActivityWatcher()
+    traktLoginAction.value.registerActivityWatcher()
   }
 }

--- a/data/trendingshows/src/commonMain/kotlin/app/tivi/data/trendingshows/TrendingShowsStore.kt
+++ b/data/trendingshows/src/commonMain/kotlin/app/tivi/data/trendingshows/TrendingShowsStore.kt
@@ -67,10 +67,10 @@ class TrendingShowsStore(
   ),
 ).validator(
   Validator.by { result ->
-    if (result.isNotEmpty()) {
-      lastRequestStore.isRequestValid(3.hours)
-    } else {
-      lastRequestStore.isRequestValid(30.minutes)
+    withContext(dispatchers.io) {
+      lastRequestStore.isRequestValid(
+        threshold = if (result.isNotEmpty()) 3.hours else 30.minutes,
+      )
     }
   },
 ).build()

--- a/data/watchedshows/src/commonMain/kotlin/app/tivi/data/watchedshows/WatchedShowsStore.kt
+++ b/data/watchedshows/src/commonMain/kotlin/app/tivi/data/watchedshows/WatchedShowsStore.kt
@@ -16,6 +16,7 @@ import app.tivi.util.AppCoroutineDispatchers
 import app.tivi.util.Logger
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.withContext
 import me.tatarka.inject.annotations.Inject
 import org.mobilenativefoundation.store.store5.Fetcher
 import org.mobilenativefoundation.store.store5.SourceOfTruth
@@ -73,10 +74,10 @@ class WatchedShowsStore(
   ),
 ).validator(
   Validator.by { result ->
-    if (result.isNotEmpty()) {
-      lastRequestStore.isRequestValid(6.hours)
-    } else {
-      lastRequestStore.isRequestValid(30.minutes)
+    withContext(dispatchers.io) {
+      lastRequestStore.isRequestValid(
+        threshold = if (result.isNotEmpty()) 6.hours else 30.minutes,
+      )
     }
   },
 ).build()

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/AddEpisodeWatch.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/AddEpisodeWatch.kt
@@ -12,12 +12,12 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class AddEpisodeWatch(
-  private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
+  private val seasonsEpisodesRepository: Lazy<SeasonsEpisodesRepository>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<AddEpisodeWatch.Params, Unit>() {
   override suspend fun doWork(params: Params) {
     withContext(dispatchers.io) {
-      seasonsEpisodesRepository.addEpisodeWatch(params.episodeId, params.timestamp)
+      seasonsEpisodesRepository.value.addEpisodeWatch(params.episodeId, params.timestamp)
     }
   }
 

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/ChangeSeasonFollowStatus.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/ChangeSeasonFollowStatus.kt
@@ -11,9 +11,11 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class ChangeSeasonFollowStatus(
-  private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
+  seasonsEpisodesRepository: Lazy<SeasonsEpisodesRepository>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<ChangeSeasonFollowStatus.Params, Unit>() {
+  private val seasonsEpisodesRepository by seasonsEpisodesRepository
+
   override suspend fun doWork(params: Params) {
     withContext(dispatchers.io) {
       when (params.action) {

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/ChangeSeasonWatchedStatus.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/ChangeSeasonWatchedStatus.kt
@@ -12,9 +12,10 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class ChangeSeasonWatchedStatus(
-  private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
+  seasonsEpisodesRepository: Lazy<SeasonsEpisodesRepository>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<ChangeSeasonWatchedStatus.Params, Unit>() {
+  private val seasonsEpisodesRepository by seasonsEpisodesRepository
 
   override suspend fun doWork(params: Params) {
     withContext(dispatchers.io) {

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/ChangeShowFollowStatus.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/ChangeShowFollowStatus.kt
@@ -14,10 +14,13 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class ChangeShowFollowStatus(
-  private val followedShowsRepository: FollowedShowsRepository,
-  private val showStore: ShowStore,
+  followedShowsRepository: Lazy<FollowedShowsRepository>,
+  showStore: Lazy<ShowStore>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<ChangeShowFollowStatus.Params, Unit>() {
+  private val followedShowsRepository by followedShowsRepository
+  private val showStore by showStore
+
   override suspend fun doWork(params: Params) {
     withContext(dispatchers.io) {
       params.showIds.forEach { showId ->

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/ClearUserDetails.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/ClearUserDetails.kt
@@ -11,9 +11,11 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class ClearUserDetails(
-  private val userDao: UserDao,
+  userDao: Lazy<UserDao>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<ClearUserDetails.Params, Unit>() {
+  private val userDao by userDao
+
   override suspend fun doWork(params: Params) {
     withContext(dispatchers.io) {
       when (params.username) {

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/FetchLicensesList.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/FetchLicensesList.kt
@@ -10,8 +10,9 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class FetchLicensesList(
-  private val licensesStore: LicensesStore,
+  licensesStore: Lazy<LicensesStore>,
 ) : Interactor<Unit, List<LicenseItem>>() {
+  private val licensesStore by licensesStore
 
   override suspend fun doWork(params: Unit): List<LicenseItem> {
     return licensesStore.getLicenses()

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/GetTraktAuthState.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/GetTraktAuthState.kt
@@ -10,8 +10,10 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class GetTraktAuthState(
-  private val traktAuthRepository: TraktAuthRepository,
+  traktAuthRepository: Lazy<TraktAuthRepository>,
 ) : Interactor<Unit, TraktAuthState>() {
+  private val traktAuthRepository by traktAuthRepository
+
   override suspend fun doWork(params: Unit): TraktAuthState {
     return traktAuthRepository.state.value
   }

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/LoginTrakt.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/LoginTrakt.kt
@@ -10,7 +10,9 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class LoginTrakt(
-  private val traktAuthRepository: TraktAuthRepository,
+  traktAuthRepository: Lazy<TraktAuthRepository>,
 ) : Interactor<Unit, AuthState?>() {
+  private val traktAuthRepository by traktAuthRepository
+
   override suspend fun doWork(params: Unit) = traktAuthRepository.login()
 }

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/LogoutTrakt.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/LogoutTrakt.kt
@@ -9,11 +9,11 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class LogoutTrakt(
-  private val traktAuthRepository: TraktAuthRepository,
-  private val clearUserDetails: ClearUserDetails,
+  private val traktAuthRepository: Lazy<TraktAuthRepository>,
+  private val clearUserDetails: Lazy<ClearUserDetails>,
 ) : Interactor<Unit, Unit>() {
   override suspend fun doWork(params: Unit) {
-    traktAuthRepository.logout()
-    clearUserDetails(ClearUserDetails.Params("me"))
+    traktAuthRepository.value.logout()
+    clearUserDetails.value.invoke(ClearUserDetails.Params("me"))
   }
 }

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/RefreshTraktTokens.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/RefreshTraktTokens.kt
@@ -10,7 +10,8 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class RefreshTraktTokens(
-  private val traktAuthRepository: TraktAuthRepository,
+  traktAuthRepository: Lazy<TraktAuthRepository>,
 ) : Interactor<Unit, AuthState?>() {
+  private val traktAuthRepository by traktAuthRepository
   override suspend fun doWork(params: Unit) = traktAuthRepository.refreshTokens()
 }

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/RemoveEpisodeWatch.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/RemoveEpisodeWatch.kt
@@ -11,12 +11,12 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class RemoveEpisodeWatch(
-  private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
+  private val seasonsEpisodesRepository: Lazy<SeasonsEpisodesRepository>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<RemoveEpisodeWatch.Params, Unit>() {
   override suspend fun doWork(params: Params) {
     withContext(dispatchers.io) {
-      seasonsEpisodesRepository.removeEpisodeWatch(params.episodeWatchId)
+      seasonsEpisodesRepository.value.removeEpisodeWatch(params.episodeWatchId)
     }
   }
 

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/RemoveEpisodeWatches.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/RemoveEpisodeWatches.kt
@@ -11,12 +11,12 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class RemoveEpisodeWatches(
-  private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
+  private val seasonsEpisodesRepository: Lazy<SeasonsEpisodesRepository>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<RemoveEpisodeWatches.Params, Unit>() {
   override suspend fun doWork(params: Params) {
     withContext(dispatchers.io) {
-      seasonsEpisodesRepository.removeAllEpisodeWatches(params.episodeId)
+      seasonsEpisodesRepository.value.removeAllEpisodeWatches(params.episodeId)
     }
   }
 

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/SearchShows.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/SearchShows.kt
@@ -13,17 +13,17 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class SearchShows(
-  private val searchRepository: SearchRepository,
-  private val showDao: TiviShowDao,
+  private val searchRepository: Lazy<SearchRepository>,
+  private val showDao: Lazy<TiviShowDao>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<SearchShows.Params, List<TiviShow>>() {
   override suspend fun doWork(params: Params): List<TiviShow> = withContext(dispatchers.io) {
-    val remoteResults = searchRepository.search(params.query)
+    val remoteResults = searchRepository.value.search(params.query)
     when {
       remoteResults.isNotEmpty() -> remoteResults
       params.query.isNotBlank() -> {
         try {
-          showDao.search("%${params.query}%")
+          showDao.value.search("%${params.query}%")
         } catch (e: Exception) {
           // Re-throw wrapped exception with the query
           throw Exception("Error while searching database with query: ${params.query}", e)

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdatePopularShows.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdatePopularShows.kt
@@ -16,9 +16,9 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class UpdatePopularShows(
-  private val popularShowStore: PopularShowsStore,
-  private val popularDao: PopularDao,
-  private val showStore: ShowStore,
+  private val popularShowStore: Lazy<PopularShowsStore>,
+  private val popularDao: Lazy<PopularDao>,
+  private val showStore: Lazy<ShowStore>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<Params, Unit>() {
   override suspend fun doWork(params: Params) {
@@ -26,14 +26,14 @@ class UpdatePopularShows(
       val page = when {
         params.page >= 0 -> params.page
         params.page == UpdateTrendingShows.Page.NEXT_PAGE -> {
-          val lastPage = popularDao.getLastPage()
+          val lastPage = popularDao.value.getLastPage()
           if (lastPage != null) lastPage + 1 else 0
         }
         else -> 0
       }
 
-      popularShowStore.fetch(page, forceFresh = params.forceRefresh).parallelForEach {
-        showStore.fetch(it.showId)
+      popularShowStore.value.fetch(page, forceFresh = params.forceRefresh).parallelForEach {
+        showStore.value.fetch(it.showId)
       }
     }
   }

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateRecommendedShows.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateRecommendedShows.kt
@@ -19,20 +19,20 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class UpdateRecommendedShows(
-  private val recommendedShowsStore: RecommendedShowsStore,
-  private val showStore: ShowStore,
+  private val recommendedShowsStore: Lazy<RecommendedShowsStore>,
+  private val showStore: Lazy<ShowStore>,
+  private val traktAuthRepository: Lazy<TraktAuthRepository>,
   private val dispatchers: AppCoroutineDispatchers,
-  private val traktAuthRepository: TraktAuthRepository,
   private val logger: Logger,
 ) : Interactor<Params, Unit>() {
   override suspend fun doWork(params: Params) {
     // If we're not logged in, we can't load the recommended shows
-    if (traktAuthRepository.state.value != TraktAuthState.LOGGED_IN) return
+    if (traktAuthRepository.value.state.value != TraktAuthState.LOGGED_IN) return
 
     withContext(dispatchers.io) {
-      recommendedShowsStore.fetch(0, forceFresh = params.forceRefresh).parallelForEach {
+      recommendedShowsStore.value.fetch(0, forceFresh = params.forceRefresh).parallelForEach {
         try {
-          showStore.fetch(it.showId)
+          showStore.value.fetch(it.showId)
         } catch (ce: CancellationException) {
           throw ce
         } catch (t: Throwable) {

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateRelatedShows.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateRelatedShows.kt
@@ -17,15 +17,15 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class UpdateRelatedShows(
-  private val relatedShowsStore: RelatedShowsStore,
-  private val showsStore: ShowStore,
+  private val relatedShowsStore: Lazy<RelatedShowsStore>,
+  private val showsStore: Lazy<ShowStore>,
   private val dispatchers: AppCoroutineDispatchers,
   private val logger: Logger,
 ) : Interactor<Params, Unit>() {
   override suspend fun doWork(params: Params) = withContext(dispatchers.io) {
-    relatedShowsStore.fetch(params.showId, params.forceLoad).related.parallelForEach {
+    relatedShowsStore.value.fetch(params.showId, params.forceLoad).related.parallelForEach {
       try {
-        showsStore.fetch(it.otherShowId)
+        showsStore.value.fetch(it.otherShowId)
       } catch (ce: CancellationException) {
         throw ce
       } catch (t: Throwable) {

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateShowDetails.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateShowDetails.kt
@@ -15,16 +15,16 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class UpdateShowDetails(
-  private val showStore: ShowStore,
-  private val lastRequestStore: ShowLastRequestStore,
+  private val showStore: Lazy<ShowStore>,
+  private val lastRequestStore: Lazy<ShowLastRequestStore>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<Params, Unit>() {
   override suspend fun doWork(params: Params) {
     withContext(dispatchers.io) {
-      showStore.fetch(
+      showStore.value.fetch(
         key = params.showId,
         forceFresh = params.forceLoad ||
-          lastRequestStore.isRequestExpired(params.showId, 28.days),
+          lastRequestStore.value.isRequestExpired(params.showId, 28.days),
       )
     }
   }

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateShowImages.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateShowImages.kt
@@ -12,12 +12,12 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class UpdateShowImages(
-  private val showImagesStore: ShowImagesStore,
+  private val showImagesStore: Lazy<ShowImagesStore>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<UpdateShowImages.Params, Unit>() {
   override suspend fun doWork(params: Params) {
     withContext(dispatchers.io) {
-      showImagesStore.fetch(params.showId, params.forceLoad)
+      showImagesStore.value.fetch(params.showId, params.forceLoad)
     }
   }
 

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateShowSeasons.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateShowSeasons.kt
@@ -13,9 +13,11 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class UpdateShowSeasons(
-  private val seasonsEpisodesRepository: SeasonsEpisodesRepository,
+  seasonsEpisodesRepository: Lazy<SeasonsEpisodesRepository>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<Params, Unit>() {
+  private val seasonsEpisodesRepository by seasonsEpisodesRepository
+
   override suspend fun doWork(params: Params) {
     withContext(dispatchers.io) {
       // Then update the seasons/episodes

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateTmdbConfig.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateTmdbConfig.kt
@@ -11,12 +11,12 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class UpdateTmdbConfig(
-  private val tmdbManager: TmdbManager,
+  private val tmdbManager: Lazy<TmdbManager>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<Unit, Unit>() {
   override suspend fun doWork(params: Unit) {
     withContext(dispatchers.io) {
-      tmdbManager.refreshConfiguration()
+      tmdbManager.value.refreshConfiguration()
     }
   }
 }

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateTrendingShows.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateTrendingShows.kt
@@ -16,9 +16,9 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class UpdateTrendingShows(
-  private val trendingShowsStore: TrendingShowsStore,
-  private val trendingShowsDao: TrendingDao,
-  private val showStore: ShowStore,
+  private val trendingShowsStore: Lazy<TrendingShowsStore>,
+  private val trendingShowsDao: Lazy<TrendingDao>,
+  private val showStore: Lazy<ShowStore>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<Params, Unit>() {
   override suspend fun doWork(params: Params) {
@@ -26,15 +26,15 @@ class UpdateTrendingShows(
       val page = when {
         params.page >= 0 -> params.page
         params.page == Page.NEXT_PAGE -> {
-          val lastPage = trendingShowsDao.getLastPage()
+          val lastPage = trendingShowsDao.value.getLastPage()
           if (lastPage != null) lastPage + 1 else 0
         }
 
         else -> 0
       }
 
-      trendingShowsStore.fetch(page, params.forceRefresh).parallelForEach {
-        showStore.fetch(it.showId)
+      trendingShowsStore.value.fetch(page, params.forceRefresh).parallelForEach {
+        showStore.value.fetch(it.showId)
       }
     }
   }

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateUpNextEpisodes.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateUpNextEpisodes.kt
@@ -13,20 +13,20 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class UpdateUpNextEpisodes(
-  private val watchedShowsDao: WatchedShowDao,
-  private val seasonEpisodeRepository: SeasonsEpisodesRepository,
-  private val updateLibraryShows: UpdateLibraryShows,
+  private val watchedShowsDao: Lazy<WatchedShowDao>,
+  private val seasonEpisodeRepository: Lazy<SeasonsEpisodesRepository>,
+  private val updateLibraryShows: Lazy<UpdateLibraryShows>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<UpdateUpNextEpisodes.Params, Unit>() {
 
   override suspend fun doWork(params: Params) {
-    updateLibraryShows(UpdateLibraryShows.Params(params.forceRefresh))
+    updateLibraryShows.value.invoke(UpdateLibraryShows.Params(params.forceRefresh))
 
     // Now update the next episodes, to fetch images, etc
     withContext(dispatchers.io) {
-      watchedShowsDao.getUpNextShows().parallelForEach { entry ->
-        if (seasonEpisodeRepository.needEpisodeUpdate(entry.episode.id)) {
-          seasonEpisodeRepository.updateEpisode(entry.episode.id)
+      watchedShowsDao.value.getUpNextShows().parallelForEach { entry ->
+        if (seasonEpisodeRepository.value.needEpisodeUpdate(entry.episode.id)) {
+          seasonEpisodeRepository.value.updateEpisode(entry.episode.id)
         }
       }
     }

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateUserDetails.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/UpdateUserDetails.kt
@@ -12,13 +12,13 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class UpdateUserDetails(
-  private val repository: TraktUsersRepository,
+  private val repository: Lazy<TraktUsersRepository>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<Params, Unit>() {
   override suspend fun doWork(params: Params) {
     withContext(dispatchers.io) {
-      if (params.forceLoad || repository.needUpdate(params.username)) {
-        repository.updateUser(params.username)
+      if (params.forceLoad || repository.value.needUpdate(params.username)) {
+        repository.value.updateUser(params.username)
       }
     }
   }

--- a/domain/src/commonMain/kotlin/app/tivi/domain/observers/ObserveShowDetails.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/observers/ObserveShowDetails.kt
@@ -25,7 +25,7 @@ class ObserveShowDetails(
     return showStore.stream(StoreReadRequest.cached(params.showId, refresh = false))
       .filter { it is StoreReadResponse.Data }
       .map { it.requireData() }
-      .flowOn(dispatchers.computation)
+      .flowOn(dispatchers.io)
   }
 
   data class Params(val showId: Long)

--- a/domain/src/commonMain/kotlin/app/tivi/domain/observers/ObserveShowImages.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/observers/ObserveShowImages.kt
@@ -24,7 +24,7 @@ class ObserveShowImages(
     return store.stream(StoreReadRequest.cached(params.showId, refresh = false))
       .filterForResult()
       .map { it.requireData() }
-      .flowOn(dispatchers.computation)
+      .flowOn(dispatchers.io)
   }
 
   data class Params(val showId: Long)

--- a/shared/common/src/androidMain/kotlin/app/tivi/inject/SharedPlatformApplicationComponent.kt
+++ b/shared/common/src/androidMain/kotlin/app/tivi/inject/SharedPlatformApplicationComponent.kt
@@ -34,7 +34,7 @@ actual interface SharedPlatformApplicationComponent {
       flavor = flavor,
       versionName = packageInfo.versionName,
       versionCode = @Suppress("DEPRECATION") packageInfo.versionCode,
-      cachePath = application.cacheDir.absolutePath,
+      cachePath = { application.cacheDir.absolutePath },
     )
   }
 

--- a/shared/common/src/commonMain/kotlin/app/tivi/appinitializers/AppInitializers.kt
+++ b/shared/common/src/commonMain/kotlin/app/tivi/appinitializers/AppInitializers.kt
@@ -8,12 +8,12 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class AppInitializers(
-  private val initializers: Set<AppInitializer>,
+  private val initializers: Lazy<Set<AppInitializer>>,
   private val tracer: Tracer,
 ) : AppInitializer {
   override fun initialize() {
     tracer.trace("AppInitializers") {
-      for (initializer in initializers) {
+      for (initializer in initializers.value) {
         initializer.initialize()
       }
     }

--- a/shared/common/src/iosMain/kotlin/app/tivi/inject/SharedPlatformApplicationComponent.kt
+++ b/shared/common/src/iosMain/kotlin/app/tivi/inject/SharedPlatformApplicationComponent.kt
@@ -33,7 +33,7 @@ actual interface SharedPlatformApplicationComponent {
     versionCode = (NSBundle.mainBundle.infoDictionary?.get("CFBundleVersion") as? String)
       ?.toIntOrNull()
       ?: 0,
-    cachePath = NSFileManager.defaultManager.cacheDir,
+    cachePath = { NSFileManager.defaultManager.cacheDir },
   )
 }
 

--- a/shared/common/src/jvmMain/kotlin/app/tivi/inject/SharedPlatformApplicationComponent.kt
+++ b/shared/common/src/jvmMain/kotlin/app/tivi/inject/SharedPlatformApplicationComponent.kt
@@ -24,7 +24,7 @@ actual interface SharedPlatformApplicationComponent {
     flavor = flavor,
     versionName = "1.0.0",
     versionCode = 1,
-    cachePath = getCacheDir().absolutePath,
+    cachePath = { getCacheDir().absolutePath },
   )
 
   @ApplicationScope

--- a/shared/prod/src/androidMain/kotlin/app/tivi/inject/AndroidApplicationComponent.kt
+++ b/shared/prod/src/androidMain/kotlin/app/tivi/inject/AndroidApplicationComponent.kt
@@ -6,6 +6,7 @@ package app.tivi.inject
 import android.app.Application
 import app.tivi.appinitializers.AppInitializers
 import app.tivi.tasks.TiviWorkerFactory
+import app.tivi.util.AppCoroutineDispatchers
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Provides
 import okhttp3.Interceptor
@@ -18,6 +19,7 @@ abstract class AndroidApplicationComponent(
 
   abstract val initializers: AppInitializers
   abstract val workerFactory: TiviWorkerFactory
+  abstract val dispatchers: AppCoroutineDispatchers
 
   /**
    * We have no interceptors in the standard release currently

--- a/shared/qa/src/androidMain/kotlin/app/tivi/inject/AndroidApplicationComponent.kt
+++ b/shared/qa/src/androidMain/kotlin/app/tivi/inject/AndroidApplicationComponent.kt
@@ -6,6 +6,7 @@ package app.tivi.inject
 import android.app.Application
 import app.tivi.appinitializers.AppInitializers
 import app.tivi.tasks.TiviWorkerFactory
+import app.tivi.util.AppCoroutineDispatchers
 import com.chuckerteam.chucker.api.ChuckerInterceptor
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.IntoSet
@@ -22,6 +23,7 @@ abstract class AndroidApplicationComponent(
 
   abstract val initializers: AppInitializers
   abstract val workerFactory: TiviWorkerFactory
+  abstract val dispatchers: AppCoroutineDispatchers
 
   @ApplicationScope
   @IntoSet

--- a/tasks/src/androidMain/kotlin/app/tivi/tasks/AndroidShowTasks.kt
+++ b/tasks/src/androidMain/kotlin/app/tivi/tasks/AndroidShowTasks.kt
@@ -13,7 +13,7 @@ import me.tatarka.inject.annotations.Inject
 
 @Inject
 class AndroidShowTasks(
-  private val workManager: WorkManager,
+  private val workManager: Lazy<WorkManager>,
 ) : ShowTasks {
   override fun register() {
     val nightlyConstraints = Constraints.Builder()
@@ -21,7 +21,7 @@ class AndroidShowTasks(
       .setRequiresCharging(true)
       .build()
 
-    workManager.enqueueUniquePeriodicWork(
+    workManager.value.enqueueUniquePeriodicWork(
       SyncLibraryShows.NIGHTLY_SYNC_TAG,
       ExistingPeriodicWorkPolicy.KEEP,
       PeriodicWorkRequestBuilder<SyncLibraryShows>(24, TimeUnit.HOURS)

--- a/ui/developer/settings/src/commonMain/kotlin/app/tivi/settings/developer/DevSettingsPresenter.kt
+++ b/ui/developer/settings/src/commonMain/kotlin/app/tivi/settings/developer/DevSettingsPresenter.kt
@@ -6,15 +6,16 @@ package app.tivi.settings.developer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import app.tivi.common.compose.rememberCoroutineScope
 import app.tivi.screens.DevLogScreen
 import app.tivi.screens.DevSettingsScreen
 import app.tivi.settings.TiviPreferences
-import app.tivi.settings.toggle
 import com.slack.circuit.retained.collectAsRetainedState
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
+import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 
@@ -35,19 +36,23 @@ class DevSettingsUiPresenterFactory(
 @Inject
 class DevSettingsPresenter(
   @Assisted private val navigator: Navigator,
-  private val preferences: TiviPreferences,
+  private val preferences: Lazy<TiviPreferences>,
 ) : Presenter<DevSettingsUiState> {
 
   @Composable
   override fun present(): DevSettingsUiState {
-    val hideArtwork by remember { preferences.observeDeveloperHideArtwork() }
+    val hideArtwork by remember { preferences.value.observeDeveloperHideArtwork() }
       .collectAsRetainedState(false)
+
+    val coroutineScope = rememberCoroutineScope()
 
     fun eventSink(event: DevSettingsUiEvent) {
       when (event) {
         DevSettingsUiEvent.NavigateUp -> navigator.pop()
         DevSettingsUiEvent.NavigateLog -> navigator.goTo(DevLogScreen)
-        DevSettingsUiEvent.ToggleHideArtwork -> preferences::developerHideArtwork.toggle()
+        DevSettingsUiEvent.ToggleHideArtwork -> {
+          coroutineScope.launch { preferences.value.toggleDeveloperHideArtwork() }
+        }
       }
     }
 

--- a/ui/library/src/commonMain/kotlin/app/tivi/home/library/LibraryPresenter.kt
+++ b/ui/library/src/commonMain/kotlin/app/tivi/home/library/LibraryPresenter.kt
@@ -89,6 +89,8 @@ class LibraryPresenter(
     val includeFollowedShows by remember { preferences.value.observeLibraryFollowedActive() }
       .collectAsRetainedState(false)
 
+    val coroutineScope = rememberCoroutineScope()
+
     fun eventSink(event: LibraryUiEvent) {
       when (event) {
         is LibraryUiEvent.ChangeFilter -> filter = event.filter
@@ -111,10 +113,14 @@ class LibraryPresenter(
           }
         }
         LibraryUiEvent.ToggleFollowedShowsIncluded -> {
-          preferences.value.libraryFollowedActive = !preferences.value.libraryFollowedActive
+          coroutineScope.launch {
+            preferences.value.toggleLibraryFollowedActive()
+          }
         }
         LibraryUiEvent.ToggleWatchedShowsIncluded -> {
-          preferences.value.libraryWatchedActive = !preferences.value.libraryWatchedActive
+          coroutineScope.launch {
+            preferences.value.toggleLibraryWatchedActive()
+          }
         }
         LibraryUiEvent.OpenAccount -> navigator.goTo(AccountScreen)
         is LibraryUiEvent.OpenShowDetails -> {
@@ -142,8 +148,8 @@ class LibraryPresenter(
         ObservePagedLibraryShows.Parameters(
           sort = sort,
           filter = filter,
-          includeFollowed = preferences.value.libraryFollowedActive,
-          includeWatched = preferences.value.libraryWatchedActive,
+          includeFollowed = includeFollowedShows,
+          includeWatched = includeWatchedShows,
           pagingConfig = PAGING_CONFIG,
         ),
       )

--- a/ui/licenses/src/commonMain/kotlin/app/tivi/settings/licenses/LicensesPresenter.kt
+++ b/ui/licenses/src/commonMain/kotlin/app/tivi/settings/licenses/LicensesPresenter.kt
@@ -42,10 +42,10 @@ class LicensesPresenter(
   @Composable
   override fun present(): LicensesUiState {
     val licenseItemList by produceState(emptyList()) {
-      val list = fetchLicensesList(Unit).getOrDefault(emptyList())
-
-      value = withContext(dispatchers.computation) {
-        list.groupBy { it.groupId }
+      value = withContext(dispatchers.io) {
+        fetchLicensesList(Unit)
+          .getOrDefault(emptyList())
+          .groupBy { it.groupId }
           .map { (groupId, artifacts) ->
             LicenseGroup(
               id = groupId,

--- a/ui/licenses/src/commonMain/kotlin/app/tivi/settings/licenses/LicensesPresenter.kt
+++ b/ui/licenses/src/commonMain/kotlin/app/tivi/settings/licenses/LicensesPresenter.kt
@@ -35,7 +35,7 @@ class LicensesUiPresenterFactory(
 @Inject
 class LicensesPresenter(
   @Assisted private val navigator: Navigator,
-  private val fetchLicensesList: FetchLicensesList,
+  private val fetchLicensesList: Lazy<FetchLicensesList>,
   private val dispatchers: AppCoroutineDispatchers,
 ) : Presenter<LicensesUiState> {
 
@@ -43,7 +43,7 @@ class LicensesPresenter(
   override fun present(): LicensesUiState {
     val licenseItemList by produceState(emptyList()) {
       value = withContext(dispatchers.io) {
-        fetchLicensesList(Unit)
+        fetchLicensesList.value.invoke(Unit)
           .getOrDefault(emptyList())
           .groupBy { it.groupId }
           .map { (groupId, artifacts) ->

--- a/ui/popular/src/commonMain/kotlin/app/tivi/home/popular/PopularShowsPresenter.kt
+++ b/ui/popular/src/commonMain/kotlin/app/tivi/home/popular/PopularShowsPresenter.kt
@@ -35,17 +35,17 @@ class PopularShowsUiPresenterFactory(
 @Inject
 class PopularShowsPresenter(
   @Assisted private val navigator: Navigator,
-  private val pagingInteractor: ObservePagedPopularShows,
+  private val pagingInteractor: Lazy<ObservePagedPopularShows>,
 ) : Presenter<PopularShowsUiState> {
 
   @Composable
   override fun present(): PopularShowsUiState {
-    val items = pagingInteractor.flow
+    val items = pagingInteractor.value.flow
       .rememberCachedPagingFlow()
       .collectAsLazyPagingItems()
 
     LaunchedEffect(Unit) {
-      pagingInteractor(ObservePagedPopularShows.Params(PAGING_CONFIG))
+      pagingInteractor.value.invoke(ObservePagedPopularShows.Params(PAGING_CONFIG))
     }
 
     fun eventSink(event: PopularShowsUiEvent) {

--- a/ui/recommended/src/commonMain/kotlin/app/tivi/home/recommended/RecommendedShowsPresenter.kt
+++ b/ui/recommended/src/commonMain/kotlin/app/tivi/home/recommended/RecommendedShowsPresenter.kt
@@ -35,17 +35,17 @@ class RecommendedShowsUiPresenterFactory(
 @Inject
 class RecommendedShowsPresenter(
   @Assisted private val navigator: Navigator,
-  private val pagingInteractor: ObservePagedRecommendedShows,
+  private val pagingInteractor: Lazy<ObservePagedRecommendedShows>,
 ) : Presenter<RecommendedShowsUiState> {
 
   @Composable
   override fun present(): RecommendedShowsUiState {
-    val items = pagingInteractor.flow
+    val items = pagingInteractor.value.flow
       .rememberCachedPagingFlow()
       .collectAsLazyPagingItems()
 
     LaunchedEffect(Unit) {
-      pagingInteractor(ObservePagedRecommendedShows.Params(PAGING_CONFIG))
+      pagingInteractor.value.invoke(ObservePagedRecommendedShows.Params(PAGING_CONFIG))
     }
 
     fun eventSink(event: RecommendedShowsUiEvent) {

--- a/ui/search/src/commonMain/kotlin/app/tivi/home/search/SearchPresenter.kt
+++ b/ui/search/src/commonMain/kotlin/app/tivi/home/search/SearchPresenter.kt
@@ -47,7 +47,7 @@ class SearchUiPresenterFactory(
 @Inject
 class SearchPresenter(
   @Assisted private val navigator: Navigator,
-  private val searchShows: SearchShows,
+  private val searchShows: Lazy<SearchShows>,
   private val logger: Logger,
 ) : Presenter<SearchUiState> {
 
@@ -60,14 +60,14 @@ class SearchPresenter(
 
     val uiMessageManager = remember { UiMessageManager() }
 
-    val loading by searchShows.inProgress.collectAsState(false)
+    val loading by searchShows.value.inProgress.collectAsState(false)
     val message by uiMessageManager.message.collectAsState(null)
 
     LaunchedEffect(query) {
       // delay for 300 milliseconds. This has the same effect as debounce
       delay(300.milliseconds)
 
-      val result = searchShows(SearchShows.Params(query))
+      val result = searchShows.value.invoke(SearchShows.Params(query))
       results = result.getOrDefault(emptyList())
 
       result.onException { e ->

--- a/ui/settings/src/commonMain/kotlin/app/tivi/settings/SettingsPresenter.kt
+++ b/ui/settings/src/commonMain/kotlin/app/tivi/settings/SettingsPresenter.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import app.tivi.app.ApplicationInfo
 import app.tivi.app.Flavor
+import app.tivi.common.compose.rememberCoroutineScope
 import app.tivi.screens.DevSettingsScreen
 import app.tivi.screens.LicensesScreen
 import app.tivi.screens.SettingsScreen
@@ -17,6 +18,7 @@ import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
+import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 
@@ -62,29 +64,38 @@ class SettingsPresenter(
     val analyticsDataReportingEnabled by remember { preferences.observeReportAnalytics() }
       .collectAsRetainedState(true)
 
+    val coroutineScope = rememberCoroutineScope()
+
     fun eventSink(event: SettingsUiEvent) {
       when (event) {
-        SettingsUiEvent.NavigateUp -> navigator.pop()
+        SettingsUiEvent.NavigateUp -> {
+          navigator.pop()
+        }
         is SettingsUiEvent.SetTheme -> {
-          preferences.theme = event.theme
+          coroutineScope.launch { preferences.setTheme(event.theme) }
         }
 
-        SettingsUiEvent.ToggleUseDynamicColors -> preferences::useDynamicColors.toggle()
-        SettingsUiEvent.ToggleUseLessData -> preferences::useLessData.toggle()
-        SettingsUiEvent.ToggleIgnoreSpecials -> preferences::ignoreSpecials.toggle()
-        SettingsUiEvent.ToggleCrashDataReporting -> preferences::reportAppCrashes.toggle()
-        SettingsUiEvent.ToggleAnalyticsDataReporting -> preferences::reportAnalytics.toggle()
+        SettingsUiEvent.ToggleUseDynamicColors -> {
+          coroutineScope.launch { preferences.toggleUseDynamicColors() }
+        }
+        SettingsUiEvent.ToggleUseLessData -> {
+          coroutineScope.launch { preferences.toggleUseLessData() }
+        }
+        SettingsUiEvent.ToggleIgnoreSpecials -> {
+          coroutineScope.launch { preferences.toggleIgnoreSpecials() }
+        }
+        SettingsUiEvent.ToggleCrashDataReporting -> {
+          coroutineScope.launch { preferences.toggleReportAppCrashes() }
+        }
+        SettingsUiEvent.ToggleAnalyticsDataReporting -> {
+          coroutineScope.launch { preferences.toggleReportAnalytics() }
+        }
         SettingsUiEvent.NavigatePrivacyPolicy -> {
           navigator.goTo(UrlScreen("https://chrisbanes.github.io/tivi/privacypolicy"))
         }
 
-        SettingsUiEvent.NavigateOpenSource -> {
-          navigator.goTo(LicensesScreen)
-        }
-
-        SettingsUiEvent.NavigateDeveloperSettings -> {
-          navigator.goTo(DevSettingsScreen)
-        }
+        SettingsUiEvent.NavigateOpenSource -> navigator.goTo(LicensesScreen)
+        SettingsUiEvent.NavigateDeveloperSettings -> navigator.goTo(DevSettingsScreen)
       }
     }
 

--- a/ui/settings/src/commonMain/kotlin/app/tivi/settings/SettingsPresenter.kt
+++ b/ui/settings/src/commonMain/kotlin/app/tivi/settings/SettingsPresenter.kt
@@ -37,9 +37,10 @@ class SettingsUiPresenterFactory(
 @Inject
 class SettingsPresenter(
   @Assisted private val navigator: Navigator,
-  private val preferences: TiviPreferences,
+  preferences: Lazy<TiviPreferences>,
   private val applicationInfo: ApplicationInfo,
 ) : Presenter<SettingsUiState> {
+  private val preferences by preferences
 
   @Composable
   override fun present(): SettingsUiState {

--- a/ui/show/details/src/commonMain/kotlin/app/tivi/showdetails/details/ShowDetailsPresenter.kt
+++ b/ui/show/details/src/commonMain/kotlin/app/tivi/showdetails/details/ShowDetailsPresenter.kt
@@ -60,21 +60,34 @@ class ShowDetailsUiPresenterFactory(
 class ShowDetailsPresenter(
   @Assisted private val screen: ShowDetailsScreen,
   @Assisted private val navigator: Navigator,
-  private val updateShowDetails: UpdateShowDetails,
-  private val observeShowDetails: ObserveShowDetails,
-  private val updateRelatedShows: UpdateRelatedShows,
-  private val observeRelatedShows: ObserveRelatedShows,
-  private val updateShowSeasons: UpdateShowSeasons,
-  private val observeShowSeasons: ObserveShowSeasonsEpisodesWatches,
-  private val changeSeasonWatchedStatus: ChangeSeasonWatchedStatus,
-  private val observeShowFollowStatus: ObserveShowFollowStatus,
-  private val observeNextEpisodeToWatch: ObserveShowNextEpisodeToWatch,
-  private val observeShowViewStats: ObserveShowViewStats,
-  private val changeShowFollowStatus: ChangeShowFollowStatus,
-  private val changeSeasonFollowStatus: ChangeSeasonFollowStatus,
+  updateShowDetails: Lazy<UpdateShowDetails>,
+  observeShowDetails: Lazy<ObserveShowDetails>,
+  updateRelatedShows: Lazy<UpdateRelatedShows>,
+  observeRelatedShows: Lazy<ObserveRelatedShows>,
+  updateShowSeasons: Lazy<UpdateShowSeasons>,
+  observeShowSeasons: Lazy<ObserveShowSeasonsEpisodesWatches>,
+  changeSeasonWatchedStatus: Lazy<ChangeSeasonWatchedStatus>,
+  observeShowFollowStatus: Lazy<ObserveShowFollowStatus>,
+  observeNextEpisodeToWatch: Lazy<ObserveShowNextEpisodeToWatch>,
+  observeShowViewStats: Lazy<ObserveShowViewStats>,
+  changeShowFollowStatus: Lazy<ChangeShowFollowStatus>,
+  changeSeasonFollowStatus: Lazy<ChangeSeasonFollowStatus>,
   private val logger: Logger,
 ) : Presenter<ShowDetailsUiState> {
   private val showId: Long get() = screen.id
+
+  private val updateShowDetails by updateShowDetails
+  private val observeShowDetails by observeShowDetails
+  private val updateRelatedShows by updateRelatedShows
+  private val observeRelatedShows by observeRelatedShows
+  private val updateShowSeasons by updateShowSeasons
+  private val observeShowSeasons by observeShowSeasons
+  private val changeSeasonWatchedStatus by changeSeasonWatchedStatus
+  private val observeShowFollowStatus by observeShowFollowStatus
+  private val observeNextEpisodeToWatch by observeNextEpisodeToWatch
+  private val observeShowViewStats by observeShowViewStats
+  private val changeShowFollowStatus by changeShowFollowStatus
+  private val changeSeasonFollowStatus by changeSeasonFollowStatus
 
   @Composable
   override fun present(): ShowDetailsUiState {

--- a/ui/trending/src/commonMain/kotlin/app/tivi/home/trending/TrendingShowsPresenter.kt
+++ b/ui/trending/src/commonMain/kotlin/app/tivi/home/trending/TrendingShowsPresenter.kt
@@ -35,17 +35,17 @@ class TrendingShowsUiPresenterFactory(
 @Inject
 class TrendingShowsPresenter(
   @Assisted private val navigator: Navigator,
-  private val pagingInteractor: ObservePagedTrendingShows,
+  private val pagingInteractor: Lazy<ObservePagedTrendingShows>,
 ) : Presenter<TrendingShowsUiState> {
 
   @Composable
   override fun present(): TrendingShowsUiState {
-    val items = pagingInteractor.flow
+    val items = pagingInteractor.value.flow
       .rememberCachedPagingFlow()
       .collectAsLazyPagingItems()
 
     LaunchedEffect(Unit) {
-      pagingInteractor(ObservePagedTrendingShows.Params(PAGING_CONFIG))
+      pagingInteractor.value.invoke(ObservePagedTrendingShows.Params(PAGING_CONFIG))
     }
 
     fun eventSink(event: TrendingShowsUiEvent) {

--- a/ui/upnext/src/commonMain/kotlin/app/tivi/home/upnext/UpNextPresenter.kt
+++ b/ui/upnext/src/commonMain/kotlin/app/tivi/home/upnext/UpNextPresenter.kt
@@ -56,12 +56,12 @@ class UpNextUiPresenterFactory(
 @Inject
 class UpNextPresenter(
   @Assisted private val navigator: Navigator,
-  private val observePagedUpNextShows: ObservePagedUpNextShows,
-  private val updateUpNextEpisodes: UpdateUpNextEpisodes,
-  private val observeTraktAuthState: ObserveTraktAuthState,
-  private val observeUserDetails: ObserveUserDetails,
-  private val getTraktAuthState: GetTraktAuthState,
-  private val preferences: TiviPreferences,
+  private val observePagedUpNextShows: Lazy<ObservePagedUpNextShows>,
+  private val updateUpNextEpisodes: Lazy<UpdateUpNextEpisodes>,
+  private val observeTraktAuthState: Lazy<ObserveTraktAuthState>,
+  private val observeUserDetails: Lazy<ObserveUserDetails>,
+  private val getTraktAuthState: Lazy<GetTraktAuthState>,
+  private val preferences: Lazy<TiviPreferences>,
   private val logger: Logger,
 ) : Presenter<UpNextUiState> {
 
@@ -71,19 +71,19 @@ class UpNextPresenter(
 
     val uiMessageManager = remember { UiMessageManager() }
 
-    val items = observePagedUpNextShows.flow
+    val items = observePagedUpNextShows.value.flow
       .rememberCachedPagingFlow(scope)
       .collectAsLazyPagingItems()
 
     var sort by remember { mutableStateOf(SortOption.LAST_WATCHED) }
 
-    val loading by updateUpNextEpisodes.inProgress.collectAsState(false)
+    val loading by updateUpNextEpisodes.value.inProgress.collectAsState(false)
     val message by uiMessageManager.message.collectAsState(null)
 
-    val user by observeUserDetails.flow.collectAsRetainedState(null)
-    val authState by observeTraktAuthState.flow.collectAsRetainedState(TraktAuthState.LOGGED_OUT)
+    val user by observeUserDetails.value.flow.collectAsRetainedState(null)
+    val authState by observeTraktAuthState.value.flow.collectAsRetainedState(TraktAuthState.LOGGED_OUT)
 
-    val followedShowsOnly by remember { preferences.observeUpNextFollowedOnly() }
+    val followedShowsOnly by remember { preferences.value.observeUpNextFollowedOnly() }
       .collectAsRetainedState(false)
 
     fun eventSink(event: UpNextUiEvent) {
@@ -97,8 +97,8 @@ class UpNextPresenter(
 
         is UpNextUiEvent.Refresh -> {
           scope.launch {
-            if (getTraktAuthState.invoke().getOrThrow() == TraktAuthState.LOGGED_IN) {
-              updateUpNextEpisodes(
+            if (getTraktAuthState.value.invoke().getOrThrow() == TraktAuthState.LOGGED_IN) {
+              updateUpNextEpisodes.value.invoke(
                 UpdateUpNextEpisodes.Params(event.fromUser),
               ).onException { e ->
                 logger.i(e)
@@ -109,7 +109,7 @@ class UpNextPresenter(
         }
 
         UpNextUiEvent.ToggleFollowedShowsOnly -> {
-          preferences.upNextFollowedOnly = !preferences.upNextFollowedOnly
+          preferences.value.upNextFollowedOnly = !preferences.value.upNextFollowedOnly
         }
 
         UpNextUiEvent.OpenAccount -> navigator.goTo(AccountScreen)
@@ -117,12 +117,12 @@ class UpNextPresenter(
     }
 
     LaunchedEffect(Unit) {
-      observeTraktAuthState(Unit)
-      observeUserDetails(ObserveUserDetails.Params("me"))
+      observeTraktAuthState.value.invoke(Unit)
+      observeUserDetails.value.invoke(ObserveUserDetails.Params("me"))
     }
 
     LaunchedEffect(observeTraktAuthState) {
-      observeTraktAuthState.flow
+      observeTraktAuthState.value.flow
         .filter { it == TraktAuthState.LOGGED_IN }
         .collect {
           eventSink(UpNextUiEvent.Refresh(false))
@@ -131,7 +131,7 @@ class UpNextPresenter(
 
     LaunchedEffect(sort, followedShowsOnly) {
       // When the filter and sort options change, update the data source
-      observePagedUpNextShows(
+      observePagedUpNextShows.value.invoke(
         ObservePagedUpNextShows.Parameters(
           sort = sort,
           followedOnly = followedShowsOnly,

--- a/ui/upnext/src/commonMain/kotlin/app/tivi/home/upnext/UpNextPresenter.kt
+++ b/ui/upnext/src/commonMain/kotlin/app/tivi/home/upnext/UpNextPresenter.kt
@@ -109,7 +109,7 @@ class UpNextPresenter(
         }
 
         UpNextUiEvent.ToggleFollowedShowsOnly -> {
-          preferences.value.upNextFollowedOnly = !preferences.value.upNextFollowedOnly
+          scope.launch { preferences.value.toggleUpNextFollowedOnly() }
         }
 
         UpNextUiEvent.OpenAccount -> navigator.goTo(AccountScreen)


### PR DESCRIPTION
- Mostly fixing obvious `StrictMode` violations. Network calls and disk reads on the main thread, etc.
- Make the interactors and presenters take lazy dependencies. This has 2 benefits:
    - The obvious benefit of not creating everything up front
    - Most of the dependencies will be things which need to call on background threads, hence the lazy instantiation will tend to be on a background thread/dispatcher.