### PR TITLE
Migrate back to AndroidX Paging

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.0-RC2" />
+    <option name="version" value="2.0.0-RC3" />
   </component>
 </project>

--- a/common/ui/compose/build.gradle.kts
+++ b/common/ui/compose/build.gradle.kts
@@ -36,7 +36,8 @@ kotlin {
 
         implementation(libs.uuid)
 
-        implementation(libs.paging.common)
+        api(libs.paging.common)
+        api(projects.thirdparty.androidx.paging.compose)
       }
     }
 

--- a/common/ui/compose/build.gradle.kts
+++ b/common/ui/compose/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
 
         implementation(libs.uuid)
 
-        implementation(libs.paging.compose)
+        implementation(libs.paging.common)
       }
     }
 

--- a/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/EntryGrid.kt
+++ b/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/EntryGrid.kt
@@ -61,6 +61,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.itemKey
 import app.tivi.common.compose.ui.PosterCard
 import app.tivi.common.compose.ui.RefreshButton
 import app.tivi.common.compose.ui.plus

--- a/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/EntryGrid.kt
+++ b/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/EntryGrid.kt
@@ -60,9 +60,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import app.cash.paging.LoadStateLoading
-import app.cash.paging.compose.LazyPagingItems
-import app.cash.paging.compose.itemKey
+import androidx.paging.LoadState
 import app.tivi.common.compose.ui.PosterCard
 import app.tivi.common.compose.ui.RefreshButton
 import app.tivi.common.compose.ui.plus
@@ -106,7 +104,7 @@ fun <E : Entry> EntryGrid(
   }
 
   val refreshing by remember(lazyPagingItems) {
-    derivedStateOf { lazyPagingItems.loadState.refresh == LoadStateLoading }
+    derivedStateOf { lazyPagingItems.loadState.refresh == LoadState.Loading }
   }
 
   HazeScaffold(

--- a/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/LazyPagingExtensions.kt
+++ b/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/LazyPagingExtensions.kt
@@ -7,7 +7,7 @@ package app.tivi.common.compose
 
 import androidx.compose.runtime.Composable
 import androidx.paging.CombinedLoadStates
-import androidx.paging.LoadStateError
+import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.slack.circuit.retained.rememberRetained
@@ -15,15 +15,15 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
 inline fun CombinedLoadStates.appendErrorOrNull(): UiMessage? {
-  return (append as? LoadStateError)?.let { UiMessage(it.error) }
+  return (append as? LoadState.Error)?.let { UiMessage(it.error) }
 }
 
 inline fun CombinedLoadStates.prependErrorOrNull(): UiMessage? {
-  return (prepend as? LoadStateError)?.let { UiMessage(it.error) }
+  return (prepend as? LoadState.Error)?.let { UiMessage(it.error) }
 }
 
 inline fun CombinedLoadStates.refreshErrorOrNull(): UiMessage? {
-  return (refresh as? LoadStateError)?.let { UiMessage(it.error) }
+  return (refresh as? LoadState.Error)?.let { UiMessage(it.error) }
 }
 
 @Composable

--- a/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/LazyPagingExtensions.kt
+++ b/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/LazyPagingExtensions.kt
@@ -6,10 +6,10 @@
 package app.tivi.common.compose
 
 import androidx.compose.runtime.Composable
-import app.cash.paging.CombinedLoadStates
-import app.cash.paging.LoadStateError
-import app.cash.paging.PagingData
-import app.cash.paging.cachedIn
+import androidx.paging.CombinedLoadStates
+import androidx.paging.LoadStateError
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import com.slack.circuit.retained.rememberRetained
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow

--- a/compose-stability.conf
+++ b/compose-stability.conf
@@ -17,7 +17,7 @@ kotlinx.datetime.LocalTime
 kotlinx.datetime.TimeZone
 kotlin.time.Duration
 
-// Consider the KMP version of LazyPagingItems as stable
-app.cash.paging.compose.LazyPagingItems
+// Consider the LazyPagingItems as stable
+androidx.paging.compose.LazyPagingItems
 
 coil3.compose.AsyncImagePainter.State

--- a/data/db-sqldelight/src/commonMain/kotlin/app/tivi/data/daos/SqlDelightLibraryShowsDao.kt
+++ b/data/db-sqldelight/src/commonMain/kotlin/app/tivi/data/daos/SqlDelightLibraryShowsDao.kt
@@ -3,7 +3,7 @@
 
 package app.tivi.data.daos
 
-import app.cash.paging.PagingSource
+import androidx.paging.PagingSource
 import app.cash.sqldelight.paging3.QueryPagingSource
 import app.tivi.data.Database
 import app.tivi.data.compoundmodels.LibraryShow

--- a/data/db-sqldelight/src/commonMain/kotlin/app/tivi/data/daos/SqlDelightPopularShowsDao.kt
+++ b/data/db-sqldelight/src/commonMain/kotlin/app/tivi/data/daos/SqlDelightPopularShowsDao.kt
@@ -3,7 +3,7 @@
 
 package app.tivi.data.daos
 
-import app.cash.paging.PagingSource
+import androidx.paging.PagingSource
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList

--- a/data/db-sqldelight/src/commonMain/kotlin/app/tivi/data/daos/SqlDelightRecommendedShowsDao.kt
+++ b/data/db-sqldelight/src/commonMain/kotlin/app/tivi/data/daos/SqlDelightRecommendedShowsDao.kt
@@ -3,7 +3,7 @@
 
 package app.tivi.data.daos
 
-import app.cash.paging.PagingSource
+import androidx.paging.PagingSource
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList

--- a/data/db-sqldelight/src/commonMain/kotlin/app/tivi/data/daos/SqlDelightTrendingShowsDao.kt
+++ b/data/db-sqldelight/src/commonMain/kotlin/app/tivi/data/daos/SqlDelightTrendingShowsDao.kt
@@ -3,7 +3,7 @@
 
 package app.tivi.data.daos
 
-import app.cash.paging.PagingSource
+import androidx.paging.PagingSource
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList

--- a/data/db-sqldelight/src/commonMain/kotlin/app/tivi/data/daos/SqlDelightWatchedShowsDao.kt
+++ b/data/db-sqldelight/src/commonMain/kotlin/app/tivi/data/daos/SqlDelightWatchedShowsDao.kt
@@ -3,7 +3,7 @@
 
 package app.tivi.data.daos
 
-import app.cash.paging.PagingSource
+import androidx.paging.PagingSource
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList

--- a/data/db/src/commonMain/kotlin/app/tivi/data/daos/LibraryShowsDao.kt
+++ b/data/db/src/commonMain/kotlin/app/tivi/data/daos/LibraryShowsDao.kt
@@ -3,7 +3,7 @@
 
 package app.tivi.data.daos
 
-import app.cash.paging.PagingSource
+import androidx.paging.PagingSource
 import app.tivi.data.compoundmodels.LibraryShow
 import app.tivi.data.models.SortOption
 

--- a/data/db/src/commonMain/kotlin/app/tivi/data/daos/PopularDao.kt
+++ b/data/db/src/commonMain/kotlin/app/tivi/data/daos/PopularDao.kt
@@ -3,7 +3,7 @@
 
 package app.tivi.data.daos
 
-import app.cash.paging.PagingSource
+import androidx.paging.PagingSource
 import app.tivi.data.compoundmodels.PopularEntryWithShow
 import app.tivi.data.models.PopularShowEntry
 import kotlinx.coroutines.flow.Flow

--- a/data/db/src/commonMain/kotlin/app/tivi/data/daos/RecommendedDao.kt
+++ b/data/db/src/commonMain/kotlin/app/tivi/data/daos/RecommendedDao.kt
@@ -3,7 +3,7 @@
 
 package app.tivi.data.daos
 
-import app.cash.paging.PagingSource
+import androidx.paging.PagingSource
 import app.tivi.data.compoundmodels.RecommendedEntryWithShow
 import app.tivi.data.models.RecommendedShowEntry
 import kotlinx.coroutines.flow.Flow

--- a/data/db/src/commonMain/kotlin/app/tivi/data/daos/TrendingDao.kt
+++ b/data/db/src/commonMain/kotlin/app/tivi/data/daos/TrendingDao.kt
@@ -3,7 +3,7 @@
 
 package app.tivi.data.daos
 
-import app.cash.paging.PagingSource
+import androidx.paging.PagingSource
 import app.tivi.data.compoundmodels.TrendingEntryWithShow
 import app.tivi.data.models.TrendingShowEntry
 import kotlinx.coroutines.flow.Flow

--- a/data/db/src/commonMain/kotlin/app/tivi/data/daos/WatchedShowDao.kt
+++ b/data/db/src/commonMain/kotlin/app/tivi/data/daos/WatchedShowDao.kt
@@ -3,7 +3,7 @@
 
 package app.tivi.data.daos
 
-import app.cash.paging.PagingSource
+import androidx.paging.PagingSource
 import app.tivi.data.compoundmodels.UpNextEntry
 import app.tivi.data.compoundmodels.WatchedShowEntryWithShow
 import app.tivi.data.models.SortOption

--- a/domain/src/commonMain/kotlin/app/tivi/domain/Interactor.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/Interactor.kt
@@ -3,8 +3,8 @@
 
 package app.tivi.domain
 
-import app.cash.paging.PagingConfig
-import app.cash.paging.PagingData
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.atomicfu.atomic

--- a/domain/src/commonMain/kotlin/app/tivi/domain/PaginatedEntryRemoteMediator.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/PaginatedEntryRemoteMediator.kt
@@ -3,12 +3,9 @@
 
 package app.tivi.domain
 
-import app.cash.paging.LoadType
-import app.cash.paging.PagingState
-import app.cash.paging.RemoteMediator
-import app.cash.paging.RemoteMediatorMediatorResult
-import app.cash.paging.RemoteMediatorMediatorResultError
-import app.cash.paging.RemoteMediatorMediatorResultSuccess
+import androidx.paging.LoadType
+import androidx.paging.PagingState
+import androidx.paging.RemoteMediator
 import app.tivi.data.compoundmodels.EntryWithShow
 import app.tivi.data.models.PaginatedEntry
 import kotlinx.coroutines.CancellationException
@@ -17,35 +14,31 @@ import kotlinx.coroutines.CancellationException
  * A [RemoteMediator] which works on [PaginatedEntry] entities. [fetch] will be called with the
  * next page to load.
  */
-@Suppress("CAST_NEVER_SUCCEEDS", "USELESS_CAST", "KotlinRedundantDiagnosticSuppress")
-@OptIn(app.cash.paging.ExperimentalPagingApi::class)
+@OptIn(androidx.paging.ExperimentalPagingApi::class)
 internal class PaginatedEntryRemoteMediator<LI, ET>(
   private val fetch: suspend (page: Int) -> Unit,
 ) : RemoteMediator<Int, LI>() where ET : PaginatedEntry, LI : EntryWithShow<ET> {
   override suspend fun load(
     loadType: LoadType,
     state: PagingState<Int, LI>,
-  ): RemoteMediatorMediatorResult {
+  ): MediatorResult {
     val nextPage = when (loadType) {
       LoadType.REFRESH -> 0
-      LoadType.PREPEND -> return RemoteMediatorMediatorResultSuccess(endOfPaginationReached = true)
-        as RemoteMediatorMediatorResult
+      LoadType.PREPEND -> return MediatorResult.Success(endOfPaginationReached = true)
       LoadType.APPEND -> {
         val lastItem = state.lastItemOrNull()
-          ?: return RemoteMediatorMediatorResultSuccess(endOfPaginationReached = true)
-            as RemoteMediatorMediatorResult
+          ?: return MediatorResult.Success(endOfPaginationReached = true)
         lastItem.entry.page + 1
       }
       else -> error("Unknown LoadType: $loadType")
     }
     return try {
       fetch(nextPage)
-      RemoteMediatorMediatorResultSuccess(endOfPaginationReached = false)
-        as RemoteMediatorMediatorResult
+      MediatorResult.Success(endOfPaginationReached = false)
     } catch (ce: CancellationException) {
       throw ce
     } catch (t: Throwable) {
-      RemoteMediatorMediatorResultError(t) as RemoteMediatorMediatorResult
+      MediatorResult.Error(t)
     }
   }
 }

--- a/domain/src/commonMain/kotlin/app/tivi/domain/RefreshOnlyRemoteMediator.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/RefreshOnlyRemoteMediator.kt
@@ -3,12 +3,9 @@
 
 package app.tivi.domain
 
-import app.cash.paging.LoadType
-import app.cash.paging.PagingState
-import app.cash.paging.RemoteMediator
-import app.cash.paging.RemoteMediatorMediatorResult
-import app.cash.paging.RemoteMediatorMediatorResultError
-import app.cash.paging.RemoteMediatorMediatorResultSuccess
+import androidx.paging.LoadType
+import androidx.paging.PagingState
+import androidx.paging.RemoteMediator
 import app.tivi.data.compoundmodels.EntryWithShow
 import app.tivi.data.models.PaginatedEntry
 import kotlinx.coroutines.CancellationException
@@ -17,8 +14,7 @@ import kotlinx.coroutines.CancellationException
  * A [RemoteMediator] which works on [PaginatedEntry] entities, but only calls
  * [fetch] for [LoadType.REFRESH] events.
  */
-@Suppress("CAST_NEVER_SUCCEEDS", "USELESS_CAST", "KotlinRedundantDiagnosticSuppress")
-@OptIn(app.cash.paging.ExperimentalPagingApi::class)
+@OptIn(androidx.paging.ExperimentalPagingApi::class)
 internal class RefreshOnlyRemoteMediator<LI, ET>(
   private val fetch: suspend () -> Unit,
 ) : RemoteMediator<Int, LI>() where ET : PaginatedEntry, LI : EntryWithShow<ET> {
@@ -26,19 +22,17 @@ internal class RefreshOnlyRemoteMediator<LI, ET>(
   override suspend fun load(
     loadType: LoadType,
     state: PagingState<Int, LI>,
-  ): RemoteMediatorMediatorResult {
+  ): MediatorResult {
     if (loadType == LoadType.PREPEND || loadType == LoadType.APPEND) {
-      return RemoteMediatorMediatorResultSuccess(endOfPaginationReached = true)
-        as RemoteMediatorMediatorResult
+      return MediatorResult.Success(endOfPaginationReached = true)
     }
     return try {
       fetch()
-      RemoteMediatorMediatorResultSuccess(endOfPaginationReached = true)
-        as RemoteMediatorMediatorResult
+      MediatorResult.Success(endOfPaginationReached = true)
     } catch (ce: CancellationException) {
       throw ce
     } catch (t: Throwable) {
-      RemoteMediatorMediatorResultError(t) as RemoteMediatorMediatorResult
+      MediatorResult.Error(t)
     }
   }
 }

--- a/domain/src/commonMain/kotlin/app/tivi/domain/observers/ObservePagedLibraryShows.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/observers/ObservePagedLibraryShows.kt
@@ -3,9 +3,9 @@
 
 package app.tivi.domain.observers
 
-import app.cash.paging.Pager
-import app.cash.paging.PagingConfig
-import app.cash.paging.PagingData
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import app.tivi.data.compoundmodels.LibraryShow
 import app.tivi.data.daos.LibraryShowsDao
 import app.tivi.data.models.SortOption
@@ -17,7 +17,7 @@ import me.tatarka.inject.annotations.Inject
 class ObservePagedLibraryShows(
   private val libraryShowsDao: LibraryShowsDao,
 ) : PagingInteractor<ObservePagedLibraryShows.Parameters, LibraryShow>() {
-  @OptIn(app.cash.paging.ExperimentalPagingApi::class)
+  @OptIn(androidx.paging.ExperimentalPagingApi::class)
   override fun createObservable(
     params: Parameters,
   ): Flow<PagingData<LibraryShow>> = Pager(config = params.pagingConfig) {

--- a/domain/src/commonMain/kotlin/app/tivi/domain/observers/ObservePagedPopularShows.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/observers/ObservePagedPopularShows.kt
@@ -3,9 +3,9 @@
 
 package app.tivi.domain.observers
 
-import app.cash.paging.Pager
-import app.cash.paging.PagingConfig
-import app.cash.paging.PagingData
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import app.tivi.data.compoundmodels.PopularEntryWithShow
 import app.tivi.data.daos.PopularDao
 import app.tivi.domain.PaginatedEntryRemoteMediator
@@ -22,7 +22,7 @@ class ObservePagedPopularShows(
   private val updatePopularShows: UpdatePopularShows,
   private val logger: Logger,
 ) : PagingInteractor<ObservePagedPopularShows.Params, PopularEntryWithShow>() {
-  @OptIn(app.cash.paging.ExperimentalPagingApi::class)
+  @OptIn(androidx.paging.ExperimentalPagingApi::class)
   override fun createObservable(
     params: Params,
   ): Flow<PagingData<PopularEntryWithShow>> {

--- a/domain/src/commonMain/kotlin/app/tivi/domain/observers/ObservePagedRecommendedShows.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/observers/ObservePagedRecommendedShows.kt
@@ -3,9 +3,9 @@
 
 package app.tivi.domain.observers
 
-import app.cash.paging.Pager
-import app.cash.paging.PagingConfig
-import app.cash.paging.PagingData
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import app.tivi.data.compoundmodels.RecommendedEntryWithShow
 import app.tivi.data.daos.RecommendedDao
 import app.tivi.domain.PagingInteractor
@@ -22,7 +22,7 @@ class ObservePagedRecommendedShows(
   private val updateRecommendedShows: UpdateRecommendedShows,
   private val logger: Logger,
 ) : PagingInteractor<ObservePagedRecommendedShows.Params, RecommendedEntryWithShow>() {
-  @OptIn(app.cash.paging.ExperimentalPagingApi::class)
+  @OptIn(androidx.paging.ExperimentalPagingApi::class)
   override fun createObservable(
     params: Params,
   ): Flow<PagingData<RecommendedEntryWithShow>> {

--- a/domain/src/commonMain/kotlin/app/tivi/domain/observers/ObservePagedTrendingShows.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/observers/ObservePagedTrendingShows.kt
@@ -3,9 +3,9 @@
 
 package app.tivi.domain.observers
 
-import app.cash.paging.Pager
-import app.cash.paging.PagingConfig
-import app.cash.paging.PagingData
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import app.tivi.data.compoundmodels.TrendingEntryWithShow
 import app.tivi.data.daos.TrendingDao
 import app.tivi.domain.PaginatedEntryRemoteMediator
@@ -22,7 +22,7 @@ class ObservePagedTrendingShows(
   private val updateTrendingShows: UpdateTrendingShows,
   private val logger: Logger,
 ) : PagingInteractor<ObservePagedTrendingShows.Params, TrendingEntryWithShow>() {
-  @OptIn(app.cash.paging.ExperimentalPagingApi::class)
+  @OptIn(androidx.paging.ExperimentalPagingApi::class)
   override fun createObservable(
     params: Params,
   ): Flow<PagingData<TrendingEntryWithShow>> {

--- a/domain/src/commonMain/kotlin/app/tivi/domain/observers/ObservePagedUpNextShows.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/observers/ObservePagedUpNextShows.kt
@@ -3,9 +3,9 @@
 
 package app.tivi.domain.observers
 
-import app.cash.paging.Pager
-import app.cash.paging.PagingConfig
-import app.cash.paging.PagingData
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import app.tivi.data.compoundmodels.UpNextEntry
 import app.tivi.data.daos.WatchedShowDao
 import app.tivi.data.models.SortOption
@@ -18,7 +18,7 @@ class ObservePagedUpNextShows(
   private val watchedShowsDao: WatchedShowDao,
 ) : PagingInteractor<ObservePagedUpNextShows.Parameters, UpNextEntry>() {
 
-  @OptIn(app.cash.paging.ExperimentalPagingApi::class)
+  @OptIn(androidx.paging.ExperimentalPagingApi::class)
   override fun createObservable(
     params: Parameters,
   ): Flow<PagingData<UpNextEntry>> = Pager(config = params.pagingConfig) {

--- a/gradle/build-logic/convention/src/main/kotlin/app/tivi/gradle/Spotless.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/app/tivi/gradle/Spotless.kt
@@ -9,6 +9,9 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 
 fun Project.configureSpotless() {
+  // Skip Spotless for thirdparty code
+  if (path.startsWith(":thirdparty")) return
+
   with(pluginManager) {
     apply("com.diffplug.spotless")
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ okhttp = "4.12.0"
 kermit = "2.0.3" # Pinned back as Store uses Kermit 1.x
 ktlint = "1.0.1"
 ktor = "2.3.11"
-paging-multiplatform = "3.3.0-alpha02-0.5.1"
+paging = "3.3.0"
 spotless = "6.25.0"
 sqldelight = "2.0.2"
 licensee = "1.11.0"
@@ -50,8 +50,7 @@ androidx-collection = "androidx.collection:collection:1.4.0"
 androidx-core = "androidx.core:core-ktx:1.13.1"
 androidx-splashscreen = "androidx.core:core-splashscreen:1.0.1"
 
-paging-common = { module = "app.cash.paging:paging-common", version.ref = "paging-multiplatform" }
-paging-compose = { module = "app.cash.paging:paging-compose-common", version.ref = "paging-multiplatform" }
+paging-common = { module = "androidx.paging:paging-common", version.ref = "paging" }
 
 androidx-profileinstaller = "androidx.profileinstaller:profileinstaller:1.3.1"
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -136,4 +136,5 @@ include(
   ":android-app:benchmark",
   ":android-app:common-test",
   ":desktop-app",
+  ":thirdparty:androidx:paging:compose",
 )

--- a/thirdparty/androidx/paging/compose/build.gradle.kts
+++ b/thirdparty/androidx/paging/compose/build.gradle.kts
@@ -1,0 +1,24 @@
+// Copyright 2024, Christopher Banes and the Tivi project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+
+plugins {
+  id("app.tivi.android.library")
+  id("app.tivi.kotlin.multiplatform")
+  id("app.tivi.compose")
+}
+
+kotlin {
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(libs.paging.common)
+        api(compose.runtime)
+      }
+    }
+  }
+}
+
+android {
+  namespace = "androidx.paging.compose"
+}

--- a/thirdparty/androidx/paging/compose/src/androidMain/kotlin/PagingPlaceholders.android.kt
+++ b/thirdparty/androidx/paging/compose/src/androidMain/kotlin/PagingPlaceholders.android.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.paging.compose
+
+import android.annotation.SuppressLint
+import android.os.Parcel
+import android.os.Parcelable
+
+internal actual fun getPagingPlaceholderKey(index: Int): Any = PagingPlaceholderKey(index)
+
+@SuppressLint("BanParcelableUsage")
+private data class PagingPlaceholderKey(private val index: Int) : Parcelable {
+  override fun writeToParcel(parcel: Parcel, flags: Int) {
+    parcel.writeInt(index)
+  }
+
+  override fun describeContents(): Int {
+    return 0
+  }
+
+  companion object {
+    @Suppress("unused")
+    @JvmField
+    val CREATOR: Parcelable.Creator<PagingPlaceholderKey> =
+      object : Parcelable.Creator<PagingPlaceholderKey> {
+        override fun createFromParcel(parcel: Parcel) =
+          PagingPlaceholderKey(parcel.readInt())
+
+        override fun newArray(size: Int) = arrayOfNulls<PagingPlaceholderKey?>(size)
+      }
+  }
+}

--- a/thirdparty/androidx/paging/compose/src/commonMain/kotlin/LazyFoundationExtensions.kt
+++ b/thirdparty/androidx/paging/compose/src/commonMain/kotlin/LazyFoundationExtensions.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.paging.compose
+
+import androidx.paging.PagingConfig
+
+/**
+ * Returns a factory of stable and unique keys representing the item.
+ *
+ * Keys are generated with the key lambda that is passed in. If null is passed in, keys will
+ * default to a placeholder key. If [PagingConfig.enablePlaceholders] is true,
+ * LazyPagingItems may return null items. Null items will also automatically default to
+ * a placeholder key.
+ *
+ * This factory can be applied to Lazy foundations such as `LazyGridScope.items` or Pagers.
+ * Examples:
+ * @sample androidx.paging.compose.samples.PagingWithHorizontalPager
+ * @sample androidx.paging.compose.samples.PagingWithLazyGrid
+ *
+ * @param [key] a factory of stable and unique keys representing the item. Using the same key
+ * for multiple items in the list is not allowed. Type of the key should be saveable
+ * via Bundle on Android. When you specify the key the scroll position will be maintained
+ * based on the key, which means if you add/remove items before the current visible item the
+ * item with the given key will be kept as the first visible one.
+ */
+public fun <T : Any> LazyPagingItems<T>.itemKey(
+  key: ((item: T) -> Any)? = null
+): (index: Int) -> Any {
+  return { index ->
+    if (key == null) {
+      getPagingPlaceholderKey(index)
+    } else {
+      val item = peek(index)
+      if (item == null) getPagingPlaceholderKey(index) else key(item)
+    }
+  }
+}
+
+/**
+ * Returns a factory for the content type of the item.
+ *
+ * ContentTypes are generated with the contentType lambda that is passed in. If null is passed in,
+ * contentType of all items will default to `null`.
+ * If [PagingConfig.enablePlaceholders] is true, LazyPagingItems may return null items. Null
+ * items will automatically default to placeholder contentType.
+ *
+ * This factory can be applied to Lazy foundations such as `LazyGridScope.items` or Pagers.
+ * Examples:
+ * @sample androidx.paging.compose.samples.PagingWithLazyGrid
+ * @sample androidx.paging.compose.samples.PagingWithLazyList
+ *
+ * @param [contentType] a factory of the content types for the item. The item compositions of
+ * the same type could be reused more efficiently. Note that null is a valid type and items of
+ * such type will be considered compatible.
+ */
+public fun <T : Any> LazyPagingItems<T>.itemContentType(
+  contentType: ((item: T) -> Any?)? = null
+): (index: Int) -> Any? {
+  return { index ->
+    if (contentType == null) {
+      null
+    } else {
+      val item = peek(index)
+      if (item == null) PagingPlaceholderContentType else contentType(item)
+    }
+  }
+}

--- a/thirdparty/androidx/paging/compose/src/commonMain/kotlin/LazyPagingItems.kt
+++ b/thirdparty/androidx/paging/compose/src/commonMain/kotlin/LazyPagingItems.kt
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.paging.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.paging.CombinedLoadStates
+import androidx.paging.ItemSnapshotList
+import androidx.paging.LoadState
+import androidx.paging.LoadStates
+import androidx.paging.PagingData
+import androidx.paging.PagingDataEvent
+import androidx.paging.PagingDataPresenter
+import androidx.paging.PagingSource
+import androidx.paging.RemoteMediator
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.withContext
+
+/**
+ * The class responsible for accessing the data from a [Flow] of [PagingData].
+ * In order to obtain an instance of [LazyPagingItems] use the [collectAsLazyPagingItems] extension
+ * method of [Flow] with [PagingData].
+ * This instance can be used for Lazy foundations such as `LazyListScope.items` to display data
+ * received from the [Flow] of [PagingData].
+ *
+ * Previewing [LazyPagingItems] is supported on a list of mock data. See sample for how to preview
+ * mock data.
+ *
+ * @sample androidx.paging.compose.samples.PagingPreview
+ *
+ * @param T the type of value used by [PagingData].
+ */
+public class LazyPagingItems<T : Any> internal constructor(
+  /**
+   * the [Flow] object which contains a stream of [PagingData] elements.
+   */
+  private val flow: Flow<PagingData<T>>
+) {
+  private val mainDispatcher = Dispatchers.Main
+
+  /**
+   * If the [flow] is a SharedFlow, it is expected to be the flow returned by from
+   * pager.flow.cachedIn(scope) which could contain a cached PagingData. We pass the cached
+   * PagingData to the presenter so that if the PagingData contains cached data, the presenter
+   * can be initialized with the data prior to collection on pager.
+   */
+  private val pagingDataPresenter = object : PagingDataPresenter<T>(
+    mainContext = mainDispatcher,
+    cachedPagingData =
+    if (flow is SharedFlow<PagingData<T>>) flow.replayCache.firstOrNull() else null
+  ) {
+    override suspend fun presentPagingDataEvent(
+      event: PagingDataEvent<T>,
+    ) {
+      updateItemSnapshotList()
+    }
+  }
+
+  /**
+   * Contains the immutable [ItemSnapshotList] of currently presented items, including any
+   * placeholders if they are enabled.
+   * Note that similarly to [peek] accessing the items in a list will not trigger any loads.
+   * Use [get] to achieve such behavior.
+   */
+  var itemSnapshotList by mutableStateOf(
+    pagingDataPresenter.snapshot()
+  )
+    private set
+
+  /**
+   * The number of items which can be accessed.
+   */
+  val itemCount: Int get() = itemSnapshotList.size
+
+  private fun updateItemSnapshotList() {
+    itemSnapshotList = pagingDataPresenter.snapshot()
+  }
+
+  /**
+   * Returns the presented item at the specified position, notifying Paging of the item access to
+   * trigger any loads necessary to fulfill prefetchDistance.
+   *
+   * @see peek
+   */
+  operator fun get(index: Int): T? {
+    pagingDataPresenter[index] // this registers the value load
+    return itemSnapshotList[index]
+  }
+
+  /**
+   * Returns the presented item at the specified position, without notifying Paging of the item
+   * access that would normally trigger page loads.
+   *
+   * @param index Index of the presented item to return, including placeholders.
+   * @return The presented item at position [index], `null` if it is a placeholder
+   */
+  fun peek(index: Int): T? {
+    return itemSnapshotList[index]
+  }
+
+  /**
+   * Retry any failed load requests that would result in a [LoadState.Error] update to this
+   * [LazyPagingItems].
+   *
+   * Unlike [refresh], this does not invalidate [PagingSource], it only retries failed loads
+   * within the same generation of [PagingData].
+   *
+   * [LoadState.Error] can be generated from two types of load requests:
+   *  * [PagingSource.load] returning [PagingSource.LoadResult.Error]
+   *  * [RemoteMediator.load] returning [RemoteMediator.MediatorResult.Error]
+   */
+  fun retry() {
+    pagingDataPresenter.retry()
+  }
+
+  /**
+   * Refresh the data presented by this [LazyPagingItems].
+   *
+   * [refresh] triggers the creation of a new [PagingData] with a new instance of [PagingSource]
+   * to represent an updated snapshot of the backing dataset. If a [RemoteMediator] is set,
+   * calling [refresh] will also trigger a call to [RemoteMediator.load] with [LoadType] [REFRESH]
+   * to allow [RemoteMediator] to check for updates to the dataset backing [PagingSource].
+   *
+   * Note: This API is intended for UI-driven refresh signals, such as swipe-to-refresh.
+   * Invalidation due repository-layer signals, such as DB-updates, should instead use
+   * [PagingSource.invalidate].
+   *
+   * @see PagingSource.invalidate
+   */
+  fun refresh() {
+    pagingDataPresenter.refresh()
+  }
+
+  /**
+   * A [CombinedLoadStates] object which represents the current loading state.
+   */
+  public var loadState: CombinedLoadStates by mutableStateOf(
+    pagingDataPresenter.loadStateFlow.value
+      ?: CombinedLoadStates(
+        refresh = InitialLoadStates.refresh,
+        prepend = InitialLoadStates.prepend,
+        append = InitialLoadStates.append,
+        source = InitialLoadStates
+      )
+  )
+    private set
+
+  internal suspend fun collectLoadState() {
+    pagingDataPresenter.loadStateFlow.filterNotNull().collect {
+      loadState = it
+    }
+  }
+
+  internal suspend fun collectPagingData() {
+    flow.collectLatest {
+      pagingDataPresenter.collectFrom(it)
+    }
+  }
+}
+
+private val IncompleteLoadState = LoadState.NotLoading(false)
+private val InitialLoadStates = LoadStates(
+  LoadState.Loading,
+  IncompleteLoadState,
+  IncompleteLoadState
+)
+
+/**
+ * Collects values from this [Flow] of [PagingData] and represents them inside a [LazyPagingItems]
+ * instance. The [LazyPagingItems] instance can be used for lazy foundations such as
+ * [LazyListScope.items] in order to display the data obtained from a [Flow] of [PagingData].
+ *
+ * @sample androidx.paging.compose.samples.PagingBackendSample
+ *
+ * @param context the [CoroutineContext] to perform the collection of [PagingData]
+ * and [CombinedLoadStates].
+ */
+@Composable
+public fun <T : Any> Flow<PagingData<T>>.collectAsLazyPagingItems(
+  context: CoroutineContext = EmptyCoroutineContext
+): LazyPagingItems<T> {
+
+  val lazyPagingItems = remember(this) { LazyPagingItems(this) }
+
+  LaunchedEffect(lazyPagingItems) {
+    if (context == EmptyCoroutineContext) {
+      lazyPagingItems.collectPagingData()
+    } else {
+      withContext(context) {
+        lazyPagingItems.collectPagingData()
+      }
+    }
+  }
+
+  LaunchedEffect(lazyPagingItems) {
+    if (context == EmptyCoroutineContext) {
+      lazyPagingItems.collectLoadState()
+    } else {
+      withContext(context) {
+        lazyPagingItems.collectLoadState()
+      }
+    }
+  }
+
+  return lazyPagingItems
+}

--- a/thirdparty/androidx/paging/compose/src/commonMain/kotlin/PagingPlaceholders.kt
+++ b/thirdparty/androidx/paging/compose/src/commonMain/kotlin/PagingPlaceholders.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.paging.compose
+
+internal expect fun getPagingPlaceholderKey(index: Int): Any
+
+internal object PagingPlaceholderContentType

--- a/thirdparty/androidx/paging/compose/src/iosMain/kotlin/PagingPlaceholders.ios.kt
+++ b/thirdparty/androidx/paging/compose/src/iosMain/kotlin/PagingPlaceholders.ios.kt
@@ -1,0 +1,6 @@
+// Copyright 2024, Christopher Banes and the Tivi project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package androidx.paging.compose
+
+internal actual fun getPagingPlaceholderKey(index: Int): Any = index

--- a/thirdparty/androidx/paging/compose/src/jvmMain/kotlin/PagingPlaceholders.jvm.kt
+++ b/thirdparty/androidx/paging/compose/src/jvmMain/kotlin/PagingPlaceholders.jvm.kt
@@ -1,0 +1,6 @@
+// Copyright 2024, Christopher Banes and the Tivi project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package androidx.paging.compose
+
+internal actual fun getPagingPlaceholderKey(index: Int): Any = index

--- a/ui/library/build.gradle.kts
+++ b/ui/library/build.gradle.kts
@@ -25,7 +25,7 @@ kotlin {
         api(libs.circuit.foundation)
         implementation(libs.circuit.retained)
 
-        implementation(libs.paging.compose)
+        implementation(libs.paging.common)
 
         implementation(compose.foundation)
         implementation(compose.material)

--- a/ui/library/src/commonMain/kotlin/app/tivi/home/library/Library.kt
+++ b/ui/library/src/commonMain/kotlin/app/tivi/home/library/Library.kt
@@ -59,9 +59,9 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import app.cash.paging.LoadStateLoading
-import app.cash.paging.compose.LazyPagingItems
-import app.cash.paging.compose.itemKey
+import androidx.paging.LoadStateLoading
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.itemKey
 import app.tivi.common.compose.HazeScaffold
 import app.tivi.common.compose.Layout
 import app.tivi.common.compose.LocalStrings

--- a/ui/library/src/commonMain/kotlin/app/tivi/home/library/Library.kt
+++ b/ui/library/src/commonMain/kotlin/app/tivi/home/library/Library.kt
@@ -59,7 +59,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import androidx.paging.LoadStateLoading
+import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.itemKey
 import app.tivi.common.compose.HazeScaffold
@@ -340,9 +340,7 @@ private fun LibraryGrid(
     }
 
     fullSpanItem {
-      if (lazyPagingItems.itemCount == 0 &&
-        lazyPagingItems.loadState.refresh != LoadStateLoading
-      ) {
+      if (lazyPagingItems.itemCount == 0 && lazyPagingItems.loadState.refresh != LoadState.Loading) {
         EmptyContent(
           title = { Text(text = LocalStrings.current.libraryEmptyTitle) },
           prompt = { Text(text = LocalStrings.current.libraryEmptyPrompt) },

--- a/ui/library/src/commonMain/kotlin/app/tivi/home/library/LibraryPresenter.kt
+++ b/ui/library/src/commonMain/kotlin/app/tivi/home/library/LibraryPresenter.kt
@@ -10,8 +10,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import app.cash.paging.PagingConfig
-import app.cash.paging.compose.collectAsLazyPagingItems
+import androidx.paging.PagingConfig
+import androidx.paging.compose.collectAsLazyPagingItems
 import app.tivi.common.compose.UiMessage
 import app.tivi.common.compose.UiMessageManager
 import app.tivi.common.compose.rememberCoroutineScope

--- a/ui/library/src/commonMain/kotlin/app/tivi/home/library/LibraryUiState.kt
+++ b/ui/library/src/commonMain/kotlin/app/tivi/home/library/LibraryUiState.kt
@@ -4,7 +4,7 @@
 package app.tivi.home.library
 
 import androidx.compose.runtime.Stable
-import app.cash.paging.compose.LazyPagingItems
+import androidx.paging.compose.LazyPagingItems
 import app.tivi.common.compose.UiMessage
 import app.tivi.data.compoundmodels.LibraryShow
 import app.tivi.data.models.SortOption

--- a/ui/popular/build.gradle.kts
+++ b/ui/popular/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
         api(libs.circuit.foundation)
         implementation(libs.circuit.retained)
 
-        implementation(libs.paging.common)
+        implementation(projects.thirdparty.androidx.paging.compose)
 
         implementation(compose.foundation)
         implementation(compose.material)

--- a/ui/popular/build.gradle.kts
+++ b/ui/popular/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
         api(libs.circuit.foundation)
         implementation(libs.circuit.retained)
 
-        implementation(libs.paging.compose)
+        implementation(libs.paging.common)
 
         implementation(compose.foundation)
         implementation(compose.material)

--- a/ui/popular/src/commonMain/kotlin/app/tivi/home/popular/PopularShowsPresenter.kt
+++ b/ui/popular/src/commonMain/kotlin/app/tivi/home/popular/PopularShowsPresenter.kt
@@ -5,8 +5,8 @@ package app.tivi.home.popular
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import app.cash.paging.PagingConfig
-import app.cash.paging.compose.collectAsLazyPagingItems
+import androidx.paging.PagingConfig
+import androidx.paging.compose.collectAsLazyPagingItems
 import app.tivi.common.compose.rememberRetainedCachedPagingFlow
 import app.tivi.domain.observers.ObservePagedPopularShows
 import app.tivi.screens.PopularShowsScreen

--- a/ui/popular/src/commonMain/kotlin/app/tivi/home/popular/PopularShowsUiState.kt
+++ b/ui/popular/src/commonMain/kotlin/app/tivi/home/popular/PopularShowsUiState.kt
@@ -4,7 +4,7 @@
 package app.tivi.home.popular
 
 import androidx.compose.runtime.Stable
-import app.cash.paging.compose.LazyPagingItems
+import androidx.paging.compose.LazyPagingItems
 import app.tivi.data.compoundmodels.PopularEntryWithShow
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState

--- a/ui/recommended/build.gradle.kts
+++ b/ui/recommended/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
         api(libs.circuit.foundation)
         implementation(libs.circuit.retained)
 
-        implementation(libs.paging.common)
+        implementation(projects.thirdparty.androidx.paging.compose)
 
         implementation(compose.foundation)
         implementation(compose.material)

--- a/ui/recommended/build.gradle.kts
+++ b/ui/recommended/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
         api(libs.circuit.foundation)
         implementation(libs.circuit.retained)
 
-        implementation(libs.paging.compose)
+        implementation(libs.paging.common)
 
         implementation(compose.foundation)
         implementation(compose.material)

--- a/ui/recommended/src/commonMain/kotlin/app/tivi/home/recommended/RecommendedShowsPresenter.kt
+++ b/ui/recommended/src/commonMain/kotlin/app/tivi/home/recommended/RecommendedShowsPresenter.kt
@@ -5,8 +5,8 @@ package app.tivi.home.recommended
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import app.cash.paging.PagingConfig
-import app.cash.paging.compose.collectAsLazyPagingItems
+import androidx.paging.PagingConfig
+import androidx.paging.compose.collectAsLazyPagingItems
 import app.tivi.common.compose.rememberRetainedCachedPagingFlow
 import app.tivi.domain.observers.ObservePagedRecommendedShows
 import app.tivi.screens.RecommendedShowsScreen

--- a/ui/recommended/src/commonMain/kotlin/app/tivi/home/recommended/RecommendedShowsUiState.kt
+++ b/ui/recommended/src/commonMain/kotlin/app/tivi/home/recommended/RecommendedShowsUiState.kt
@@ -4,7 +4,7 @@
 package app.tivi.home.recommended
 
 import androidx.compose.runtime.Stable
-import app.cash.paging.compose.LazyPagingItems
+import androidx.paging.compose.LazyPagingItems
 import app.tivi.data.compoundmodels.RecommendedEntryWithShow
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState

--- a/ui/trending/build.gradle.kts
+++ b/ui/trending/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
         api(libs.circuit.foundation)
         implementation(libs.circuit.retained)
 
-        implementation(libs.paging.common)
+        implementation(projects.thirdparty.androidx.paging.compose)
 
         implementation(compose.foundation)
         implementation(compose.material)

--- a/ui/trending/build.gradle.kts
+++ b/ui/trending/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
         api(libs.circuit.foundation)
         implementation(libs.circuit.retained)
 
-        implementation(libs.paging.compose)
+        implementation(libs.paging.common)
 
         implementation(compose.foundation)
         implementation(compose.material)

--- a/ui/trending/src/commonMain/kotlin/app/tivi/home/trending/TrendingShowsPresenter.kt
+++ b/ui/trending/src/commonMain/kotlin/app/tivi/home/trending/TrendingShowsPresenter.kt
@@ -5,8 +5,8 @@ package app.tivi.home.trending
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import app.cash.paging.PagingConfig
-import app.cash.paging.compose.collectAsLazyPagingItems
+import androidx.paging.PagingConfig
+import androidx.paging.compose.collectAsLazyPagingItems
 import app.tivi.common.compose.rememberRetainedCachedPagingFlow
 import app.tivi.domain.observers.ObservePagedTrendingShows
 import app.tivi.screens.ShowDetailsScreen

--- a/ui/trending/src/commonMain/kotlin/app/tivi/home/trending/TrendingShowsUiState.kt
+++ b/ui/trending/src/commonMain/kotlin/app/tivi/home/trending/TrendingShowsUiState.kt
@@ -4,7 +4,7 @@
 package app.tivi.home.trending
 
 import androidx.compose.runtime.Stable
-import app.cash.paging.compose.LazyPagingItems
+import androidx.paging.compose.LazyPagingItems
 import app.tivi.data.compoundmodels.TrendingEntryWithShow
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState

--- a/ui/upnext/build.gradle.kts
+++ b/ui/upnext/build.gradle.kts
@@ -25,7 +25,7 @@ kotlin {
         api(libs.circuit.foundation)
         implementation(libs.circuit.retained)
 
-        implementation(libs.paging.common)
+        implementation(projects.thirdparty.androidx.paging.compose)
 
         implementation(libs.swipe)
 

--- a/ui/upnext/build.gradle.kts
+++ b/ui/upnext/build.gradle.kts
@@ -25,7 +25,7 @@ kotlin {
         api(libs.circuit.foundation)
         implementation(libs.circuit.retained)
 
-        implementation(libs.paging.compose)
+        implementation(libs.paging.common)
 
         implementation(libs.swipe)
 

--- a/ui/upnext/src/commonMain/kotlin/app/tivi/home/upnext/UpNext.kt
+++ b/ui/upnext/src/commonMain/kotlin/app/tivi/home/upnext/UpNext.kt
@@ -56,7 +56,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.paging.LoadStateLoading
+import androidx.paging.LoadState
 import androidx.paging.compose.itemKey
 import app.tivi.common.compose.HazeScaffold
 import app.tivi.common.compose.Layout
@@ -250,9 +250,7 @@ internal fun UpNext(
           )
         }
 
-        if (state.items.itemCount == 0 &&
-          state.items.loadState.refresh != LoadStateLoading
-        ) {
+        if (state.items.itemCount == 0 && state.items.loadState.refresh != LoadState.Loading) {
           fullSpanItem {
             EmptyContent(
               title = { Text(text = LocalStrings.current.upnextEmptyTitle) },

--- a/ui/upnext/src/commonMain/kotlin/app/tivi/home/upnext/UpNext.kt
+++ b/ui/upnext/src/commonMain/kotlin/app/tivi/home/upnext/UpNext.kt
@@ -56,8 +56,8 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
-import app.cash.paging.LoadStateLoading
-import app.cash.paging.compose.itemKey
+import androidx.paging.LoadStateLoading
+import androidx.paging.compose.itemKey
 import app.tivi.common.compose.HazeScaffold
 import app.tivi.common.compose.Layout
 import app.tivi.common.compose.LocalStrings

--- a/ui/upnext/src/commonMain/kotlin/app/tivi/home/upnext/UpNextPresenter.kt
+++ b/ui/upnext/src/commonMain/kotlin/app/tivi/home/upnext/UpNextPresenter.kt
@@ -10,8 +10,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import app.cash.paging.PagingConfig
-import app.cash.paging.compose.collectAsLazyPagingItems
+import androidx.paging.PagingConfig
+import androidx.paging.compose.collectAsLazyPagingItems
 import app.tivi.common.compose.UiMessage
 import app.tivi.common.compose.UiMessageManager
 import app.tivi.common.compose.rememberCoroutineScope

--- a/ui/upnext/src/commonMain/kotlin/app/tivi/home/upnext/UpNextUiState.kt
+++ b/ui/upnext/src/commonMain/kotlin/app/tivi/home/upnext/UpNextUiState.kt
@@ -4,7 +4,7 @@
 package app.tivi.home.upnext
 
 import androidx.compose.runtime.Stable
-import app.cash.paging.compose.LazyPagingItems
+import androidx.paging.compose.LazyPagingItems
 import app.tivi.common.compose.UiMessage
 import app.tivi.data.compoundmodels.UpNextEntry
 import app.tivi.data.models.SortOption


### PR DESCRIPTION
Now that [AndroidX Paging 3.3](https://developer.android.com/jetpack/androidx/releases/paging#version_33_2) is (mostly) built and shipped using Kotlin Multiplatform, we can move off Cash App's fork and back to AndroidX.

Unfortunately there's isn't a Compose Multiplatform version of `paging-compose` yet, so this PR includes a copy of that library, stored in `thirdparty`.