### PR TITLE
 Add retained caching for paging flows

### DIFF
--- a/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/LazyPagingExtensions.kt
+++ b/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/LazyPagingExtensions.kt
@@ -6,11 +6,11 @@
 package app.tivi.common.compose
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import app.cash.paging.CombinedLoadStates
 import app.cash.paging.LoadStateError
 import app.cash.paging.PagingData
 import app.cash.paging.cachedIn
+import com.slack.circuit.retained.rememberRetained
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
@@ -30,6 +30,6 @@ fun CombinedLoadStates.refreshErrorOrNull(): UiMessage? {
 }
 
 @Composable
-inline fun <T : Any> Flow<PagingData<T>>.rememberCachedPagingFlow(
-  scope: CoroutineScope = rememberCoroutineScope(),
-): Flow<PagingData<T>> = remember(this, scope) { cachedIn(scope) }
+inline fun <T : Any> Flow<PagingData<T>>.rememberRetainedCachedPagingFlow(
+  scope: CoroutineScope = rememberRetainedCoroutineScope(),
+): Flow<PagingData<T>> = rememberRetained(this, scope) { cachedIn(scope) }

--- a/ui/popular/src/commonMain/kotlin/app/tivi/home/popular/PopularShowsPresenter.kt
+++ b/ui/popular/src/commonMain/kotlin/app/tivi/home/popular/PopularShowsPresenter.kt
@@ -7,10 +7,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import app.cash.paging.PagingConfig
 import app.cash.paging.compose.collectAsLazyPagingItems
-import app.tivi.common.compose.rememberCachedPagingFlow
+import app.tivi.common.compose.rememberRetainedCachedPagingFlow
 import app.tivi.domain.observers.ObservePagedPopularShows
 import app.tivi.screens.PopularShowsScreen
 import app.tivi.screens.ShowDetailsScreen
+import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
@@ -40,12 +41,17 @@ class PopularShowsPresenter(
 
   @Composable
   override fun present(): PopularShowsUiState {
-    val items = pagingInteractor.value.flow
-      .rememberCachedPagingFlow()
+    // Yes, this is gross. We need the same flow instance across Presenter instances. We could
+    // make the interactor have @ApplicationScope, but that has other consequences if we use the
+    // same interactor at the same time across UIs. Instead we just retain the instance
+    val retainedPagingInteractor = rememberRetained { pagingInteractor.value }
+
+    val items = retainedPagingInteractor.flow
+      .rememberRetainedCachedPagingFlow()
       .collectAsLazyPagingItems()
 
     LaunchedEffect(Unit) {
-      pagingInteractor.value.invoke(ObservePagedPopularShows.Params(PAGING_CONFIG))
+      retainedPagingInteractor(ObservePagedPopularShows.Params(PAGING_CONFIG))
     }
 
     fun eventSink(event: PopularShowsUiEvent) {

--- a/ui/recommended/src/commonMain/kotlin/app/tivi/home/recommended/RecommendedShowsPresenter.kt
+++ b/ui/recommended/src/commonMain/kotlin/app/tivi/home/recommended/RecommendedShowsPresenter.kt
@@ -7,10 +7,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import app.cash.paging.PagingConfig
 import app.cash.paging.compose.collectAsLazyPagingItems
-import app.tivi.common.compose.rememberCachedPagingFlow
+import app.tivi.common.compose.rememberRetainedCachedPagingFlow
 import app.tivi.domain.observers.ObservePagedRecommendedShows
 import app.tivi.screens.RecommendedShowsScreen
 import app.tivi.screens.ShowDetailsScreen
+import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
@@ -40,12 +41,17 @@ class RecommendedShowsPresenter(
 
   @Composable
   override fun present(): RecommendedShowsUiState {
-    val items = pagingInteractor.value.flow
-      .rememberCachedPagingFlow()
+    // Yes, this is gross. We need the same flow instance across Presenter instances. We could
+    // make the interactor have @ApplicationScope, but that has other consequences if we use the
+    // same interactor at the same time across UIs. Instead we just retain the instance
+    val retainedPagingInteractor = rememberRetained { pagingInteractor.value }
+
+    val items = retainedPagingInteractor.flow
+      .rememberRetainedCachedPagingFlow()
       .collectAsLazyPagingItems()
 
     LaunchedEffect(Unit) {
-      pagingInteractor.value.invoke(ObservePagedRecommendedShows.Params(PAGING_CONFIG))
+      retainedPagingInteractor(ObservePagedRecommendedShows.Params(PAGING_CONFIG))
     }
 
     fun eventSink(event: RecommendedShowsUiEvent) {

--- a/ui/upnext/src/commonMain/kotlin/app/tivi/home/upnext/UpNextPresenter.kt
+++ b/ui/upnext/src/commonMain/kotlin/app/tivi/home/upnext/UpNextPresenter.kt
@@ -14,8 +14,8 @@ import app.cash.paging.PagingConfig
 import app.cash.paging.compose.collectAsLazyPagingItems
 import app.tivi.common.compose.UiMessage
 import app.tivi.common.compose.UiMessageManager
-import app.tivi.common.compose.rememberCachedPagingFlow
 import app.tivi.common.compose.rememberCoroutineScope
+import app.tivi.common.compose.rememberRetainedCachedPagingFlow
 import app.tivi.data.models.SortOption
 import app.tivi.data.traktauth.TraktAuthState
 import app.tivi.domain.interactors.GetTraktAuthState
@@ -30,6 +30,7 @@ import app.tivi.settings.TiviPreferences
 import app.tivi.util.Logger
 import app.tivi.util.onException
 import com.slack.circuit.retained.collectAsRetainedState
+import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
@@ -71,8 +72,13 @@ class UpNextPresenter(
 
     val uiMessageManager = remember { UiMessageManager() }
 
-    val items = observePagedUpNextShows.value.flow
-      .rememberCachedPagingFlow(scope)
+    // Yes, this is gross. We need the same flow instance across Presenter instances. We could
+    // make the interactor have @ApplicationScope, but that has other consequences if we use the
+    // same interactor at the same time across UIs. Instead we just retain the instance
+    val retainedObservePagedUpNextShows = rememberRetained { observePagedUpNextShows.value }
+
+    val items = retainedObservePagedUpNextShows.flow
+      .rememberRetainedCachedPagingFlow()
       .collectAsLazyPagingItems()
 
     var sort by remember { mutableStateOf(SortOption.LAST_WATCHED) }
@@ -131,7 +137,7 @@ class UpNextPresenter(
 
     LaunchedEffect(sort, followedShowsOnly) {
       // When the filter and sort options change, update the data source
-      observePagedUpNextShows.value.invoke(
+      retainedObservePagedUpNextShows(
         ObservePagedUpNextShows.Parameters(
           sort = sort,
           followedOnly = followedShowsOnly,


### PR DESCRIPTION
We now use a `rememberRetainedCoroutineScope` to keep a CoroutineScope running in a retained state. This allows to then keep a retained `cachedIn` paging flow running too.