### PR TITLE
Enable Compose Compiler source info

### DIFF
--- a/gradle/build-logic/convention/src/main/kotlin/app/tivi/gradle/ComposeMultiplatformConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/app/tivi/gradle/ComposeMultiplatformConventionPlugin.kt
@@ -24,6 +24,10 @@ fun Project.configureCompose() {
     // https://medium.com/androiddevelopers/jetpack-compose-strong-skipping-mode-explained-cbdb2aa4b900
     enableStrongSkippingMode.set(true)
 
+    // Needed for Layout Inspector to be able to see all of the nodes in the component tree:
+    //https://issuetracker.google.com/issues/338842143
+    includeSourceInformation.set(true)
+
     if (project.providers.gradleProperty("tivi.enableComposeCompilerReports").isPresent) {
       val composeReports = layout.buildDirectory.map { it.dir("reports").dir("compose") }
       reportsDestination.set(composeReports)


### PR DESCRIPTION
Needed for Layout Inspector to be able to see all of the nodes in the component tree:
https://issuetracker.google.com/issues/338842143