### PR TITLE
Fix 'installQaRelease' not found in project

### DIFF
--- a/gradle/build-logic/convention/src/main/kotlin/app/tivi/gradle/AndroidApplicationLauncher.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/app/tivi/gradle/AndroidApplicationLauncher.kt
@@ -12,8 +12,13 @@ fun Project.configureLauncherTasks() {
   androidComponents {
     onVariants { variant ->
       tasks.register("open${variant.name.capitalized()}") {
-        dependsOn(tasks.named("install${variant.name.capitalized()}"))
-
+        val installTask = tasks.findByName("install${variant.name.capitalized()}")
+        // Only enable the open task if the corresponding install task exists
+        if (installTask == null) {
+          enabled = false
+        } else {
+          dependsOn(installTask)
+        }
         doLast {
           exec {
             commandLine = "adb shell monkey -p ${variant.applicationId.get()} -c android.intent.category.LAUNCHER 1".split(" ")


### PR DESCRIPTION
This could happen if running various gradle tasks like `tasks` or `check` when no release signing config are setup. Which would occur if checking out the source code on a new machine. 

That said I could not see where those `open...` tasks are called and if I try to call one of them manually I get a a build error due to those open tasks not compatible with configuration cache. 