### PR TITLE
Removing Hilt mention from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Tivi is an app that attempts to use the latest libraries and tools. As a summary
  * UI completely written in [Jetpack Compose](https://developer.android.com/jetpack/compose) (see below).
  * Uses [Kotlin Coroutines](https://kotlinlang.org/docs/reference/coroutines/coroutines-guide.html) throughout.
  * Uses many of the [Architecture Components](https://developer.android.com/topic/libraries/architecture/), including: Room, Lifecycle, Navigation.
- * Uses [Hilt](https://dagger.dev/hilt/) for dependency injection
 
 ## Development setup
 


### PR DESCRIPTION
I'd love to see Dagger/Hilt KMP, but since this project no-longer uses them, it should probably be removed from the README.