### PR TITLE
Fix presenter actions sometimes not doing anything

### DIFF
--- a/android-app/app/src/main/kotlin/app/tivi/home/MainActivity.kt
+++ b/android-app/app/src/main/kotlin/app/tivi/home/MainActivity.kt
@@ -31,10 +31,10 @@ import app.tivi.inject.create
 import app.tivi.navigation.DeepLinker
 import app.tivi.screens.DiscoverScreen
 import app.tivi.settings.TiviPreferences
+import app.tivi.util.launchOrThrow
 import com.eygraber.uri.toUri
 import com.slack.circuit.backstack.rememberSaveableBackStack
 import com.slack.circuit.foundation.rememberCircuitNavigator
-import kotlinx.coroutines.launch
 
 class MainActivity : TiviActivity() {
 
@@ -51,7 +51,7 @@ class MainActivity : TiviActivity() {
 
     deepLinker = applicationComponent.deepLinker
 
-    lifecycle.coroutineScope.launch {
+    lifecycle.coroutineScope.launchOrThrow {
       repeatOnLifecycle(Lifecycle.State.STARTED) {
         applicationComponent.preferences.theme.flow
           .collect(::enableEdgeToEdgeForTheme)

--- a/api/tmdb/src/commonMain/kotlin/app/tivi/tmdb/TmdbInitializer.kt
+++ b/api/tmdb/src/commonMain/kotlin/app/tivi/tmdb/TmdbInitializer.kt
@@ -5,7 +5,7 @@ package app.tivi.tmdb
 
 import app.tivi.appinitializers.AppInitializer
 import app.tivi.inject.ApplicationCoroutineScope
-import kotlinx.coroutines.launch
+import app.tivi.util.launchOrThrow
 import me.tatarka.inject.annotations.Inject
 
 @Inject
@@ -14,7 +14,7 @@ class TmdbInitializer(
   private val scope: ApplicationCoroutineScope,
 ) : AppInitializer {
   override fun initialize() {
-    scope.launch {
+    scope.launchOrThrow {
       tmdbManager.value.refreshConfiguration()
     }
   }

--- a/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/ImageLoaderCleanupInitializer.kt
+++ b/common/imageloading/src/commonMain/kotlin/app/tivi/common/imageloading/ImageLoaderCleanupInitializer.kt
@@ -7,7 +7,7 @@ import app.tivi.app.ApplicationInfo
 import app.tivi.appinitializers.AppInitializer
 import app.tivi.inject.ApplicationCoroutineScope
 import app.tivi.util.AppCoroutineDispatchers
-import kotlinx.coroutines.launch
+import app.tivi.util.launchOrThrow
 import me.tatarka.inject.annotations.Inject
 import okio.FileSystem
 import okio.Path.Companion.toPath
@@ -21,7 +21,7 @@ class ImageLoaderCleanupInitializer(
 ) : AppInitializer {
 
   override fun initialize() {
-    scope.launch(dispatchers.io) {
+    scope.launchOrThrow(dispatchers.io) {
       // We delete ImageLoader's disk cache folder to claim back space for the user
       val cachePath = applicationInfo.cachePath().toPath()
       val fs = fileSystem.value

--- a/common/ui/circuit/src/commonMain/kotlin/app/tivi/overlays/BottomSheetOverlay.kt
+++ b/common/ui/circuit/src/commonMain/kotlin/app/tivi/overlays/BottomSheetOverlay.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.unit.Dp
+import app.tivi.util.launchOrThrow
 import com.slack.circuit.foundation.CircuitContent
 import com.slack.circuit.foundation.NavEvent
 import com.slack.circuit.foundation.internal.BackHandler
@@ -24,7 +25,6 @@ import com.slack.circuit.overlay.OverlayHost
 import com.slack.circuit.overlay.OverlayNavigator
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.screen.Screen
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 class BottomSheetOverlay<Model : Any, Result : Any>(
@@ -43,7 +43,7 @@ class BottomSheetOverlay<Model : Any, Result : Any>(
     val coroutineScope = rememberCoroutineScope()
     BackHandler(enabled = sheetState.isVisible) {
       coroutineScope
-        .launch { sheetState.hide() }
+        .launchOrThrow { sheetState.hide() }
         .invokeOnCompletion {
           if (!sheetState.isVisible) {
             navigator.finish(onDismiss())
@@ -57,7 +57,7 @@ class BottomSheetOverlay<Model : Any, Result : Any>(
         // Delay setting the result until we've finished dismissing
         content(model) { result ->
           // This is the OverlayNavigator.finish() callback
-          coroutineScope.launch {
+          coroutineScope.launchOrThrow {
             try {
               sheetState.hide()
             } finally {

--- a/common/ui/circuit/src/commonMain/kotlin/app/tivi/overlays/DialogOverlay.kt
+++ b/common/ui/circuit/src/commonMain/kotlin/app/tivi/overlays/DialogOverlay.kt
@@ -8,13 +8,13 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.window.Dialog
+import app.tivi.util.launchOrThrow
 import com.slack.circuit.foundation.CircuitContent
 import com.slack.circuit.foundation.NavEvent
 import com.slack.circuit.overlay.Overlay
 import com.slack.circuit.overlay.OverlayHost
 import com.slack.circuit.overlay.OverlayNavigator
 import com.slack.circuit.runtime.screen.Screen
-import kotlinx.coroutines.launch
 
 class DialogOverlay<Model : Any, Result : Any>(
   private val model: Model,
@@ -35,7 +35,7 @@ class DialogOverlay<Model : Any, Result : Any>(
         // Delay setting the result until we've finished dismissing
         content(model) { result ->
           // This is the OverlayNavigator.finish() callback
-          coroutineScope.launch {
+          coroutineScope.launchOrThrow {
             navigator.finish(result)
           }
         }

--- a/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/EntryGrid.kt
+++ b/common/ui/compose/src/commonMain/kotlin/app/tivi/common/compose/EntryGrid.kt
@@ -75,8 +75,8 @@ import app.tivi.data.models.Entry
 import app.tivi.data.models.TiviShow
 import app.tivi.data.models.TrendingShowEntry
 import app.tivi.util.fmt
+import app.tivi.util.launchOrThrow
 import kotlin.math.roundToInt
-import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 
 @OptIn(
@@ -126,7 +126,7 @@ fun <E : Entry> EntryGrid(
         onRefreshActionClick = lazyPagingItems::refresh,
         modifier = Modifier
           .noIndicationClickable {
-            coroutineScope.launch {
+            coroutineScope.launchOrThrow {
               lazyGridState.animateScrollToItem(0)
             }
           }

--- a/core/analytics/src/commonMain/kotlin/app/tivi/core/analytics/AnalyticsInitializer.kt
+++ b/core/analytics/src/commonMain/kotlin/app/tivi/core/analytics/AnalyticsInitializer.kt
@@ -6,7 +6,7 @@ package app.tivi.core.analytics
 import app.tivi.appinitializers.AppInitializer
 import app.tivi.inject.ApplicationCoroutineScope
 import app.tivi.settings.TiviPreferences
-import kotlinx.coroutines.launch
+import app.tivi.util.launchOrThrow
 import me.tatarka.inject.annotations.Inject
 
 @Inject
@@ -16,7 +16,7 @@ class AnalyticsInitializer(
   private val scope: ApplicationCoroutineScope,
 ) : AppInitializer {
   override fun initialize() {
-    scope.launch {
+    scope.launchOrThrow {
       preferences.value.reportAnalytics.flow
         .collect { enabled -> analytics.value.setEnabled(enabled) }
     }

--- a/core/base/src/commonMain/kotlin/app/tivi/util/CoroutineContext.kt
+++ b/core/base/src/commonMain/kotlin/app/tivi/util/CoroutineContext.kt
@@ -1,0 +1,21 @@
+// Copyright 2024, Christopher Banes and the Tivi project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package app.tivi.util
+
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+fun CoroutineScope.launchOrThrow(
+  context: CoroutineContext = EmptyCoroutineContext,
+  start: CoroutineStart = CoroutineStart.DEFAULT,
+  block: suspend CoroutineScope.() -> Unit,
+): Job = launch(context, start, block).also {
+  check(!it.isCancelled) {
+    "launch failed. Job is already cancelled"
+  }
+}

--- a/core/logging/src/commonMain/kotlin/app/tivi/util/CrashReportingInitializer.kt
+++ b/core/logging/src/commonMain/kotlin/app/tivi/util/CrashReportingInitializer.kt
@@ -6,7 +6,6 @@ package app.tivi.util
 import app.tivi.appinitializers.AppInitializer
 import app.tivi.inject.ApplicationCoroutineScope
 import app.tivi.settings.TiviPreferences
-import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Inject
 
 @Inject
@@ -16,7 +15,7 @@ class CrashReportingInitializer(
   private val scope: ApplicationCoroutineScope,
 ) : AppInitializer {
   override fun initialize() {
-    scope.launch {
+    scope.launchOrThrow {
       preferences.value.reportAppCrashes.flow
         .collect { action.value(it) }
     }

--- a/core/notifications/core/src/androidMain/kotlin/app/tivi/core/notifications/PostNotificationBroadcastReceiver.kt
+++ b/core/notifications/core/src/androidMain/kotlin/app/tivi/core/notifications/PostNotificationBroadcastReceiver.kt
@@ -12,9 +12,9 @@ import android.net.Uri
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import app.tivi.util.launchOrThrow
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 
 class PostNotificationBroadcastReceiver : BroadcastReceiver() {
 
@@ -33,11 +33,11 @@ class PostNotificationBroadcastReceiver : BroadcastReceiver() {
     val store = context.pendingNotificationsStore
     val result = goAsync()
 
-    GlobalScope.launch {
+    GlobalScope.launchOrThrow {
       val pending = store.findWithId(id) ?: run {
         Log.d(TAG, "Pending Notification with ID: $id not found. Exiting.")
         result.finish()
-        return@launch
+        return@launchOrThrow
       }
 
       Log.d(TAG, "Found pending notification with ID: $id: $pending")

--- a/data/traktauth/src/commonMain/kotlin/app/tivi/data/traktauth/TraktAuthRepository.kt
+++ b/data/traktauth/src/commonMain/kotlin/app/tivi/data/traktauth/TraktAuthRepository.kt
@@ -7,13 +7,13 @@ import app.tivi.data.traktauth.store.AuthStore
 import app.tivi.inject.ApplicationCoroutineScope
 import app.tivi.inject.ApplicationScope
 import app.tivi.util.AppCoroutineDispatchers
+import app.tivi.util.launchOrThrow
 import co.touchlab.kermit.Logger
 import kotlin.time.Duration.Companion.hours
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -47,7 +47,7 @@ class TraktAuthRepository(
 
   init {
     // Read the auth state from the AuthStore
-    scope.launch {
+    scope.launchOrThrow {
       val state = getAuthState() ?: AuthState.Empty
       updateAuthState(authState = state, persist = false)
     }

--- a/domain/src/commonMain/kotlin/app/tivi/domain/interactors/ChangeSeasonWatchedStatus.kt
+++ b/domain/src/commonMain/kotlin/app/tivi/domain/interactors/ChangeSeasonWatchedStatus.kt
@@ -20,16 +20,16 @@ class ChangeSeasonWatchedStatus(
   override suspend fun doWork(params: Params) {
     withContext(dispatchers.io) {
       when (params.action) {
-        Action.WATCHED -> {
+        Action.WATCH -> {
           seasonsEpisodesRepository.markSeasonWatched(
-            params.seasonId,
-            params.onlyAired,
-            params.actionDate,
+            seasonId = params.seasonId,
+            onlyAired = params.onlyAired,
+            date = params.actionDate,
           )
         }
 
         Action.UNWATCH -> {
-          seasonsEpisodesRepository.markSeasonUnwatched(params.seasonId)
+          seasonsEpisodesRepository.markSeasonUnwatched(seasonId = params.seasonId)
         }
       }
     }
@@ -42,5 +42,5 @@ class ChangeSeasonWatchedStatus(
     val actionDate: ActionDate = ActionDate.NOW,
   )
 
-  enum class Action { WATCHED, UNWATCH }
+  enum class Action { WATCH, UNWATCH }
 }

--- a/tasks/src/commonMain/kotlin/app/tivi/tasks/TasksInitializer.kt
+++ b/tasks/src/commonMain/kotlin/app/tivi/tasks/TasksInitializer.kt
@@ -7,7 +7,7 @@ import app.tivi.appinitializers.AppInitializer
 import app.tivi.entitlements.EntitlementManager
 import app.tivi.inject.ApplicationCoroutineScope
 import app.tivi.settings.TiviPreferences
-import kotlinx.coroutines.launch
+import app.tivi.util.launchOrThrow
 import me.tatarka.inject.annotations.Inject
 
 @Inject
@@ -26,7 +26,7 @@ class TasksInitializer(
 
     tasks.scheduleLibrarySync()
 
-    coroutineScope.launch {
+    coroutineScope.launchOrThrow {
       preferences.episodeAiringNotificationsEnabled.flow
         .collect { enabled ->
           val isPro = entitlementManager.hasProEntitlement()

--- a/tasks/src/iosMain/kotlin/app/tivi/tasks/IosTasks.kt
+++ b/tasks/src/iosMain/kotlin/app/tivi/tasks/IosTasks.kt
@@ -6,10 +6,10 @@ package app.tivi.tasks
 import app.tivi.domain.interactors.ScheduleEpisodeNotifications
 import app.tivi.domain.interactors.UpdateLibraryShows
 import app.tivi.inject.ApplicationCoroutineScope
+import app.tivi.util.launchOrThrow
 import co.touchlab.kermit.Logger
 import kotlin.time.Duration.Companion.hours
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
 import kotlinx.datetime.toNSDate
@@ -60,7 +60,7 @@ class IosTasks(
 
     // iOS has no concept of running tasks while the app is open, so we'll just run them
     // manually now
-    scope.launch { runScheduleEpisodeNotifications() }
+    scope.launchOrThrow { runScheduleEpisodeNotifications() }
   }
 
   override fun cancelEpisodeNotifications() {
@@ -143,7 +143,7 @@ class IosTasks(
   private fun BGTask.runInteractor(block: suspend () -> Unit) {
     logger.d { "Starting to run task [$identifier]" }
 
-    val job = scope.launch { block() }
+    val job = scope.launchOrThrow { block() }
 
     expirationHandler = {
       logger.d { "Expiration handler called for task [$identifier]" }

--- a/ui/account/src/commonMain/kotlin/app/tivi/account/AccountPresenter.kt
+++ b/ui/account/src/commonMain/kotlin/app/tivi/account/AccountPresenter.kt
@@ -15,12 +15,12 @@ import app.tivi.domain.observers.ObserveTraktAuthState
 import app.tivi.domain.observers.ObserveUserDetails
 import app.tivi.screens.AccountScreen
 import app.tivi.screens.SettingsScreen
+import app.tivi.util.launchOrThrow
 import com.slack.circuit.retained.collectAsRetainedState
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
-import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 
@@ -66,8 +66,8 @@ class AccountPresenter(
           navigator.pop() // dismiss ourselves
           navigator.goTo(SettingsScreen)
         }
-        AccountUiEvent.Login -> scope.launch { loginTrakt.value.invoke() }
-        AccountUiEvent.Logout -> scope.launch { logoutTrakt.value.invoke() }
+        AccountUiEvent.Login -> scope.launchOrThrow { loginTrakt.value.invoke() }
+        AccountUiEvent.Logout -> scope.launchOrThrow { logoutTrakt.value.invoke() }
       }
     }
   }

--- a/ui/anticipated/src/commonMain/kotlin/app/tivi/home/anticipated/AnticipatedShowsPresenter.kt
+++ b/ui/anticipated/src/commonMain/kotlin/app/tivi/home/anticipated/AnticipatedShowsPresenter.kt
@@ -54,7 +54,7 @@ class AnticipatedShowsPresenter(
       retainedPagingInteractor(ObservePagedAnticipatedShows.Params(PAGING_CONFIG))
     }
 
-    fun eventSink(event: AnticipatedShowsUiEvent) {
+    val eventSink: (AnticipatedShowsUiEvent) -> Unit = { event ->
       when (event) {
         AnticipatedShowsUiEvent.NavigateUp -> navigator.pop()
         is AnticipatedShowsUiEvent.OpenShowDetails -> {
@@ -65,7 +65,7 @@ class AnticipatedShowsPresenter(
 
     return AnticipatedShowsUiState(
       items = items,
-      eventSink = ::eventSink,
+      eventSink = eventSink,
     )
   }
 

--- a/ui/developer/log/src/commonMain/kotlin/app/tivi/developer/log/DevLogPresenter.kt
+++ b/ui/developer/log/src/commonMain/kotlin/app/tivi/developer/log/DevLogPresenter.kt
@@ -42,7 +42,7 @@ class DevLogPresenter(
       RecordingLoggerWriter.buffer.map { it.asReversed() }
     }.collectAsState(emptyList())
 
-    fun eventSink(event: DevLogUiEvent) {
+    val eventSink: (DevLogUiEvent) -> Unit = { event ->
       when (event) {
         DevLogUiEvent.NavigateUp -> navigator.pop()
       }
@@ -50,7 +50,7 @@ class DevLogPresenter(
 
     return DevLogUiState(
       logs = logs,
-      eventSink = ::eventSink,
+      eventSink = eventSink,
     )
   }
 }

--- a/ui/developer/notifications/src/commonMain/kotlin/app/tivi/developer/notifications/DevNotificationsPresenter.kt
+++ b/ui/developer/notifications/src/commonMain/kotlin/app/tivi/developer/notifications/DevNotificationsPresenter.kt
@@ -15,6 +15,7 @@ import app.tivi.data.models.Notification
 import app.tivi.data.models.NotificationChannel
 import app.tivi.domain.interactors.ScheduleDebugEpisodeNotification
 import app.tivi.screens.DevNotificationsScreen
+import app.tivi.util.launchOrThrow
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
@@ -23,7 +24,6 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
@@ -61,18 +61,18 @@ class DevNotificationsPresenter(
       }
     }
 
-    fun eventSink(event: DevNotificationsUiEvent) {
+    val eventSink: (DevNotificationsUiEvent) -> Unit = { event ->
       when (event) {
         DevNotificationsUiEvent.NavigateUp -> navigator.pop()
         DevNotificationsUiEvent.ShowEpisodeAiringNotification -> {
-          coroutineScope.launch {
+          coroutineScope.launchOrThrow {
             scheduleDebugEpisodeNotification(
               ScheduleDebugEpisodeNotification.Params(3.seconds),
             )
           }
         }
         DevNotificationsUiEvent.ScheduleNotification -> {
-          coroutineScope.launch {
+          coroutineScope.launchOrThrow {
             notificationsManager.schedule(
               Notification(
                 id = "scheduled_test",
@@ -86,7 +86,7 @@ class DevNotificationsPresenter(
         }
 
         DevNotificationsUiEvent.ShowNotification -> {
-          coroutineScope.launch {
+          coroutineScope.launchOrThrow {
             notificationsManager.schedule(
               Notification(
                 id = "immediate_test",
@@ -103,7 +103,7 @@ class DevNotificationsPresenter(
 
     return DevNotificationsUiState(
       pendingNotifications = pending,
-      eventSink = ::eventSink,
+      eventSink = eventSink,
     )
   }
 }

--- a/ui/developer/settings/src/commonMain/kotlin/app/tivi/settings/developer/DevSettingsPresenter.kt
+++ b/ui/developer/settings/src/commonMain/kotlin/app/tivi/settings/developer/DevSettingsPresenter.kt
@@ -12,11 +12,11 @@ import app.tivi.screens.DevNotificationsScreen
 import app.tivi.screens.DevSettingsScreen
 import app.tivi.settings.TiviPreferences
 import app.tivi.settings.toggle
+import app.tivi.util.launchOrThrow
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
-import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 
@@ -46,20 +46,20 @@ class DevSettingsPresenter(
 
     val coroutineScope = rememberCoroutineScope()
 
-    fun eventSink(event: DevSettingsUiEvent) {
+    val eventSink: (DevSettingsUiEvent) -> Unit = { event ->
       when (event) {
         DevSettingsUiEvent.NavigateUp -> navigator.pop()
         DevSettingsUiEvent.NavigateLog -> navigator.goTo(DevLogScreen)
         DevSettingsUiEvent.NavigateNotifications -> navigator.goTo(DevNotificationsScreen)
         DevSettingsUiEvent.ToggleHideArtwork -> {
-          coroutineScope.launch { preferences.value.developerHideArtwork.toggle() }
+          coroutineScope.launchOrThrow { preferences.value.developerHideArtwork.toggle() }
         }
       }
     }
 
     return DevSettingsUiState(
       hideArtwork = hideArtwork,
-      eventSink = ::eventSink,
+      eventSink = eventSink,
     )
   }
 }

--- a/ui/discover/src/commonMain/kotlin/app/tivi/home/discover/Discover.kt
+++ b/ui/discover/src/commonMain/kotlin/app/tivi/home/discover/Discover.kt
@@ -101,6 +101,7 @@ import app.tivi.navigation.LocalNavigator
 import app.tivi.overlays.showInDialog
 import app.tivi.screens.AccountScreen
 import app.tivi.screens.DiscoverScreen
+import app.tivi.util.launchOrThrow
 import coil3.compose.AsyncImagePainter
 import com.materialkolor.PaletteStyle
 import com.slack.circuit.overlay.LocalOverlayHost
@@ -108,7 +109,6 @@ import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.runtime.ui.Ui
 import com.slack.circuit.runtime.ui.ui
-import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Inject
 import org.jetbrains.compose.resources.stringResource
 
@@ -143,7 +143,7 @@ internal fun Discover(
     state = state,
     refresh = { eventSink(DiscoverUiEvent.Refresh(true)) },
     openUser = {
-      scope.launch {
+      scope.launchOrThrow {
         overlayHost.showInDialog(AccountScreen, navigator::goTo)
       }
     },
@@ -217,7 +217,7 @@ internal fun Discover(
         onUserActionClick = openUser,
         modifier = Modifier
           .noIndicationClickable {
-            coroutineScope.launch { lazyListState.animateScrollToItem(0) }
+            coroutineScope.launchOrThrow { lazyListState.animateScrollToItem(0) }
           }
           .fillMaxWidth(),
       )

--- a/ui/discover/src/commonMain/kotlin/app/tivi/home/discover/DiscoverPresenter.kt
+++ b/ui/discover/src/commonMain/kotlin/app/tivi/home/discover/DiscoverPresenter.kt
@@ -31,13 +31,13 @@ import app.tivi.screens.PopularShowsScreen
 import app.tivi.screens.RecommendedShowsScreen
 import app.tivi.screens.ShowDetailsScreen
 import app.tivi.screens.TrendingShowsScreen
+import app.tivi.util.launchOrThrow
 import co.touchlab.kermit.Logger
 import com.slack.circuit.retained.collectAsRetainedState
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
-import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 
@@ -95,16 +95,16 @@ class DiscoverPresenter(
 
     val message by uiMessageManager.message.collectAsState(null)
 
-    fun eventSink(event: DiscoverUiEvent) {
+    val eventSink: (DiscoverUiEvent) -> Unit = { event ->
       when (event) {
         is DiscoverUiEvent.ClearMessage -> {
-          scope.launch {
+          scope.launchOrThrow {
             uiMessageManager.clearMessage(event.id)
           }
         }
 
         is DiscoverUiEvent.Refresh -> {
-          scope.launch {
+          scope.launchOrThrow {
             updatePopularShows.value.invoke(
               UpdatePopularShows.Params(
                 page = UpdatePopularShows.Page.REFRESH,
@@ -115,7 +115,7 @@ class DiscoverPresenter(
               uiMessageManager.emitMessage(UiMessage(e))
             }
           }
-          scope.launch {
+          scope.launchOrThrow {
             updateTrendingShows.value.invoke(
               UpdateTrendingShows.Params(
                 page = UpdateTrendingShows.Page.REFRESH,
@@ -126,7 +126,7 @@ class DiscoverPresenter(
               uiMessageManager.emitMessage(UiMessage(e))
             }
           }
-          scope.launch {
+          scope.launchOrThrow {
             updateAntipicatedShows.value.invoke(
               UpdateAnticipatedShows.Params(
                 page = UpdateAnticipatedShows.Page.REFRESH,
@@ -138,7 +138,7 @@ class DiscoverPresenter(
             }
           }
           if (authState == TraktAuthState.LOGGED_IN) {
-            scope.launch {
+            scope.launchOrThrow {
               updateRecommendedShows.value.invoke(
                 UpdateRecommendedShows.Params(isUserInitiated = event.fromUser),
               ).onFailure { e ->
@@ -190,7 +190,7 @@ class DiscoverPresenter(
       anticipatedRefreshing = anticipatedLoading,
       nextEpisodesToWatch = nextEpisodesToWatch,
       message = message,
-      eventSink = ::eventSink,
+      eventSink = eventSink,
     )
   }
 }

--- a/ui/episode/details/src/commonMain/kotlin/app/tivi/episodedetails/EpisodeDetails.kt
+++ b/ui/episode/details/src/commonMain/kotlin/app/tivi/episodedetails/EpisodeDetails.kt
@@ -101,13 +101,13 @@ import app.tivi.overlays.showInBottomSheet
 import app.tivi.screens.EpisodeDetailsScreen
 import app.tivi.screens.EpisodeTrackScreen
 import app.tivi.util.fmt
+import app.tivi.util.launchOrThrow
 import com.slack.circuit.overlay.ContentWithOverlays
 import com.slack.circuit.overlay.LocalOverlayHost
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.runtime.ui.Ui
 import com.slack.circuit.runtime.ui.ui
-import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import me.tatarka.inject.annotations.Inject
 import org.jetbrains.compose.resources.stringResource
@@ -142,7 +142,7 @@ internal fun EpisodeDetails(
       onRemoveAllWatches = { viewState.eventSink(EpisodeDetailsUiEvent.RemoveAllWatches) },
       onRemoveWatch = { id -> viewState.eventSink(EpisodeDetailsUiEvent.RemoveWatchEntry(id)) },
       onAddWatch = {
-        scope.launch {
+        scope.launchOrThrow {
           overlayHost.showInBottomSheet(EpisodeTrackScreen(viewState.episode!!.id))
         }
       },

--- a/ui/episode/track/src/commonMain/kotlin/app/tivi/episode/track/EpisodeTrackPresenter.kt
+++ b/ui/episode/track/src/commonMain/kotlin/app/tivi/episode/track/EpisodeTrackPresenter.kt
@@ -18,13 +18,13 @@ import app.tivi.domain.interactors.AddEpisodeWatch
 import app.tivi.domain.interactors.UpdateEpisodeDetails
 import app.tivi.domain.observers.ObserveEpisodeDetails
 import app.tivi.screens.EpisodeTrackScreen
+import app.tivi.util.launchOrThrow
 import co.touchlab.kermit.Logger
 import com.slack.circuit.retained.collectAsRetainedState
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
-import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
@@ -76,16 +76,16 @@ class EpisodeTrackPresenter(
       }
     }
 
-    fun eventSink(event: EpisodeTrackUiEvent) {
+    val eventSink: (EpisodeTrackUiEvent) -> Unit = { event ->
       when (event) {
         is EpisodeTrackUiEvent.ClearMessage -> {
-          scope.launch {
+          scope.launchOrThrow {
             uiMessageManager.clearMessage(event.id)
           }
         }
 
         is EpisodeTrackUiEvent.Refresh -> {
-          scope.launch {
+          scope.launchOrThrow {
             updateEpisodeDetails.value.invoke(
               UpdateEpisodeDetails.Params(screen.id, event.fromUser),
             ).onFailure { e ->
@@ -121,7 +121,7 @@ class EpisodeTrackPresenter(
         }
 
         EpisodeTrackUiEvent.Submit -> {
-          scope.launch {
+          scope.launchOrThrow {
             addEpisodeWatch.value.invoke(
               AddEpisodeWatch.Params(
                 episodeId = screen.id,
@@ -156,7 +156,7 @@ class EpisodeTrackPresenter(
       message = message,
       submitInProgress = submitting,
       canSubmit = !submitting,
-      eventSink = ::eventSink,
+      eventSink = eventSink,
     )
   }
 }

--- a/ui/library/src/commonMain/kotlin/app/tivi/home/library/Library.kt
+++ b/ui/library/src/commonMain/kotlin/app/tivi/home/library/Library.kt
@@ -91,12 +91,12 @@ import app.tivi.navigation.LocalNavigator
 import app.tivi.overlays.showInDialog
 import app.tivi.screens.AccountScreen
 import app.tivi.screens.LibraryScreen
+import app.tivi.util.launchOrThrow
 import com.slack.circuit.overlay.LocalOverlayHost
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.runtime.ui.Ui
 import com.slack.circuit.runtime.ui.ui
-import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
 import me.tatarka.inject.annotations.Inject
 import org.jetbrains.compose.resources.stringResource
@@ -133,7 +133,7 @@ internal fun Library(
     onMessageShown = { eventSink(LibraryUiEvent.ClearMessage(it)) },
     onToggleIncludeFollowedShows = { eventSink(LibraryUiEvent.ToggleFollowedShowsIncluded) },
     openUser = {
-      scope.launch {
+      scope.launchOrThrow {
         overlayHost.showInDialog(AccountScreen, navigator::goTo)
       }
     },
@@ -190,7 +190,7 @@ internal fun Library(
         onUserActionClick = openUser,
         modifier = Modifier
           .noIndicationClickable {
-            coroutineScope.launch { lazyGridState.animateScrollToItem(0) }
+            coroutineScope.launchOrThrow { lazyGridState.animateScrollToItem(0) }
           }
           .fillMaxWidth(),
       )

--- a/ui/licenses/src/commonMain/kotlin/app/tivi/settings/licenses/LicensesPresenter.kt
+++ b/ui/licenses/src/commonMain/kotlin/app/tivi/settings/licenses/LicensesPresenter.kt
@@ -56,7 +56,7 @@ class LicensesPresenter(
       }
     }
 
-    fun eventSink(event: LicensesUiEvent) {
+    val eventSink: (LicensesUiEvent) -> Unit = { event ->
       when (event) {
         LicensesUiEvent.NavigateUp -> navigator.pop()
         is LicensesUiEvent.NavigateRepository -> {
@@ -70,7 +70,7 @@ class LicensesPresenter(
 
     return LicensesUiState(
       licenses = licenseItemList,
-      eventSink = ::eventSink,
+      eventSink = eventSink,
     )
   }
 }

--- a/ui/popular/src/commonMain/kotlin/app/tivi/home/popular/PopularShowsPresenter.kt
+++ b/ui/popular/src/commonMain/kotlin/app/tivi/home/popular/PopularShowsPresenter.kt
@@ -54,7 +54,7 @@ class PopularShowsPresenter(
       retainedPagingInteractor(ObservePagedPopularShows.Params(PAGING_CONFIG))
     }
 
-    fun eventSink(event: PopularShowsUiEvent) {
+    val eventSink: (PopularShowsUiEvent) -> Unit = { event ->
       when (event) {
         PopularShowsUiEvent.NavigateUp -> navigator.pop()
         is PopularShowsUiEvent.OpenShowDetails -> {
@@ -65,7 +65,7 @@ class PopularShowsPresenter(
 
     return PopularShowsUiState(
       items = items,
-      eventSink = ::eventSink,
+      eventSink = eventSink,
     )
   }
 

--- a/ui/recommended/src/commonMain/kotlin/app/tivi/home/recommended/RecommendedShowsPresenter.kt
+++ b/ui/recommended/src/commonMain/kotlin/app/tivi/home/recommended/RecommendedShowsPresenter.kt
@@ -54,7 +54,7 @@ class RecommendedShowsPresenter(
       retainedPagingInteractor(ObservePagedRecommendedShows.Params(PAGING_CONFIG))
     }
 
-    fun eventSink(event: RecommendedShowsUiEvent) {
+    val eventSink: (RecommendedShowsUiEvent) -> Unit = { event ->
       when (event) {
         RecommendedShowsUiEvent.NavigateUp -> navigator.pop()
         is RecommendedShowsUiEvent.OpenShowDetails -> {
@@ -65,7 +65,7 @@ class RecommendedShowsPresenter(
 
     return RecommendedShowsUiState(
       items = items,
-      eventSink = ::eventSink,
+      eventSink = eventSink,
     )
   }
 

--- a/ui/root/src/commonMain/kotlin/app/tivi/home/RootViewModel.kt
+++ b/ui/root/src/commonMain/kotlin/app/tivi/home/RootViewModel.kt
@@ -9,6 +9,7 @@ import app.tivi.domain.interactors.UpdateUserDetails
 import app.tivi.domain.invoke
 import app.tivi.domain.observers.ObserveTraktAuthState
 import app.tivi.util.cancellableRunCatching
+import app.tivi.util.launchOrThrow
 import io.ktor.client.plugins.ResponseException
 import io.ktor.http.HttpStatusCode
 import kotlin.time.Duration.Companion.milliseconds
@@ -17,7 +18,6 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 
@@ -31,7 +31,7 @@ class RootViewModel(
 ) {
 
   init {
-    coroutineScope.launch {
+    coroutineScope.launchOrThrow {
       observeTraktAuthState.value.flow
         .debounce(200.milliseconds)
         .filter { it == TraktAuthState.LOGGED_IN }
@@ -41,7 +41,7 @@ class RootViewModel(
   }
 
   private fun refreshMe() {
-    coroutineScope.launch {
+    coroutineScope.launchOrThrow {
       cancellableRunCatching {
         updateUserDetails.value.invoke(UpdateUserDetails.Params("me", false))
       }.onFailure { e ->

--- a/ui/search/src/commonMain/kotlin/app/tivi/home/search/Search.kt
+++ b/ui/search/src/commonMain/kotlin/app/tivi/home/search/Search.kt
@@ -60,11 +60,11 @@ import app.tivi.common.ui.resources.search_hint
 import app.tivi.common.ui.resources.search_noresults_prompt
 import app.tivi.data.models.TiviShow
 import app.tivi.screens.SearchScreen
+import app.tivi.util.launchOrThrow
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.runtime.ui.Ui
 import com.slack.circuit.runtime.ui.ui
-import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Inject
 import org.jetbrains.compose.resources.stringResource
 
@@ -133,7 +133,7 @@ internal fun Search(
       Box(
         Modifier
           .noIndicationClickable {
-            coroutineScope.launch { gridState.animateScrollToItem(0) }
+            coroutineScope.launchOrThrow { gridState.animateScrollToItem(0) }
           }
           .padding(horizontal = Layout.bodyMargin, vertical = 16.dp)
           .windowInsetsPadding(WindowInsets.statusBars),

--- a/ui/search/src/commonMain/kotlin/app/tivi/home/search/SearchPresenter.kt
+++ b/ui/search/src/commonMain/kotlin/app/tivi/home/search/SearchPresenter.kt
@@ -17,6 +17,7 @@ import app.tivi.data.models.TiviShow
 import app.tivi.domain.interactors.SearchShows
 import app.tivi.screens.SearchScreen
 import app.tivi.screens.ShowDetailsScreen
+import app.tivi.util.launchOrThrow
 import co.touchlab.kermit.Logger
 import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.runtime.CircuitContext
@@ -25,7 +26,6 @@ import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 
@@ -74,10 +74,10 @@ class SearchPresenter(
       }
     }
 
-    fun eventSink(event: SearchUiEvent) {
+    val eventSink: (SearchUiEvent) -> Unit = { event ->
       when (event) {
         is SearchUiEvent.ClearMessage -> {
-          scope.launch {
+          scope.launchOrThrow {
             uiMessageManager.clearMessage(event.id)
           }
         }
@@ -94,7 +94,7 @@ class SearchPresenter(
       searchResults = results,
       refreshing = loading,
       message = message,
-      eventSink = ::eventSink,
+      eventSink = eventSink,
     )
   }
 }

--- a/ui/settings/src/commonMain/kotlin/app/tivi/settings/Settings.kt
+++ b/ui/settings/src/commonMain/kotlin/app/tivi/settings/Settings.kt
@@ -68,6 +68,7 @@ import app.tivi.common.ui.resources.settings_ui_category_title
 import app.tivi.common.ui.resources.view_privacy_policy
 import app.tivi.entitlements.ui.Paywall
 import app.tivi.screens.SettingsScreen
+import app.tivi.util.launchOrThrow
 import com.slack.circuit.overlay.ContentWithOverlays
 import com.slack.circuit.overlay.LocalOverlayHost
 import com.slack.circuit.overlay.OverlayHost
@@ -77,7 +78,6 @@ import com.slack.circuit.runtime.ui.Ui
 import com.slack.circuit.runtime.ui.ui
 import com.slack.circuitx.overlays.DialogResult
 import com.slack.circuitx.overlays.alertDialogOverlay
-import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Inject
 import org.jetbrains.compose.resources.stringResource
 
@@ -218,7 +218,7 @@ internal fun Settings(
               Preference(
                 title = stringResource(Res.string.account_delete_account_cta),
                 onClick = {
-                  scope.launch {
+                  scope.launchOrThrow {
                     val result = overlayHost.showDeleteAccountConfirmationDialog()
                     if (result == DialogResult.Confirm) {
                       eventSink(SettingsUiEvent.DeleteAccount)

--- a/ui/settings/src/commonMain/kotlin/app/tivi/settings/SettingsPresenter.kt
+++ b/ui/settings/src/commonMain/kotlin/app/tivi/settings/SettingsPresenter.kt
@@ -26,11 +26,11 @@ import app.tivi.screens.DevSettingsScreen
 import app.tivi.screens.LicensesScreen
 import app.tivi.screens.SettingsScreen
 import app.tivi.screens.UrlScreen
+import app.tivi.util.launchOrThrow
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
-import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 
@@ -85,39 +85,39 @@ class SettingsPresenter(
       observeTraktAuthState(Unit)
     }
 
-    fun eventSink(event: SettingsUiEvent) {
+    val eventSink: (SettingsUiEvent) -> Unit = { event ->
       when (event) {
         SettingsUiEvent.NavigateUp -> {
           navigator.pop()
         }
 
         is SettingsUiEvent.SetTheme -> {
-          coroutineScope.launch { preferences.theme.set(event.theme) }
+          coroutineScope.launchOrThrow { preferences.theme.set(event.theme) }
         }
 
         SettingsUiEvent.ToggleUseDynamicColors -> {
-          coroutineScope.launch { preferences.useDynamicColors.toggle() }
+          coroutineScope.launchOrThrow { preferences.useDynamicColors.toggle() }
         }
 
         SettingsUiEvent.ToggleUseLessData -> {
-          coroutineScope.launch { preferences.useLessData.toggle() }
+          coroutineScope.launchOrThrow { preferences.useLessData.toggle() }
         }
 
         SettingsUiEvent.ToggleIgnoreSpecials -> {
-          coroutineScope.launch { preferences.ignoreSpecials.toggle() }
+          coroutineScope.launchOrThrow { preferences.ignoreSpecials.toggle() }
         }
 
         SettingsUiEvent.ToggleCrashDataReporting -> {
-          coroutineScope.launch { preferences.reportAppCrashes.toggle() }
+          coroutineScope.launchOrThrow { preferences.reportAppCrashes.toggle() }
         }
 
         SettingsUiEvent.ToggleAnalyticsDataReporting -> {
-          coroutineScope.launch { preferences.reportAnalytics.toggle() }
+          coroutineScope.launchOrThrow { preferences.reportAnalytics.toggle() }
         }
 
         SettingsUiEvent.ToggleAiringEpisodeNotificationsEnabled -> {
           if (isPro) {
-            coroutineScope.launch {
+            coroutineScope.launchOrThrow {
               if (preferences.episodeAiringNotificationsEnabled.get()) {
                 // If we're enabled, and being turned off, we don't need to mess with permissions
                 preferences.episodeAiringNotificationsEnabled.set(false)
@@ -168,7 +168,7 @@ class SettingsPresenter(
       isPro = isPro,
       isLoggedIn = authState == TraktAuthState.LOGGED_IN,
       showDeleteAccount = authState == TraktAuthState.LOGGED_IN,
-      eventSink = ::eventSink,
+      eventSink = eventSink,
     )
   }
 }

--- a/ui/show/details/src/commonMain/kotlin/app/tivi/showdetails/details/ShowDetails.kt
+++ b/ui/show/details/src/commonMain/kotlin/app/tivi/showdetails/details/ShowDetails.kt
@@ -145,11 +145,11 @@ import app.tivi.data.models.TiviShow
 import app.tivi.data.views.ShowsWatchStats
 import app.tivi.screens.ShowDetailsScreen
 import app.tivi.util.fmt
+import app.tivi.util.launchOrThrow
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.runtime.ui.Ui
 import com.slack.circuit.runtime.ui.ui
-import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
 import me.tatarka.inject.annotations.Inject
 import org.jetbrains.compose.resources.stringResource
@@ -247,7 +247,7 @@ internal fun ShowDetails(
         scrollBehavior = scrollBehavior,
         modifier = Modifier
           .noIndicationClickable {
-            coroutineScope.launch { listState.animateScrollToItem(0) }
+            coroutineScope.launchOrThrow { listState.animateScrollToItem(0) }
           }
           .fillMaxWidth(),
       )
@@ -819,7 +819,7 @@ private fun WatchStats(
 
     // TODO: Do something better with CharSequences containing markup/spans
     Text(
-      text = "${textCreator.followedShowEpisodeWatchStatus(watchedEpisodeCount, episodeCount)}",
+      text = textCreator.followedShowEpisodeWatchStatus(watchedEpisodeCount, episodeCount),
       style = MaterialTheme.typography.bodyMedium,
     )
   }

--- a/ui/show/seasons/src/commonMain/kotlin/app/tivi/showdetails/seasons/ShowSeasons.kt
+++ b/ui/show/seasons/src/commonMain/kotlin/app/tivi/showdetails/seasons/ShowSeasons.kt
@@ -89,11 +89,11 @@ import app.tivi.data.imagemodels.asImageModel
 import app.tivi.data.models.Episode
 import app.tivi.data.models.Season
 import app.tivi.screens.ShowSeasonsScreen
+import app.tivi.util.launchOrThrow
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.runtime.ui.Ui
 import com.slack.circuit.runtime.ui.ui
-import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Inject
 import org.jetbrains.compose.resources.stringResource
 
@@ -204,7 +204,7 @@ internal fun ShowSeasons(
           modifier = Modifier.noIndicationClickable {
             val currentSeasonId = state.seasons[pagerState.currentPage].season.id
             lazyListStates[currentSeasonId]?.let { lazyListState ->
-              coroutineScope.launch {
+              coroutineScope.launchOrThrow {
                 lazyListState.animateScrollToItem(0)
               }
             }
@@ -295,7 +295,7 @@ private fun SeasonPagerTabs(
         selected = pagerState.currentPage == index,
         onClick = {
           // Animate to the selected page when clicked
-          coroutineScope.launch {
+          coroutineScope.launchOrThrow {
             pagerState.animateScrollToPage(index)
           }
         },

--- a/ui/show/seasons/src/commonMain/kotlin/app/tivi/showdetails/seasons/ShowSeasonsPresenter.kt
+++ b/ui/show/seasons/src/commonMain/kotlin/app/tivi/showdetails/seasons/ShowSeasonsPresenter.kt
@@ -17,13 +17,13 @@ import app.tivi.domain.observers.ObserveShowDetails
 import app.tivi.domain.observers.ObserveShowSeasonsEpisodesWatches
 import app.tivi.screens.EpisodeDetailsScreen
 import app.tivi.screens.ShowSeasonsScreen
+import app.tivi.util.launchOrThrow
 import co.touchlab.kermit.Logger
 import com.slack.circuit.retained.collectAsRetainedState
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
-import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 
@@ -60,10 +60,10 @@ class ShowSeasonsPresenter(
     val refreshing by updateShowSeasons.value.inProgress.collectAsState(false)
     val message by uiMessageManager.message.collectAsState(null)
 
-    fun eventSink(event: ShowSeasonsUiEvent) {
+    val eventSink: (ShowSeasonsUiEvent) -> Unit = { event ->
       when (event) {
         is ShowSeasonsUiEvent.ClearMessage -> {
-          scope.launch {
+          scope.launchOrThrow {
             uiMessageManager.clearMessage(event.id)
           }
         }
@@ -71,7 +71,7 @@ class ShowSeasonsPresenter(
         is ShowSeasonsUiEvent.OpenEpisodeDetails -> navigator.goTo(EpisodeDetailsScreen(event.id))
 
         is ShowSeasonsUiEvent.Refresh -> {
-          scope.launch {
+          scope.launchOrThrow {
             updateShowSeasons.value.invoke(
               UpdateShowSeasons.Params(screen.showId, event.fromUser),
             ).onFailure { e ->
@@ -98,7 +98,7 @@ class ShowSeasonsPresenter(
       refreshing = refreshing,
       message = message,
       initialSeasonId = screen.selectedSeasonId,
-      eventSink = ::eventSink,
+      eventSink = eventSink,
     )
   }
 }

--- a/ui/trending/src/commonMain/kotlin/app/tivi/home/trending/TrendingShowsPresenter.kt
+++ b/ui/trending/src/commonMain/kotlin/app/tivi/home/trending/TrendingShowsPresenter.kt
@@ -54,7 +54,7 @@ class TrendingShowsPresenter(
       retainedPagingInteractor(ObservePagedTrendingShows.Params(PAGING_CONFIG))
     }
 
-    fun eventSink(event: TrendingShowsUiEvent) {
+    val eventSink: (TrendingShowsUiEvent) -> Unit = { event ->
       when (event) {
         TrendingShowsUiEvent.NavigateUp -> navigator.pop()
         is TrendingShowsUiEvent.OpenShowDetails -> {
@@ -65,7 +65,7 @@ class TrendingShowsPresenter(
 
     return TrendingShowsUiState(
       items = items,
-      eventSink = ::eventSink,
+      eventSink = eventSink,
     )
   }
 

--- a/ui/upnext/src/commonMain/kotlin/app/tivi/home/upnext/UpNext.kt
+++ b/ui/upnext/src/commonMain/kotlin/app/tivi/home/upnext/UpNext.kt
@@ -88,13 +88,13 @@ import app.tivi.overlays.showInDialog
 import app.tivi.screens.AccountScreen
 import app.tivi.screens.EpisodeTrackScreen
 import app.tivi.screens.UpNextScreen
+import app.tivi.util.launchOrThrow
 import coil3.compose.AsyncImagePainter
 import com.slack.circuit.overlay.LocalOverlayHost
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.runtime.ui.Ui
 import com.slack.circuit.runtime.ui.ui
-import kotlinx.coroutines.launch
 import me.saket.swipe.SwipeAction
 import me.saket.swipe.SwipeableActionsBox
 import me.tatarka.inject.annotations.Inject
@@ -130,13 +130,13 @@ internal fun UpNext(
     state = state,
     openEpisodeDetails = { eventSink(UpNextUiEvent.OpenEpisodeDetails(it)) },
     openTrackEpisode = {
-      scope.launch {
+      scope.launchOrThrow {
         overlayHost.showInBottomSheet(EpisodeTrackScreen(it))
       }
     },
     onMessageShown = { eventSink(UpNextUiEvent.ClearMessage(it)) },
     openUser = {
-      scope.launch {
+      scope.launchOrThrow {
         overlayHost.showInDialog(AccountScreen, navigator::goTo)
       }
     },
@@ -193,7 +193,7 @@ internal fun UpNext(
         onUserActionClick = openUser,
         modifier = Modifier
           .noIndicationClickable {
-            coroutineScope.launch { lazyGridState.animateScrollToItem(0) }
+            coroutineScope.launchOrThrow { lazyGridState.animateScrollToItem(0) }
           }
           .fillMaxWidth(),
       )


### PR DESCRIPTION
Caused by the referenced CoroutineScope being cancelled from eventSink functions. Seems that a combination of Compose Strong Skipping mode + Kotlin remembering inner functions instances, means that the function instances are not recreated when any referenced value changes.

Easily fixed by moving to a lambda instead.